### PR TITLE
fix: use stable `typescript` cuz `tseslint` doesn't support ts rc

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,9 +4,9 @@ const { defineConfig } = require("eslint-define-config");
 module.exports = defineConfig({
   root: true,
   env: {
+    node: true,
     browser: false,
     es2024: true,
-    node: true,
   },
   parser: "@typescript-eslint/parser",
   parserOptions: {
@@ -14,11 +14,9 @@ module.exports = defineConfig({
     project: [
       "./tsconfig.json",
       "./packages/*/tsconfig.json",
-      // "./website/*/tsconfig.json",
     ],
     sourceType: "module",
     tsconfigRootDir: __dirname,
-    warnOnUnsupportedTypeScriptVersion: false,
   },
   extends: [
     "with-tsconfig",
@@ -135,6 +133,15 @@ module.exports = defineConfig({
       },
     },
     {
+      files: ["./scripts/**/*.ts"],
+      globals: {
+        Bun: "readonly",
+      },
+      rules: {
+        "no-await-in-loop": "off",
+      },
+    },
+    {
       extends: ["plugin:vitest/recommended"],
       files: "*.spec.ts",
       plugins: ["vitest"],
@@ -144,16 +151,6 @@ module.exports = defineConfig({
         "sonarjs/no-duplicate-string": "off",
         "vitest/consistent-test-filename": "off",
         "vitest/require-hook": "off",
-      },
-    },
-    {
-      files: ["./scripts/**/*.ts"],
-      globals: {
-        Bun: "readonly",
-      },
-      rules: {
-        "no-await-in-loop": "off",
-        "functional-core/purity": "off",
       },
     },
     {

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ export default [
 - [x] `react/no-children-map`
 - [x] `react/no-children-only`
 - [x] `react/no-children-to-array`
-- [ ] `react/no-children-prop`
+- [x] `react/no-children-prop`
 - [x] `react/no-children-in-void-dom-elements`
 - [ ] `react/no-create-class`
 - [ ] `react/no-find-dom-node`
@@ -152,8 +152,9 @@ export default [
 - [x] `react/no-dangerously-set-innerhtml`
 - [x] `react/no-dangerously-set-innerhtml-with-children`
 - [x] `react/no-missing-button-type`
-- [x] `react/no-missing-display-name`
 - [x] `react/no-missing-iframe-sandbox`
+- [ ] `react/no-missing-context-display-name`
+- [ ] `react/no-missing-component-display-name`
 - [x] `react/no-script-url`
 - [ ] `react/no-direct-mutation-state`
 - [ ] `react/no-redundant-should-component-update`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/monorepo",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint plugins for React function components with TypeScript, built (mostly) from scratch",
   "keywords": [
     "eslint",
@@ -107,7 +107,7 @@
     "eslint": ">=8.53.0",
     "typescript": ">=5.2.2"
   },
-  "packageManager": "pnpm@8.10.3",
+  "packageManager": "pnpm@8.10.5",
   "engines": {
     "bun": ">=1.0.11",
     "node": ">=18.15.0"
@@ -123,11 +123,11 @@
       "@typescript-eslint/types": "6.10.0",
       "@typescript-eslint/utils": "6.10.0",
       "eslint": ">=8.53.0",
-      "eslint-plugin-import": "npm:eslint-plugin-i@latest",
-      "has": "npm:@nolyfill/has@latest",
       "react": "18.2.0",
       "react-dom": "18.2.0",
-      "typescript": "rc",
+      "typescript": ">=5.2.2",
+      "eslint-plugin-import": "npm:eslint-plugin-i@latest",
+      "has": "npm:@nolyfill/has@latest",
       "array-includes": "npm:@nolyfill/array-includes@latest",
       "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@latest",
       "array.prototype.flatmap": "npm:@nolyfill/array.prototype.flatmap@latest",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "inspect:unused": "knip",
     "lint": "pnpm run format:check && pnpm run lint:spell && pnpm run lint:deps && pnpm run lint:type && pnpm run lint:ts && pnpm run lint:publish && pnpm run lint:examples",
     "lint:deps": "bun run --bun skott -m file-tree -e .ts -s",
-    "lint:fix": "bun run --bun eslint --max-warnings 0 --cache --fix .",
     "lint:publish": "pnpm -r run --parallel lint:publish",
     "lint:spell": "cspell lint --relative --no-progress '**'",
     "lint:ts": "bun run --bun eslint --max-warnings 0 --cache .",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/ast",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "TSESTree AST primitive utility module.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/core",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint utility module for static analysis of React core API and Patterns.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/eslint-plugin-debug/package.json
+++ b/packages/eslint-plugin-debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/eslint-plugin-debug",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint plugin for debugging related rules.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/eslint-plugin-jsx/package.json
+++ b/packages/eslint-plugin-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/eslint-plugin-jsx",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint plugin for JSX related rules.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.ts
@@ -41,7 +41,7 @@ const allowedVariants = [
   "falsy string",
   "truthy boolean",
   "truthy string",
-] as const satisfies VariantType[];
+] as const satisfies readonly VariantType[];
 
 /**
  * Ported from https://github.com/typescript-eslint/typescript-eslint/blob/eb736bbfc22554694400e6a4f97051d845d32e0b/packages/eslint-plugin/src/rules/strict-boolean-expressions.ts#L826

--- a/packages/eslint-plugin-naming-convention/package.json
+++ b/packages/eslint-plugin-naming-convention/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/eslint-plugin-naming-convention",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint plugin for naming convention related rules.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/eslint-plugin-react-hooks/package.json
+++ b/packages/eslint-plugin-react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/eslint-plugin-react-hooks",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "Hooks specific rules for @eslint-react/eslint-plugin",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/eslint-plugin-react/package.json
+++ b/packages/eslint-plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/eslint-plugin-react",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint plugin for React related rules.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/eslint-plugin-react/src/rules/no-unsafe-target-blank.ts
+++ b/packages/eslint-plugin-react/src/rules/no-unsafe-target-blank.ts
@@ -43,7 +43,7 @@ export default createRule<[], MessageID>({
             : node.value,
           context.getScope(),
         );
-        if (!isString(link?.value) || link.value !== "_blank") {
+        if (!isString(link?.value) || link?.value !== "_blank") {
           return;
         }
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/eslint-plugin",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint plugins for React function components with TypeScript, built (mostly) from scratch, built (mostly) from scratch",
   "keywords": [
     "eslint",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/jsx",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "ESLint plugin for React Hooks related rules.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/shared",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "Shared constants and utilities for @eslint-react packages",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/tools",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "Std library and primitives for @eslint-react packages.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eslint-react/types",
-  "version": "0.8.6-beta.2",
+  "version": "0.8.6-beta.3",
   "description": "Type definitions for @eslint-react packages.",
   "homepage": "https://github.com/rel1cx/eslint-react",
   "bugs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,11 +11,11 @@ overrides:
   '@typescript-eslint/types': 6.10.0
   '@typescript-eslint/utils': 6.10.0
   eslint: '>=8.53.0'
-  eslint-plugin-import: npm:eslint-plugin-i@latest
-  has: npm:@nolyfill/has@latest
   react: 18.2.0
   react-dom: 18.2.0
-  typescript: rc
+  typescript: '>=5.2.2'
+  eslint-plugin-import: npm:eslint-plugin-i@latest
+  has: npm:@nolyfill/has@latest
   array-includes: npm:@nolyfill/array-includes@latest
   array.prototype.flat: npm:@nolyfill/array.prototype.flat@latest
   array.prototype.flatmap: npm:@nolyfill/array.prototype.flatmap@latest
@@ -44,7 +44,7 @@ importers:
         version: 15.2.3(rollup@4.4.1)
       '@rollup/plugin-typescript':
         specifier: 11.1.5
-        version: 11.1.5(rollup@4.4.1)(typescript@5.3.1-rc)
+        version: 11.1.5(rollup@4.4.1)(typescript@5.2.2)
       '@swc/core':
         specifier: 1.3.96
         version: 1.3.96
@@ -59,13 +59,13 @@ importers:
         version: 20.9.0
       '@typescript-eslint/eslint-plugin':
         specifier: 6.10.0
-        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/rule-tester':
         specifier: 6.10.0
-        version: 6.10.0(@eslint/eslintrc@2.1.3)(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(@eslint/eslintrc@2.1.3)(eslint@8.53.0)(typescript@5.2.2)
       '@vitest/ui':
         specifier: 0.34.6
         version: 0.34.6(vitest@0.34.6)
@@ -89,7 +89,7 @@ importers:
         version: 8.53.0
       eslint-config-with-tsconfig:
         specifier: 2.9.50
-        version: 2.9.50(eslint@8.53.0)(tailwindcss@3.3.5)(typescript@5.3.1-rc)
+        version: 2.9.50(eslint@8.53.0)(tailwindcss@3.3.5)(typescript@5.2.2)
       eslint-plugin-eslint-plugin:
         specifier: 5.1.1
         version: 5.1.1(eslint@8.53.0)
@@ -98,13 +98,13 @@ importers:
         version: 0.8.0(eslint@8.53.0)
       eslint-plugin-functional-core:
         specifier: 1.7.1
-        version: 1.7.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 1.7.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
       eslint-plugin-jsdoc:
         specifier: 46.9.0
         version: 46.9.0(eslint@8.53.0)
       eslint-plugin-vitest:
         specifier: 0.3.9
-        version: 0.3.9(@typescript-eslint/eslint-plugin@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)(vitest@0.34.6)
+        version: 0.3.9(@typescript-eslint/eslint-plugin@6.10.0)(eslint@8.53.0)(typescript@5.2.2)(vitest@0.34.6)
       fast-equals:
         specifier: 5.0.1
         version: 5.0.1
@@ -128,7 +128,7 @@ importers:
         version: 4.4.1
       rollup-plugin-dts:
         specifier: 6.1.0
-        version: 6.1.0(rollup@4.4.1)(typescript@5.3.1-rc)
+        version: 6.1.0(rollup@4.4.1)(typescript@5.2.2)
       rollup-plugin-swc3:
         specifier: 0.10.3
         version: 0.10.3(@swc/core@1.3.96)(rollup@4.4.1)
@@ -152,7 +152,7 @@ importers:
         version: 4.7.1
       typedoc:
         specifier: 0.25.3
-        version: 0.25.3(typescript@5.3.1-rc)
+        version: 0.25.3(typescript@5.2.2)
       typedoc-plugin-markdown:
         specifier: 3.17.1
         version: 3.17.1(typedoc@0.25.3)
@@ -163,8 +163,8 @@ importers:
         specifier: 0.7.0
         version: 0.7.0(typedoc@0.25.3)
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
       vitest:
         specifier: 0.34.6
         version: 0.34.6(@vitest/ui@0.34.6)
@@ -195,10 +195,10 @@ importers:
         version: 18.2.14
       '@typescript-eslint/eslint-plugin':
         specifier: 6.10.0
-        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@vitejs/plugin-react':
         specifier: 4.1.1
         version: 4.1.1(vite@4.5.0)
@@ -212,8 +212,8 @@ importers:
         specifier: 0.4.4
         version: 0.4.4(eslint@8.53.0)
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@20.9.0)(sass@1.69.5)
@@ -244,10 +244,10 @@ importers:
         version: 18.2.14
       '@typescript-eslint/eslint-plugin':
         specifier: 6.10.0
-        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@vitejs/plugin-react':
         specifier: 4.1.1
         version: 4.1.1(vite@4.5.0)
@@ -261,8 +261,8 @@ importers:
         specifier: 0.4.4
         version: 0.4.4(eslint@8.53.0)
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
       vite:
         specifier: 4.5.0
         version: 4.5.0(@types/node@20.9.0)(sass@1.69.5)
@@ -286,7 +286,7 @@ importers:
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       rambda:
         specifier: 8.5.0
         version: 8.5.0
@@ -313,37 +313,37 @@ importers:
         version: 6.10.0
       '@typescript-eslint/type-utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
 
   packages/eslint-plugin:
     dependencies:
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/type-utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint:
         specifier: '>=8.53.0'
         version: 8.53.0
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
     devDependencies:
       '@eslint-react/eslint-plugin-debug':
         specifier: workspace:*
@@ -374,19 +374,19 @@ importers:
     dependencies:
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/type-utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       dedent:
         specifier: 1.5.1
         version: 1.5.1
@@ -404,13 +404,13 @@ importers:
         version: 1.3.2
       ts-api-utils:
         specifier: 1.0.3
-        version: 1.0.3(typescript@5.3.1-rc)
+        version: 1.0.3(typescript@5.2.2)
       ts-pattern:
         specifier: 5.0.5
         version: 5.0.5
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
     devDependencies:
       '@eslint-react/ast':
         specifier: workspace:*
@@ -435,19 +435,19 @@ importers:
     dependencies:
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/type-utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       dedent:
         specifier: 1.5.1
         version: 1.5.1
@@ -465,13 +465,13 @@ importers:
         version: 1.3.2
       ts-api-utils:
         specifier: 1.0.3
-        version: 1.0.3(typescript@5.3.1-rc)
+        version: 1.0.3(typescript@5.2.2)
       ts-pattern:
         specifier: 5.0.5
         version: 5.0.5
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
     devDependencies:
       '@eslint-react/ast':
         specifier: workspace:*
@@ -496,19 +496,19 @@ importers:
     dependencies:
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/type-utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       dedent:
         specifier: 1.5.1
         version: 1.5.1
@@ -526,13 +526,13 @@ importers:
         version: 1.3.2
       ts-api-utils:
         specifier: 1.0.3
-        version: 1.0.3(typescript@5.3.1-rc)
+        version: 1.0.3(typescript@5.2.2)
       ts-pattern:
         specifier: 5.0.5
         version: 5.0.5
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
     devDependencies:
       '@eslint-react/ast':
         specifier: workspace:*
@@ -557,19 +557,19 @@ importers:
     dependencies:
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/type-utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       dedent:
         specifier: 1.5.1
         version: 1.5.1
@@ -587,13 +587,13 @@ importers:
         version: 1.3.2
       ts-api-utils:
         specifier: 1.0.3
-        version: 1.0.3(typescript@5.3.1-rc)
+        version: 1.0.3(typescript@5.2.2)
       ts-pattern:
         specifier: 5.0.5
         version: 5.0.5
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
     devDependencies:
       '@eslint-react/ast':
         specifier: workspace:*
@@ -618,19 +618,19 @@ importers:
     dependencies:
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/type-utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types':
         specifier: 6.10.0
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       dedent:
         specifier: 1.5.1
         version: 1.5.1
@@ -648,13 +648,13 @@ importers:
         version: 1.3.2
       ts-api-utils:
         specifier: 1.0.3
-        version: 1.0.3(typescript@5.3.1-rc)
+        version: 1.0.3(typescript@5.2.2)
       ts-pattern:
         specifier: 5.0.5
         version: 5.0.5
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
     devDependencies:
       '@eslint-react/ast':
         specifier: workspace:*
@@ -685,7 +685,7 @@ importers:
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
     devDependencies:
       '@eslint-react/ast':
         specifier: workspace:*
@@ -707,7 +707,7 @@ importers:
         version: link:../tools
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       dedent:
         specifier: 1.5.1
         version: 1.5.1
@@ -734,7 +734,7 @@ importers:
         version: 6.10.0
       '@typescript-eslint/utils':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       string-ts:
         specifier: 1.3.2
         version: 1.3.2
@@ -765,7 +765,7 @@ importers:
     devDependencies:
       '@eslint-react/eslint-plugin':
         specifier: latest
-        version: 0.8.6-beta.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 0.8.6-beta.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
       '@mdx-js/mdx':
         specifier: 3.0.0
         version: 3.0.0
@@ -780,10 +780,10 @@ importers:
         version: 18.2.14
       '@typescript-eslint/eslint-plugin':
         specifier: 6.10.0
-        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
         specifier: 6.10.0
-        version: 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@vanilla-extract/css':
         specifier: 1.13.0
         version: 1.13.0
@@ -801,13 +801,13 @@ importers:
         version: 8.53.0
       eslint-config-next:
         specifier: 14.0.1
-        version: 14.0.1(eslint@8.53.0)(typescript@5.3.1-rc)
+        version: 14.0.1(eslint@8.53.0)(typescript@5.2.2)
       eslint-config-prettier:
         specifier: 9.0.0
         version: 9.0.0(eslint@8.53.0)
       eslint-config-with-tsconfig:
         specifier: 2.9.50
-        version: 2.9.50(eslint@8.53.0)(tailwindcss@3.3.5)(typescript@5.3.1-rc)
+        version: 2.9.50(eslint@8.53.0)(tailwindcss@3.3.5)(typescript@5.2.2)
       eslint-define-config:
         specifier: 1.24.1
         version: 1.24.1
@@ -831,13 +831,13 @@ importers:
         version: 4.0.0
       remark-shiki-twoslash:
         specifier: 3.1.3
-        version: 3.1.3(typescript@5.3.1-rc)
+        version: 3.1.3(typescript@5.2.2)
       sass:
         specifier: 1.69.5
         version: 1.69.5
       typescript:
-        specifier: rc
-        version: 5.3.1-rc
+        specifier: '>=5.2.2'
+        version: 5.2.2
 
 packages:
 
@@ -1983,21 +1983,21 @@ packages:
     resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  /@eslint-react/eslint-plugin@0.8.6-beta.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc):
+  /@eslint-react/eslint-plugin@0.8.6-beta.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-OR3zx8iZfdhlkzVMAWmTF/OcQFl8M1yWeNsYyJteiZrnXQD9KR11nq13n13+AqwSqeQhEud1atRwpnz0kHfxdw==}
     engines: {bun: '>=1.0.11', node: '>=18.15.0'}
     peerDependencies:
       '@typescript-eslint/parser': 6.10.0
       eslint: '>=8.53.0'
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 6.10.0
-      '@typescript-eslint/type-utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/type-utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2980,13 +2980,13 @@ packages:
       rollup: 4.4.1
     dev: true
 
-  /@rollup/plugin-typescript@11.1.5(rollup@4.4.1)(typescript@5.3.1-rc):
+  /@rollup/plugin-typescript@11.1.5(rollup@4.4.1)(typescript@5.2.2):
     resolution: {integrity: sha512-rnMHrGBB0IUEv69Q8/JGRD/n4/n6b3nfpufUu26axhUcboUzv/twfZU8fIBbTOphRAe0v8EyxzeDpKXqGHfyDA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.14.0||^3.0.0||^4.0.0
       tslib: '*'
-      typescript: rc
+      typescript: '>=5.2.2'
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2996,7 +2996,7 @@ packages:
       '@rollup/pluginutils': 5.0.5(rollup@4.4.1)
       resolve: 1.22.8
       rollup: 4.4.1
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     dev: true
 
   /@rollup/pluginutils@5.0.5(rollup@4.4.1):
@@ -3531,7 +3531,7 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc):
+  /@typescript-eslint/eslint-plugin@6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-uoLj4g2OTL8rfUQVx2AFO1hp/zja1wABJq77P6IclQs6I/m9GLrm7jCdgzZkvWdDCQf1uEvoa8s8CupsgWQgVg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3543,10 +3543,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 6.10.0
-      '@typescript-eslint/type-utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/type-utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.10.0
       debug: 4.3.4
       eslint: 8.53.0
@@ -3554,26 +3554,26 @@ packages:
       ignore: 5.2.4
       natural-compare: 1.4.0
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.1-rc)
-      typescript: 5.3.1-rc
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.53.0)(typescript@5.3.1-rc):
+  /@typescript-eslint/experimental-utils@5.62.0(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-RTXpeB3eMkpoclG3ZHft6vG/Z30azNHuqY6wKPBHlVMZFuEvrtlEDe8gMqDb+SO+9hjC/pLekeSCryf9vMZlCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8.53.0'
     dependencies:
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@6.10.0(eslint@8.53.0)(typescript@5.3.1-rc):
+  /@typescript-eslint/parser@6.10.0(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-+sZwIj+s+io9ozSxIWbNB5873OSdfeBEH/FR0re14WLI6BaKuSOnnwCJ2foUiu8uXf4dRp1UqHP0vrZ1zXGrog==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3585,15 +3585,15 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 6.10.0
       '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.3.1-rc)
+      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.10.0
       debug: 4.3.4
       eslint: 8.53.0
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/rule-tester@6.10.0(@eslint/eslintrc@2.1.3)(eslint@8.53.0)(typescript@5.3.1-rc):
+  /@typescript-eslint/rule-tester@6.10.0(@eslint/eslintrc@2.1.3)(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-I0ZY+9ei73dlOuXwIYWsn/r/ue26Ygf4yEJPxeJRPI06YWDawmR1FI1dXL6ChAWVrmBQRvWep/1PxnV41zfcMA==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3601,8 +3601,8 @@ packages:
       eslint: '>=8.53.0'
     dependencies:
       '@eslint/eslintrc': 2.1.3
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.3.1-rc)
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       ajv: 6.12.6
       eslint: 8.53.0
       lodash.merge: 4.6.2
@@ -3619,7 +3619,7 @@ packages:
       '@typescript-eslint/types': 6.10.0
       '@typescript-eslint/visitor-keys': 6.10.0
 
-  /@typescript-eslint/type-utils@6.10.0(eslint@8.53.0)(typescript@5.3.1-rc):
+  /@typescript-eslint/type-utils@6.10.0(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-wYpPs3hgTFblMYwbYWPT3eZtaDOjbLyIYuqpwuLBBqhLiuvJ+9sEp2gNRJEtR5N/c9G1uTtQQL5AhV0fEPJYcg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3629,12 +3629,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.3.1-rc)
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       debug: 4.3.4
       eslint: 8.53.0
-      ts-api-utils: 1.0.3(typescript@5.3.1-rc)
-      typescript: 5.3.1-rc
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3642,7 +3642,7 @@ packages:
     resolution: {integrity: sha512-36Fq1PWh9dusgo3vH7qmQAj5/AZqARky1Wi6WpINxB6SkQdY5vQoT2/7rW7uBIsPDcvvGCLi4r10p0OJ7ITAeg==}
     engines: {node: ^16.0.0 || >=18.0.0}
 
-  /@typescript-eslint/typescript-estree@6.10.0(typescript@5.3.1-rc):
+  /@typescript-eslint/typescript-estree@6.10.0(typescript@5.2.2):
     resolution: {integrity: sha512-ek0Eyuy6P15LJVeghbWhSrBCj/vJpPXXR+EpaRZqou7achUWL8IdYnMSC5WHAeTWswYQuP2hAZgij/bC9fanBg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3657,12 +3657,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.1-rc)
-      typescript: 5.3.1-rc
+      ts-api-utils: 1.0.3(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/utils@6.10.0(eslint@8.53.0)(typescript@5.3.1-rc):
+  /@typescript-eslint/utils@6.10.0(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-v+pJ1/RcVyRc0o4wAGux9x42RHmAjIGzPRo538Z8M1tVx6HOnoQBCX/NoadHQlZeC+QO2yr4nNSFWOoraZCAyg==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -3673,7 +3673,7 @@ packages:
       '@types/semver': 7.5.5
       '@typescript-eslint/scope-manager': 6.10.0
       '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.3.1-rc)
+      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
       eslint: 8.53.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -5730,18 +5730,18 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  /eslint-config-next@14.0.1(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-config-next@14.0.1(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-QfIFK2WD39H4WOespjgf6PLv9Bpsd7KGGelCtmq4l67nGvnlsGpuvj0hIT+aIy6p5gKH+lAChYILsyDlxP52yg==}
     peerDependencies:
       eslint: '>=8.53.0'
-      typescript: rc
+      typescript: '>=5.2.2'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
       '@next/eslint-plugin-next': 14.0.1
       '@rushstack/eslint-patch': 1.5.1
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.10.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-i@2.29.0)(eslint@8.53.0)
@@ -5749,7 +5749,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.53.0)
       eslint-plugin-react: 7.33.2(eslint@8.53.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -5764,7 +5764,7 @@ packages:
       eslint: 8.53.0
     dev: true
 
-  /eslint-config-rel1cx@0.12.50(@babel/core@7.23.3)(@babel/eslint-parser@7.23.3)(@babel/preset-react@7.23.3)(@typescript-eslint/eslint-plugin@6.10.0)(@typescript-eslint/parser@6.10.0)(eslint-plugin-perfectionist@1.5.1)(eslint-plugin-promise@6.1.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react-refresh@0.4.4)(eslint-plugin-regexp@2.1.1)(eslint-plugin-rxjs@5.0.3)(eslint-plugin-security@1.7.1)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sonarjs@0.23.0)(eslint-plugin-tailwindcss@3.13.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-config-rel1cx@0.12.50(@babel/core@7.23.3)(@babel/eslint-parser@7.23.3)(@babel/preset-react@7.23.3)(@typescript-eslint/eslint-plugin@6.10.0)(@typescript-eslint/parser@6.10.0)(eslint-plugin-perfectionist@1.5.1)(eslint-plugin-promise@6.1.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react-refresh@0.4.4)(eslint-plugin-regexp@2.1.1)(eslint-plugin-rxjs@5.0.3)(eslint-plugin-security@1.7.1)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sonarjs@0.23.0)(eslint-plugin-tailwindcss@3.13.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-mY+fh51kjbDNix0jfD7hluVR32G9PpFPwundJTDX19HIIAiDXGN2xfnK5kBumlUwBcIuf11NDvFXesIGlQ8nWw==}
     engines: {bun: '>=1.0.7', node: '>=18.15.0'}
     peerDependencies:
@@ -5785,59 +5785,59 @@ packages:
       eslint-plugin-sonarjs: '>=0.23.0'
       eslint-plugin-tailwindcss: '>=3.13.0'
       eslint-plugin-unicorn: '>=48.0.1'
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       '@babel/core': 7.23.3
       '@babel/eslint-parser': 7.23.3(@babel/core@7.23.3)(eslint@8.53.0)
       '@babel/preset-react': 7.23.3(@babel/core@7.23.3)
-      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
-      eslint-plugin-perfectionist: 1.5.1(eslint@8.53.0)(typescript@5.3.1-rc)
+      eslint-plugin-perfectionist: 1.5.1(eslint@8.53.0)(typescript@5.2.2)
       eslint-plugin-promise: 6.1.1(eslint@8.53.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
       eslint-plugin-react-refresh: 0.4.4(eslint@8.53.0)
       eslint-plugin-regexp: 2.1.1(eslint@8.53.0)
-      eslint-plugin-rxjs: 5.0.3(eslint@8.53.0)(typescript@5.3.1-rc)
+      eslint-plugin-rxjs: 5.0.3(eslint@8.53.0)(typescript@5.2.2)
       eslint-plugin-security: 1.7.1
       eslint-plugin-simple-import-sort: 10.0.0(eslint@8.53.0)
       eslint-plugin-sonarjs: 0.23.0(eslint@8.53.0)
       eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.5)
       eslint-plugin-unicorn: 49.0.0(eslint@8.53.0)
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     dev: true
 
-  /eslint-config-with-tsconfig@2.9.50(eslint@8.53.0)(tailwindcss@3.3.5)(typescript@5.3.1-rc):
+  /eslint-config-with-tsconfig@2.9.50(eslint@8.53.0)(tailwindcss@3.3.5)(typescript@5.2.2):
     resolution: {integrity: sha512-8j7YlikKFrlQtjtugO8Fr9RG+FtVbwju+KGM+SqGvr5tXqRduFUQBlC1UdGFZKibOnCENGPH449nRXGXE0c0oQ==}
     engines: {bun: '>=1.0.3', node: '>=18.16.0'}
     peerDependencies:
       eslint: '>=8.53.0'
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       '@babel/core': 7.23.3
       '@babel/eslint-parser': 7.23.3(@babel/core@7.23.3)(eslint@8.53.0)
       '@babel/preset-react': 7.23.3(@babel/core@7.23.3)
-      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       consola: 3.2.3
       eslint: 8.53.0
-      eslint-config-rel1cx: 0.12.50(@babel/core@7.23.3)(@babel/eslint-parser@7.23.3)(@babel/preset-react@7.23.3)(@typescript-eslint/eslint-plugin@6.10.0)(@typescript-eslint/parser@6.10.0)(eslint-plugin-perfectionist@1.5.1)(eslint-plugin-promise@6.1.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react-refresh@0.4.4)(eslint-plugin-regexp@2.1.1)(eslint-plugin-rxjs@5.0.3)(eslint-plugin-security@1.7.1)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sonarjs@0.23.0)(eslint-plugin-tailwindcss@3.13.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.53.0)(typescript@5.3.1-rc)
+      eslint-config-rel1cx: 0.12.50(@babel/core@7.23.3)(@babel/eslint-parser@7.23.3)(@babel/preset-react@7.23.3)(@typescript-eslint/eslint-plugin@6.10.0)(@typescript-eslint/parser@6.10.0)(eslint-plugin-perfectionist@1.5.1)(eslint-plugin-promise@6.1.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react-refresh@0.4.4)(eslint-plugin-regexp@2.1.1)(eslint-plugin-rxjs@5.0.3)(eslint-plugin-security@1.7.1)(eslint-plugin-simple-import-sort@10.0.0)(eslint-plugin-sonarjs@0.23.0)(eslint-plugin-tailwindcss@3.13.0)(eslint-plugin-unicorn@49.0.0)(eslint@8.53.0)(typescript@5.2.2)
       eslint-define-config: 1.24.1
-      eslint-plugin-expect-type: 0.2.3(eslint@8.53.0)(typescript@5.3.1-rc)
-      eslint-plugin-import-access: 2.1.2(eslint@8.53.0)(typescript@5.3.1-rc)
-      eslint-plugin-perfectionist: 1.5.1(eslint@8.53.0)(typescript@5.3.1-rc)
+      eslint-plugin-expect-type: 0.2.3(eslint@8.53.0)(typescript@5.2.2)
+      eslint-plugin-import-access: 2.1.2(eslint@8.53.0)(typescript@5.2.2)
+      eslint-plugin-perfectionist: 1.5.1(eslint@8.53.0)(typescript@5.2.2)
       eslint-plugin-promise: 6.1.1(eslint@8.53.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.53.0)
       eslint-plugin-react-refresh: 0.4.4(eslint@8.53.0)
       eslint-plugin-regexp: 2.1.1(eslint@8.53.0)
-      eslint-plugin-rxjs: 5.0.3(eslint@8.53.0)(typescript@5.3.1-rc)
+      eslint-plugin-rxjs: 5.0.3(eslint@8.53.0)(typescript@5.2.2)
       eslint-plugin-security: 1.7.1
       eslint-plugin-simple-import-sort: 10.0.0(eslint@8.53.0)
       eslint-plugin-sonarjs: 0.23.0(eslint@8.53.0)
       eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.5)
       eslint-plugin-unicorn: 49.0.0(eslint@8.53.0)
       get-tsconfig: 4.7.2
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
       - tailwindcss
@@ -5848,17 +5848,17 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=9.0.0', pnpm: '>= 8.6.0'}
     dev: true
 
-  /eslint-etc@5.2.1(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-etc@5.2.1(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-lFJBSiIURdqQKq9xJhvSJFyPA+VeTh5xvk24e8pxVL7bwLBtGF60C/KRkLTMrvCZ6DA3kbPuYhLWY0TZMlqTsg==}
     peerDependencies:
       eslint: '>=8.53.0'
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
-      tsutils: 3.21.0(typescript@5.3.1-rc)
-      tsutils-etc: 1.4.2(tsutils@3.21.0)(typescript@5.3.1-rc)
-      typescript: 5.3.1-rc
+      tsutils: 3.21.0(typescript@5.2.2)
+      tsutils-etc: 1.4.2(tsutils@3.21.0)(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5942,7 +5942,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       debug: 3.2.7
       eslint: 8.53.0
       eslint-import-resolver-node: 0.3.9
@@ -5962,17 +5962,17 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-plugin-expect-type@0.2.3(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-plugin-expect-type@0.2.3(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-pMmrbePlIU/mlvKMk1OvnASggKWawgX9yaUYhGrGnsyNceAttek8NqYzNdAVUYoD0ygyqVG8mz3mmL2oa0QE5w==}
     engines: {node: '>=14'}
     peerDependencies:
       eslint: '>=8.53.0'
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       fs-extra: 10.1.0
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5987,7 +5987,7 @@ packages:
       pluralize: 8.0.0
     dev: true
 
-  /eslint-plugin-functional-core@1.7.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-plugin-functional-core@1.7.1(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-w71vqO0w43+cHI60Tm99CA+9y2xGUV+EXHUlMULW+qiEK3Tega5cizMblSKIxQ5avRxymbB40wK2Nd9Ijhfz6Q==}
     engines: {node: ^14.17.0 || 16 || 18}
     peerDependencies:
@@ -5998,10 +5998,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/parser': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6029,11 +6029,11 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import-access@2.1.2(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-plugin-import-access@2.1.2(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-pSkOemuqFUdn/AfPx2WpeVQmErRqXOH8utfbzfjk69F+F1Ax7seFXJP9u3T9D/Jk/a2s0Q0RRjgplKFq+4ybfg==}
     dependencies:
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
-      tsutils: 3.21.0(typescript@5.3.1-rc)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
+      tsutils: 3.21.0(typescript@5.2.2)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -6116,13 +6116,13 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-perfectionist@1.5.1(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-plugin-perfectionist@1.5.1(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-PiUrAfGDc/l6MKKUP8qt5RXueC7FZC6F/0j8ijXYU8o3x8o2qUi6zEEYBkId/IiKloIXM5KTD4jrH9833kDNzA==}
     peerDependencies:
       eslint: '>=8.53.0'
     dependencies:
       '@typescript-eslint/types': 6.10.0
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       is-core-module: 2.13.1
       json5: 2.2.3
@@ -6200,23 +6200,23 @@ packages:
       scslre: 0.3.0
     dev: true
 
-  /eslint-plugin-rxjs@5.0.3(eslint@8.53.0)(typescript@5.3.1-rc):
+  /eslint-plugin-rxjs@5.0.3(eslint@8.53.0)(typescript@5.2.2):
     resolution: {integrity: sha512-fcVkqLmYLRfRp+ShafjpUKuaZ+cw/sXAvM5dfSxiEr7M28QZ/NY7vaOr09FB4rSaZsQyLBnNPh5SL+4EgKjh8Q==}
     peerDependencies:
       eslint: '>=8.53.0'
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/experimental-utils': 5.62.0(eslint@8.53.0)(typescript@5.2.2)
       common-tags: 1.8.2
       decamelize: 5.0.1
       eslint: 8.53.0
-      eslint-etc: 5.2.1(eslint@8.53.0)(typescript@5.3.1-rc)
+      eslint-etc: 5.2.1(eslint@8.53.0)(typescript@5.2.2)
       requireindex: 1.2.0
       rxjs-report-usage: 1.0.6
       tslib: 2.6.2
-      tsutils: 3.21.0(typescript@5.3.1-rc)
-      tsutils-etc: 1.4.2(tsutils@3.21.0)(typescript@5.3.1-rc)
-      typescript: 5.3.1-rc
+      tsutils: 3.21.0(typescript@5.2.2)
+      tsutils-etc: 1.4.2(tsutils@3.21.0)(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6278,7 +6278,7 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /eslint-plugin-vitest@0.3.9(@typescript-eslint/eslint-plugin@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)(vitest@0.34.6):
+  /eslint-plugin-vitest@0.3.9(@typescript-eslint/eslint-plugin@6.10.0)(eslint@8.53.0)(typescript@5.2.2)(vitest@0.34.6):
     resolution: {integrity: sha512-ZGrz8dWFlotM5dwrsMLP4VcY5MizwKNV4JTnY0VKdnuCZ+qeEUMHf1qd8kRGQA3tqLvXcV929wt2ANkduq2Pgw==}
     engines: {node: 14.x || >= 16}
     peerDependencies:
@@ -6291,8 +6291,8 @@ packages:
       vitest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.3.1-rc)
-      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.3.1-rc)
+      '@typescript-eslint/eslint-plugin': 6.10.0(@typescript-eslint/parser@6.10.0)(eslint@8.53.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.10.0(eslint@8.53.0)(typescript@5.2.2)
       eslint: 8.53.0
       vitest: 0.34.6(@vitest/ui@0.34.6)
     transitivePeerDependencies:
@@ -7808,7 +7808,7 @@ packages:
       pretty-ms: 8.0.0
       strip-json-comments: 5.0.1
       summary: 2.1.0
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
       zod: 3.22.4
       zod-validation-error: 1.5.0(zod@3.22.4)
     transitivePeerDependencies:
@@ -10580,10 +10580,10 @@ packages:
       vfile: 6.0.1
     dev: true
 
-  /remark-shiki-twoslash@3.1.3(typescript@5.3.1-rc):
+  /remark-shiki-twoslash@3.1.3(typescript@5.2.2):
     resolution: {integrity: sha512-4e8OH3ySOCw5wUbDcPszokOKjKuebOqlP2WlySvC7ITBOq27BiGsFlq+FNWhxppZ+JzhTWah4gQrnMjX3KDbAQ==}
     peerDependencies:
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       '@types/unist': 2.0.10
       '@typescript/twoslash': 3.1.0
@@ -10591,9 +10591,9 @@ packages:
       fenceparser: 1.1.1
       regenerator-runtime: 0.13.11
       shiki: 0.10.1
-      shiki-twoslash: 3.1.2(typescript@5.3.1-rc)
+      shiki-twoslash: 3.1.2(typescript@5.2.2)
       tslib: 2.1.0
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
       unist-util-visit: 2.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10724,16 +10724,16 @@ packages:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
     dev: false
 
-  /rollup-plugin-dts@6.1.0(rollup@4.4.1)(typescript@5.3.1-rc):
+  /rollup-plugin-dts@6.1.0(rollup@4.4.1)(typescript@5.2.2):
     resolution: {integrity: sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==}
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       magic-string: 0.30.5
       rollup: 4.4.1
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     optionalDependencies:
       '@babel/code-frame': 7.22.13
     dev: true
@@ -10944,16 +10944,16 @@ packages:
     resolution: {integrity: sha512-lT297f1WLAdq0A4O+AknIFRP6kkiI3s8C913eJ0XqBxJbZPGWUNkRQk2u8zk4bEAjUJ5i+fSLwB6z1HzeT+DEg==}
     dev: true
 
-  /shiki-twoslash@3.1.2(typescript@5.3.1-rc):
+  /shiki-twoslash@3.1.2(typescript@5.2.2):
     resolution: {integrity: sha512-JBcRIIizi+exIA/OUhYkV6jtyeZco0ykCkIRd5sgwIt1Pm4pz+maoaRZpm6SkhPwvif4fCA7xOtJOykhpIV64Q==}
     peerDependencies:
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       '@typescript/twoslash': 3.1.0
       '@typescript/vfs': 1.3.4
       fenceparser: 1.1.1
       shiki: 0.10.1
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11021,7 +11021,7 @@ packages:
     dependencies:
       '@effect/data': 0.4.1
       '@effect/io': 0.8.0
-      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.3.1-rc)
+      '@typescript-eslint/typescript-estree': 6.10.0(typescript@5.2.2)
       commander: 11.1.0
       compression: 1.7.4
       depcheck: 1.4.7
@@ -11041,7 +11041,7 @@ packages:
       polka: 0.5.2
       sirv: 2.0.3
       skott-webapp: 2.0.1
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11591,13 +11591,13 @@ packages:
       matchit: 1.1.0
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.3.1-rc):
+  /ts-api-utils@1.0.3(typescript@5.2.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
 
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -11622,27 +11622,27 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsutils-etc@1.4.2(tsutils@3.21.0)(typescript@5.3.1-rc):
+  /tsutils-etc@1.4.2(tsutils@3.21.0)(typescript@5.2.2):
     resolution: {integrity: sha512-2Dn5SxTDOu6YWDNKcx1xu2YUy6PUeKrWZB/x2cQ8vY2+iz3JRembKn/iZ0JLT1ZudGNwQQvtFX9AwvRHbXuPUg==}
     hasBin: true
     peerDependencies:
       tsutils: ^3.0.0
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       '@types/yargs': 17.0.31
-      tsutils: 3.21.0(typescript@5.3.1-rc)
-      typescript: 5.3.1-rc
+      tsutils: 3.21.0(typescript@5.2.2)
+      typescript: 5.2.2
       yargs: 17.7.2
     dev: true
 
-  /tsutils@3.21.0(typescript@5.3.1-rc):
+  /tsutils@3.21.0(typescript@5.2.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     dev: true
 
   /tuf-js@2.1.0:
@@ -11766,7 +11766,7 @@ packages:
       typedoc: '>=0.24.0'
     dependencies:
       handlebars: 4.7.8
-      typedoc: 0.25.3(typescript@5.3.1-rc)
+      typedoc: 0.25.3(typescript@5.2.2)
     dev: true
 
   /typedoc-plugin-mermaid@1.10.0(typedoc@0.25.3):
@@ -11775,7 +11775,7 @@ packages:
       typedoc: '>=0.23.0'
     dependencies:
       html-escaper: 3.0.3
-      typedoc: 0.25.3(typescript@5.3.1-rc)
+      typedoc: 0.25.3(typescript@5.2.2)
     dev: true
 
   /typedoc-plugin-rename-defaults@0.7.0(typedoc@0.25.3):
@@ -11784,25 +11784,25 @@ packages:
       typedoc: 0.22.x || 0.23.x || 0.24.x || 0.25.x
     dependencies:
       camelcase: 8.0.0
-      typedoc: 0.25.3(typescript@5.3.1-rc)
+      typedoc: 0.25.3(typescript@5.2.2)
     dev: true
 
-  /typedoc@0.25.3(typescript@5.3.1-rc):
+  /typedoc@0.25.3(typescript@5.2.2):
     resolution: {integrity: sha512-Ow8Bo7uY1Lwy7GTmphRIMEo6IOZ+yYUyrc8n5KXIZg1svpqhZSWgni2ZrDhe+wLosFS8yswowUzljTAV/3jmWw==}
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:
-      typescript: rc
+      typescript: '>=5.2.2'
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
       minimatch: 9.0.3
       shiki: 0.14.5
-      typescript: 5.3.1-rc
+      typescript: 5.2.2
     dev: true
 
-  /typescript@5.3.1-rc:
-    resolution: {integrity: sha512-NVq/AufFc6KVjmVPcuVwdCkhTQlTcMEyRYJPvaGhPvj+X80MYUF+90qf0//uvINPb2ULg9m91/gbdIOhN2cZqA==}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
