### PR TITLE
Update Documentation for `no-useless-fragment` Rule

### DIFF
--- a/website/pages/rules/no-useless-fragment.mdx
+++ b/website/pages/rules/no-useless-fragment.mdx
@@ -43,3 +43,30 @@ function Example() {
   );
 }
 ```
+
+## Note
+
+[This rule always allows single expressions in a fragment](https://github.com/Rel1cx/eslint-react/pull/188), even though this was previously controlled by the `allowExpressions` option. This is useful in
+places like Typescript where `string` does not satisfy the expected return type
+of `JSX.Element`. A common workaround is to wrap the variable holding a string
+in a fragment and expression.
+
+### Examples of correct code for single expressions in fragments:
+
+```tsx twoslash
+import React from "react";
+
+function Example() {
+  const foo = "bar";
+  return <>{foo}</>;
+}
+
+function AnotherExample() {
+  const foo = "bar";
+  return (
+    <Fragment>
+      {foo}
+    </Fragment>
+  );
+}
+```


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This pull request updates the documentation to reflect the changes in the `no-useless-fragment` rule. The rule previously had an `allowExpressions` option, which controlled whether single expressions in a fragment were allowed. [This option has been removed](https://github.com/Rel1cx/eslint-react/pull/188), and the rule now always allows single expressions in a fragment.

### Motivation

- The removal of the `allowExpressions` option was not reflected in the documentation, potentially causing confusion for users transitioning from [`eslint-plugin-react`](https://github.com/jsx-eslint/eslint-plugin-react) to `@eslint-react`.
- By updating the documentation, we provide clear guidance on the current behavior of the `no-useless-fragment` rule.
