### PR TITLE
refactor: react-no-useless-fragment always allow expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## v0.8.13 (Wed Nov 29 2023)
+
+### Release Notes
+
+#### Update Options of rule `jsx/no-useless-fragment`
+
+#### Refactor Fragment related APIs of `@eslint-react/jsx`
+
+---
+
+#### 💥 Breaking Change
+
+- `@eslint-react/eslint-plugin-jsx`
+  - Remove `allowExpressions` option from rule `jsx/no-useless-fragment`.
+- `@eslint-react/jsx`
+  - Remove `isFragmentWithOnlyTextAndIsNotChild`, `isFragmentHasLessThanTwoChildren`, `isFragmentWithSingleExpression` from `@eslint-react/jsx`'s API.
+
+#### 🏠 Internal
+
+- `@eslint-react/eslint-plugin-jsx`
+  - Update Options of rule `jsx/no-useless-fragment`.
+
+- `@eslint-react/jsx`
+  - Refactor Fragment related APIs.
+
+- `@eslint-react/monorepo`
+  - Update `@typescript-eslint`'s packages to `6.13.1`.
+
+#### Authors: 1
+
+- Eva1ent ([@Rel1cx](https://github.com/Rel1cx))
+
 ## v0.8.12 (Tue Nov 28 2023)
 
 ### Release Notes
@@ -15,6 +47,7 @@
 
 - `@eslint-react/eslint-plugin-react`
   - Optimize bundle size.
+  - Add rule `react/no-render-return-value`.
 
 - `@eslint-react/eslint-plugin-react-hooks`
   - Optimize bundle size.
@@ -57,6 +90,9 @@
 
 - `@eslint-react/types`
   - Add `ExRSettings` type.
+
+- `@eslint-react/eslint-plugin-react`
+  - Add rule `react/no-find-dom-node`.
 
 - `@eslint-react/monorepo`
   - Update `@typescript-eslint`'s packages to `6.12.0`.

--- a/packages/eslint-plugin-jsx/src/rules/no-useless-fragment.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-useless-fragment.md
@@ -72,22 +72,3 @@ const cat = <>meow</>
 
 {showFullName ? fullName : firstName}
 ```
-
-## Rule Options
-
-### `allowExpressions`
-
-When `true` single expressions in a fragment will be allowed. This is useful in
-places like Typescript where `string` does not satisfy the expected return type
-of `JSX.Element`. A common workaround is to wrap the variable holding a string
-in a fragment and expression.
-
-Examples of **correct** code for the rule, when `"allowExpressions"` is `true`:
-
-```jsx
-<>{foo}</>
-
-<>
-  {foo}
-</>
-```

--- a/packages/eslint-plugin-jsx/src/rules/no-useless-fragment.spec.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-useless-fragment.spec.ts
@@ -27,7 +27,6 @@ ruleTester.run(RULE_NAME, rule, {
     "<>{moo}</>",
     "<>{}</>",
     "<>{meow}</>",
-    "<p><>{meow}</></p>",
     dedent`
       <SomeReact.SomeFragment>
         {foo}
@@ -50,6 +49,10 @@ ruleTester.run(RULE_NAME, rule, {
         { messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXFragment },
         { messageId: "NO_USELESS_FRAGMENT_IN_BUILT_IN", type: NodeType.JSXFragment },
       ],
+    },
+    {
+      code: "<p><>{meow}</></p>",
+      errors: [{ messageId: "NO_USELESS_FRAGMENT_IN_BUILT_IN", type: NodeType.JSXFragment }],
     },
     {
       code: "<><div/></>",

--- a/packages/eslint-plugin-jsx/src/rules/no-useless-fragment.spec.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-useless-fragment.spec.ts
@@ -25,6 +25,14 @@ ruleTester.run(RULE_NAME, rule, {
     "<Fooo content={<>eeee ee eeeeeee eeeeeeee</>} />",
     "<>{foos.map(foo => foo)}</>",
     "<>{moo}</>",
+    "<>{}</>",
+    "<>{meow}</>",
+    "<p><>{meow}</></p>",
+    dedent`
+      <SomeReact.SomeFragment>
+        {foo}
+      </SomeReact.SomeFragment>
+    `,
     dedent`
       <>
         {moo}
@@ -37,25 +45,7 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXFragment }],
     },
     {
-      code: "<>{}</>",
-      options: [{ allowExpressions: false }],
-      errors: [{ messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXFragment }],
-    },
-    {
       code: "<p>moo<>foo</></p>",
-      errors: [
-        { messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXFragment },
-        { messageId: "NO_USELESS_FRAGMENT_IN_BUILT_IN", type: NodeType.JSXFragment },
-      ],
-    },
-    {
-      code: "<>{meow}</>",
-      options: [{ allowExpressions: false }],
-      errors: [{ messageId: "NO_USELESS_FRAGMENT" }],
-    },
-    {
-      code: "<p><>{meow}</></p>",
-      options: [{ allowExpressions: false }],
       errors: [
         { messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXFragment },
         { messageId: "NO_USELESS_FRAGMENT_IN_BUILT_IN", type: NodeType.JSXFragment },
@@ -86,22 +76,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXElement }],
     },
     {
-      code: `
-        <SomeReact.SomeFragment>
-          {foo}
-        </SomeReact.SomeFragment>
-      `,
-      options: [{ allowExpressions: false }],
-      errors: [{ messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXElement }],
-      settings: {
-        react: {
-          pragma: "SomeReact",
-          fragment: "SomeFragment",
-        },
-      },
-    },
-    {
-      // Not safe to fix this case because `Eeee` might require child be ReactElement
       code: "<Eeee><>foo</></Eeee>",
       errors: [{ messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXFragment }],
     },
@@ -166,7 +140,6 @@ ruleTester.run(RULE_NAME, rule, {
     // Ensure allowExpressions still catches expected violations
     {
       code: "<><Foo>{moo}</Foo></>",
-      options: [{ allowExpressions: true }],
       errors: [{ messageId: "NO_USELESS_FRAGMENT", type: NodeType.JSXFragment }],
     },
   ],

--- a/packages/jsx/docs/README.md
+++ b/packages/jsx/docs/README.md
@@ -48,10 +48,7 @@
 - [isCreateElementCall](README.md#iscreateelementcall)
 - [isFragment](README.md#isfragment)
 - [isFragmentElement](README.md#isfragmentelement)
-- [isFragmentHasLessThanTwoChildren](README.md#isfragmenthaslessthantwochildren)
 - [isFragmentSyntax](README.md#isfragmentsyntax)
-- [isFragmentWithOnlyTextAndIsNotChild](README.md#isfragmentwithonlytextandisnotchild)
-- [isFragmentWithSingleExpression](README.md#isfragmentwithsingleexpression)
 - [isFunctionReturningJSXValue](README.md#isfunctionreturningjsxvalue)
 - [isInitializedFromPragma](README.md#isinitializedfrompragma)
 - [isInsideCreateElementProps](README.md#isinsidecreateelementprops)
@@ -623,26 +620,6 @@ Check if a node is `<Fragment></Fragment>` or `<Pragma.Fragment></Pragma.Fragmen
 
 ---
 
-### isFragmentHasLessThanTwoChildren
-
-▸ **isFragmentHasLessThanTwoChildren**(`node`): `boolean`
-
-Check if a JSXElement or JSXFragment has less than two non-padding children and the first child is not a call expression
-
-#### Parameters
-
-| Name   | Type                          | Description           |
-| :----- | :---------------------------- | :-------------------- |
-| `node` | `JSXElement` \| `JSXFragment` | The AST node to check |
-
-#### Returns
-
-`boolean`
-
-boolean
-
----
-
 ### isFragmentSyntax
 
 ▸ **isFragmentSyntax**(`node`): node is JSXFragment
@@ -658,48 +635,6 @@ Check if a node is `<></>`
 #### Returns
 
 node is JSXFragment
-
----
-
-### isFragmentWithOnlyTextAndIsNotChild
-
-▸ **isFragmentWithOnlyTextAndIsNotChild**(`node`): `boolean`
-
-Check if a JSXElement or JSXFragment has only one literal child and is not a child
-
-#### Parameters
-
-| Name   | Type                          | Description           |
-| :----- | :---------------------------- | :-------------------- |
-| `node` | `JSXElement` \| `JSXFragment` | The AST node to check |
-
-#### Returns
-
-`boolean`
-
-`true` if the node has only one literal child and is not a child
-
-**`Example`**
-
-```ts
-Somehow fragment like this is useful: <Foo content={<>ee eeee eeee ...</>} />
-```
-
----
-
-### isFragmentWithSingleExpression
-
-▸ **isFragmentWithSingleExpression**(`node`): `boolean`
-
-#### Parameters
-
-| Name   | Type                          |
-| :----- | :---------------------------- |
-| `node` | `JSXElement` \| `JSXFragment` |
-
-#### Returns
-
-`boolean`
 
 ---
 

--- a/packages/jsx/src/fragment.ts
+++ b/packages/jsx/src/fragment.ts
@@ -1,8 +1,6 @@
 import { is, isOneOf, NodeType } from "@eslint-react/ast";
 import { type TSESTree } from "@typescript-eslint/types";
 
-import { isLiteral, isPaddingSpaces } from "./textnode";
-
 export const isFragment = (
   node: TSESTree.Node,
   pragma: string,
@@ -39,47 +37,4 @@ export function isFragmentElement(node: TSESTree.JSXElement, pragma: string, fra
     && name.object.type === NodeType.JSXIdentifier
     && name.object.name === pragma
     && name.property.name === fragment;
-}
-
-/**
- * Check if a JSXElement or JSXFragment has only one literal child and is not a child
- * @param node The AST node to check
- * @returns `true` if the node has only one literal child and is not a child
- * @example Somehow fragment like this is useful: <Foo content={<>ee eeee eeee ...</>} />
- */
-export function isFragmentWithOnlyTextAndIsNotChild(node: TSESTree.JSXElement | TSESTree.JSXFragment) {
-  return node.children.length === 1
-    && isLiteral(node.children[0])
-    && !(node.parent.type === NodeType.JSXElement || node.parent.type === NodeType.JSXFragment);
-}
-
-function containsCallExpression(node: TSESTree.Node) {
-  return node.type === NodeType.JSXExpressionContainer
-    && node.expression.type === NodeType.CallExpression;
-}
-
-/**
- * Check if a JSXElement or JSXFragment has less than two non-padding children and the first child is not a call expression
- * @param node The AST node to check
- * @returns boolean
- */
-export function isFragmentHasLessThanTwoChildren(node: TSESTree.JSXElement | TSESTree.JSXFragment) {
-  const nonPaddingChildren = node.children.filter(
-    (child) => !isPaddingSpaces(child),
-  );
-
-  if (nonPaddingChildren.length === 1) {
-    return !containsCallExpression(nonPaddingChildren[0] as TSESTree.Node);
-  }
-
-  return nonPaddingChildren.length === 0;
-}
-
-export function isFragmentWithSingleExpression(node: TSESTree.JSXElement | TSESTree.JSXFragment) {
-  const children = node.children.filter((child) => !isPaddingSpaces(child));
-
-  return (
-    children.length === 1
-    && children[0]?.type === NodeType.JSXExpressionContainer
-  );
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
