### PR TITLE
Fix rules' documentation

### DIFF
--- a/website/pages/docs/rules/avoid-shorthand-fragment.mdx
+++ b/website/pages/docs/rules/avoid-shorthand-fragment.mdx
@@ -1,4 +1,4 @@
-# prefer-shorthand-fragment
+# avoid-shorthand-fragment
 
 ## Rule category
 

--- a/website/pages/docs/rules/overview.md
+++ b/website/pages/docs/rules/overview.md
@@ -75,7 +75,7 @@
 | [`dom/no-missing-button-type`](dom-no-missing-button-type)                                         | Enforces explicit `type` attribute for `<button>` elements.                             |  ✔️  |     |     |
 | [`dom/no-missing-iframe-sandbox`](dom-no-missing-iframe-sandbox)                                   | Enforces explicit `sandbox` attribute for `iframe` elements.                            | 🔒  |     |     |
 | [`dom/no-namespace`](dom-no-namespace)                                                             | Enforces the absence of a `namespace` in React elements.                                |  ✔️  |     |     |
-| [`dom/no-render-return-value`](no-render-return-value)                                             | Prevents usage of the return value of `ReactDOM.render`.                                | ⛔  |     |     |
+| [`dom/no-render-return-value`](dom-no-render-return-value)                                             | Prevents usage of the return value of `ReactDOM.render`.                                | ⛔  |     |     |
 | [`dom/no-script-url`](dom-no-script-url)                                                           | Prevents usage of `javascript:` URLs as the value of certain attributes.                | 🔒  |     |     |
 | [`dom/no-unsafe-iframe-sandbox`](dom-no-unsafe-iframe-sandbox)                                     | Enforces `sandbox` attribute for `iframe` elements is not set to unsafe combinations.   | 🔒  |     |     |
 | [`dom/no-unsafe-target-blank`](dom-no-unsafe-target-blank)                                         | Prevents the use of `target="_blank"` without `rel="noreferrer noopener"`.              | 🔒  |     |     |

--- a/website/pages/docs/rules/prefer-read-only-props.mdx
+++ b/website/pages/docs/rules/prefer-read-only-props.mdx
@@ -1,4 +1,4 @@
-# prefer-readonly-props
+# prefer-read-only-props
 
 💭 This rule requires type information.
 


### PR DESCRIPTION
When configuring this plugin in my project, I've noticed some inconsistencies in the documentation, related to the rules. This pull request fixes them.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

I've also noticed, that `avoid-shorthand-fragment` and `prefer-shorthand-fragment` rules have identical descriptions, though they do opposite things:

* https://eslint-react.xyz/docs/rules/avoid-shorthand-fragment#what-it-does
* https://eslint-react.xyz/docs/rules/prefer-shorthand-fragment#what-it-does

Makes sense to fix it by maintainers, but it is not the scope of this pull request.
