### PR TITLE
Undeprecate `hooks-extra-no-direct-set-state-in-use-layout-effect` and remove it from recommended presets, closes #839

### DIFF
--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/index.ts
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/index.ts
@@ -1,6 +1,7 @@
 /* eslint-disable perfectionist/sort-objects */
 import { name, version } from "../package.json";
 import noDirectSetStateInUseEffect from "./rules/no-direct-set-state-in-use-effect";
+import noDirectSetStateInUseLayoutEffect from "./rules/no-direct-set-state-in-use-layout-effect";
 import noRedundantCustomHook from "./rules/no-redundant-custom-hook";
 import ensureUseCallbackHasNonEmptyDeps from "./rules/no-unnecessary-use-callback";
 import noUnnecessaryUseMemo from "./rules/no-unnecessary-use-memo";
@@ -13,6 +14,7 @@ export default {
   },
   rules: {
     "no-direct-set-state-in-use-effect": noDirectSetStateInUseEffect,
+    "no-direct-set-state-in-use-layout-effect": noDirectSetStateInUseLayoutEffect,
     "no-redundant-custom-hook": noRedundantCustomHook,
     "no-unnecessary-use-callback": ensureUseCallbackHasNonEmptyDeps,
     "no-unnecessary-use-memo": noUnnecessaryUseMemo,
@@ -22,7 +24,5 @@ export default {
     "ensure-custom-hooks-using-other-hooks": noRedundantCustomHook,
     /** @deprecated Use `no-unnecessary-use-memo` instead */
     "ensure-use-memo-has-non-empty-deps": noUnnecessaryUseMemo,
-    /** @deprecated Use `no-direct-set-state-in-use-effect` instead */
-    "no-direct-set-state-in-use-layout-effect": noDirectSetStateInUseEffect,
   },
 } as const;

--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-effect.spec.ts
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-effect.spec.ts
@@ -21,61 +21,6 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: /* tsx */ `
-        import { useLayoutEffect, useState } from "react";
-
-        function Component() {
-          const [data, setData] = useState(0);
-          useLayoutEffect(() => {
-            setData(1);
-          }, []);
-          return null;
-        }
-      `,
-      errors: [
-        { messageId: "noDirectSetStateInUseEffect" },
-      ],
-    },
-    {
-      code: /* tsx */ `
-        import { useInsertionEffect, useState } from "react";
-
-        function Component() {
-          const [data, setData] = useState(0);
-          useInsertionEffect(() => {
-            setData(1);
-          }, []);
-          return null;
-        }
-      `,
-      errors: [
-        { messageId: "noDirectSetStateInUseEffect" },
-      ],
-    },
-    {
-      code: /* tsx */ `
-        import { useState } from "react";
-
-        function Component() {
-          const [data, setData] = useState(0);
-          useIsomorphicLayoutEffect(() => {
-            setData(1);
-          }, []);
-          return null;
-        }
-      `,
-      errors: [
-        { messageId: "noDirectSetStateInUseEffect" },
-      ],
-      settings: {
-        "react-x": {
-          additionalHooks: {
-            useLayoutEffect: ["useIsomorphicLayoutEffect"],
-          },
-        },
-      },
-    },
-    {
-      code: /* tsx */ `
         import { useEffect, useState } from "react";
 
         function Component() {
@@ -823,6 +768,21 @@ ruleTester.run(RULE_NAME, rule, {
                 )
             return () => abortController.abort()
         }, [handlerWatcher])
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState, useRef } from "react";
+
+      function Tooltip() {
+        const ref = useRef(null);
+        const [tooltipHeight, setTooltipHeight] = useState(0); // You don't know real height yet
+
+        useLayoutEffect(() => {
+          const { height } = ref.current.getBoundingClientRect();
+          setTooltipHeight(height); // Re-render now that you know the real height
+        }, []);
+
+        // ...use tooltipHeight in the rendering logic below...
       }
     `,
   ],

--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-layout-effect.spec.ts
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-layout-effect.spec.ts
@@ -1,0 +1,829 @@
+import { allValid, ruleTester } from "../../../../../test";
+import rule, { RULE_NAME } from "./no-direct-set-state-in-use-layout-effect";
+
+ruleTester.run(RULE_NAME, rule, {
+  invalid: [
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          useLayoutEffect(() => {
+            setData(1);
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          useLayoutEffect(() => {
+            setData(1);
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useInsertionEffect, useState } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          useInsertionEffect(() => {
+            setData(1);
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useState } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          useIsomorphicLayoutEffect(() => {
+            setData(1);
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+      settings: {
+        "react-x": {
+          additionalHooks: {
+            useLayoutEffect: ["useIsomorphicLayoutEffect"],
+          },
+        },
+      },
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        function Component() {
+          const data = useState(0);
+          useLayoutEffect(() => {
+            data[1]();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        function Component() {
+          const data = useState(0);
+          useLayoutEffect(() => {
+            data.at(1)();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const index = 1;
+        function Component() {
+          const data = useState(0);
+          useLayoutEffect(() => {
+            data.at(index)();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const index = 1;
+        function Component() {
+          const data = useState(0);
+          useLayoutEffect(() => {
+            data[index]();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect } from "react";
+
+        const index = 1;
+        function Component() {
+          const data = useCustomState(0);
+          useLayoutEffect(() => {
+            data[index]();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+      settings: {
+        "react-x": {
+          additionalHooks: {
+            useState: ["useCustomState"],
+          },
+        },
+      },
+    },
+    {
+      code: /* tsx */ `
+        import { useState } from "react";
+
+        const index = 1;
+        function Component() {
+          const data = useState(0);
+          useCustomEffect(() => {
+            data[index]();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+      settings: {
+        "react-x": {
+          additionalHooks: {
+            useLayoutEffect: ["useCustomEffect"],
+          },
+        },
+      },
+    },
+    {
+      code: /* tsx */ `
+        const index = 1;
+        function Component() {
+          const data = useCustomState(0);
+          useCustomEffect(() => {
+            data[index]();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+      settings: {
+        "react-x": {
+          additionalHooks: {
+            useLayoutEffect: ["useCustomEffect"],
+            useState: ["useCustomState"],
+          },
+        },
+      },
+    },
+    {
+      code: /* tsx */ `
+        const index = 1;
+        function Component() {
+          const data = useCustomState(0);
+          useCustomEffect(() => {
+            data.at(index)();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+      settings: {
+        "react-x": {
+          additionalHooks: {
+            useLayoutEffect: ["useCustomEffect"],
+            useState: ["useCustomState"],
+          },
+        },
+      },
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          useLayoutEffect(() => {
+            if (data === 0) {
+              setData(1);
+            }
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          useLayoutEffect(() => {
+          const onLoad = () => {
+            setData();
+          };
+          onLoad();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data1, setData1] = useState();
+          const [data2, setData2] = useState();
+          const setAll = () => {
+            setData1();
+            setData2();
+          }
+          useLayoutEffect(() => {
+            setAll();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect", data: { name: "setData1" } },
+        { messageId: "noDirectSetStateInUseLayoutEffect", data: { name: "setData2" } },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState, useCallback } from "react";
+
+        const Component = () => {
+          const [data1, setData1] = useState();
+          const [data2, setData2] = useState();
+          const setAll = useCallback(() => {
+            setData1();
+            setData2();
+          })
+          useLayoutEffect(() => {
+            setAll();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect", data: { name: "setData1" } },
+        { messageId: "noDirectSetStateInUseLayoutEffect", data: { name: "setData2" } },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          useLayoutEffect(() => {
+              (() => { setData() })();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          useLayoutEffect(() => {
+            !(function onLoad() {
+              setData()
+            })();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          useLayoutEffect(() => {
+            const setAll = () => {
+              setData();
+            }
+            setAll()
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState, useCallback } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          const setAll = useCallback(() => setData(), []);
+          useLayoutEffect(() => {
+            setAll()
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState, useMemo } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          const setAll = useMemo(() => () => setData(), []);
+          useLayoutEffect(() => {
+            setAll()
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState, useCallback } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          const setAll = useCallback(setData, []);
+          useLayoutEffect(() => {
+            setAll()
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState, useMemo } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          const setAll = useMemo(() => setData, []);
+          useLayoutEffect(() => {
+            setAll()
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState, useMemo } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          const setAll = useMemo(() => setData, []);
+          useLayoutEffect(setAll, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    // TODO: Add cleanup function check
+    // {
+    //   code: /* tsx */ `
+    //     import { useLayoutEffect, useState } from "react";
+
+    //     const Component = () => {
+    //       const [data, setData] = useState();
+    //       useLayoutEffect(() => {
+    //         return () => {
+    //           setData();
+    //         }
+    //       }, []);
+    //       return null;
+    //     }
+    //   `,
+    //   errors: [
+    //     { messageId: "noDirectSetStateInUseLayoutEffect" },
+    //   ],
+    // },
+    // TODO: Add cleanup function check
+    // {
+    //   code: /* tsx */ `
+    //     import { useLayoutEffect, useState } from "react";
+
+    //     const Component = () => {
+    //       const [data, setData] = useState();
+    //       useLayoutEffect(() => {
+    //         const cleanup = () => {
+    //           setData();
+    //         }
+    //         return cleanup;
+    //       }, []);
+    //       return null;
+    //     }
+    //   `,
+    //   errors: [
+    //     { messageId: "noDirectSetStateInUseLayoutEffect" },
+    //   ],
+    // },
+    // TODO: Add cleanup function check
+    // {
+    //   code: /* tsx */ `
+    //     import { useLayoutEffect, useState } from "react";
+
+    //     const Component = () => {
+    //       const [data, setData] = useState();
+    //       useLayoutEffect(() => setData, []);
+    //       return null;
+    //     }
+    //   `,
+    //   errors: [
+    //     { messageId: "noDirectSetStateInUseLayoutEffect" },
+    //   ],
+    // },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          useLayoutEffect(() => setData(), []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          useLayoutEffect(setData, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          const setupFunction = () => {
+            setData()
+          }
+          useLayoutEffect(setupFunction, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          function setupFunction() {
+            setData()
+          }
+          useLayoutEffect(setupFunction, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component = () => {
+          const [data, setData] = useState();
+          useLayoutEffect(setupFunction, []);
+          function setupFunction() {
+            setData()
+          }
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        const Component1 = () => {
+          const [data, setData] = useState();
+          const setupFunction = () => {
+            setData()
+          }
+          useLayoutEffect(setupFunction, []);
+          return null;
+        }
+
+        const Component2 = () => {
+          const [data, setData] = useState();
+          const setupFunction = () => {
+            setData()
+          }
+          useLayoutEffect(setupFunction, []);
+          return null;
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+    {
+      code: /* tsx */ `
+        import { useLayoutEffect, useState } from "react";
+
+        function useCustomHook() {
+          const [data, setData] = useState();
+          const handlerWatcher = () => {
+              setData()
+          }
+          useLayoutEffect(() => {
+              const abortController = new AbortController()
+              new MutationObserverWatcher(searchAvatarMetaSelector())
+                  .addListener('onChange', handlerWatcher)
+                  .startWatch(
+                      {
+                          childList: true,
+                          subtree: true,
+                          attributes: true,
+                          attributeFilter: ['src'],
+                      },
+                      abortController.signal,
+                  )
+              handlerWatcher();
+              return () => abortController.abort()
+          }, [handlerWatcher])
+        }
+      `,
+      errors: [
+        { messageId: "noDirectSetStateInUseLayoutEffect" },
+      ],
+    },
+  ],
+  valid: [
+    ...allValid,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      function Component() {
+        const [fn] = useState(() => () => "Function");
+        // ...
+        useLayoutEffect(() => {
+          fn();
+        }, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      function Component() {
+        const [data, setData] = useState(0);
+        useLayoutEffect(() => {
+          const handler = () => setData(1);
+        }, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      function Component() {
+        const [data, setData] = useState(0);
+        useLayoutEffect(() => {
+          fetch().then(() => setData());
+        }, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const Component = () => {
+        const [data, setData] = useState();
+        useLayoutEffect(() => {
+        const onLoad = () => {
+          setData();
+        };
+        }, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const index = 0;
+      function Component() {
+        const data = useState(() => 0);
+        useLayoutEffect(() => {
+          data.at(index)();
+        }, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const index = 0;
+      function Component() {
+        const [data, setData] = useState(() => 0);
+        useLayoutEffect(() => {
+          void async function () {
+            const ret = await fetch("https://example.com");
+            setData(ret);
+          }()
+        }, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const Component = () => {
+        const [data1, setData1] = useState();
+        const [data2, setData2] = useState();
+        const setAll = () => {
+          setData1();
+          setData2();
+        }
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const Component = () => {
+        const [data1, setData1] = useState();
+        const [data2, setData2] = useState();
+        const setAll = () => {
+          setData1();
+          setData2();
+        }
+        const handler = () => {
+          setAll();
+        }
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const Component = () => {
+        const [data1, setData1] = useState();
+        const [data2, setData2] = useState();
+        function handler() {
+          setAll();
+        }
+        function setAll() {
+          setData1();
+          setData2();
+        }
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const Component1 = () => {
+        const [data, setData] = useState();
+        const setupFunction = () => {
+          setData()
+        }
+        return null;
+      }
+
+      const Component2 = () => {
+        const [data, setData] = useState();
+        useLayoutEffect(setupFunction, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      const Component1 = () => {
+        const [data, setData] = useState();
+        const setAll = () => {
+          setData();
+        }
+        return null;
+      }
+
+      const Component2 = () => {
+        const [data, setData] = useState();
+        useLayoutEffect(() => {
+          setAll();
+        }, []);
+        return null;
+      }
+    `,
+    /* tsx */ `
+      import { useLayoutEffect, useState } from "react";
+
+      function useCustomHook() {
+        const [data, setData] = useState();
+        const handlerWatcher = () => {
+            setData()
+        }
+        useLayoutEffect(() => {
+            const abortController = new AbortController()
+            new MutationObserverWatcher(searchAvatarMetaSelector())
+                .addListener('onChange', handlerWatcher)
+                .startWatch(
+                    {
+                        childList: true,
+                        subtree: true,
+                        attributes: true,
+                        attributeFilter: ['src'],
+                    },
+                    abortController.signal,
+                )
+            return () => abortController.abort()
+        }, [handlerWatcher])
+      }
+    `,
+  ],
+});

--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-layout-effect.spec.ts
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-layout-effect.spec.ts
@@ -21,38 +21,6 @@ ruleTester.run(RULE_NAME, rule, {
     },
     {
       code: /* tsx */ `
-        import { useLayoutEffect, useState } from "react";
-
-        function Component() {
-          const [data, setData] = useState(0);
-          useLayoutEffect(() => {
-            setData(1);
-          }, []);
-          return null;
-        }
-      `,
-      errors: [
-        { messageId: "noDirectSetStateInUseLayoutEffect" },
-      ],
-    },
-    {
-      code: /* tsx */ `
-        import { useInsertionEffect, useState } from "react";
-
-        function Component() {
-          const [data, setData] = useState(0);
-          useInsertionEffect(() => {
-            setData(1);
-          }, []);
-          return null;
-        }
-      `,
-      errors: [
-        { messageId: "noDirectSetStateInUseLayoutEffect" },
-      ],
-    },
-    {
-      code: /* tsx */ `
         import { useState } from "react";
 
         function Component() {
@@ -823,6 +791,21 @@ ruleTester.run(RULE_NAME, rule, {
                 )
             return () => abortController.abort()
         }, [handlerWatcher])
+      }
+    `,
+    /* tsx */ `
+      import { useEffect, useState, useRef } from "react";
+
+      function Tooltip() {
+        const ref = useRef(null);
+        const [tooltipHeight, setTooltipHeight] = useState(0); // You don't know real height yet
+
+        useEffect(() => {
+          const { height } = ref.current.getBoundingClientRect();
+          setTooltipHeight(height); // Re-render now that you know the real height
+        }, []);
+
+        // ...use tooltipHeight in the rendering logic below...
       }
     `,
   ],

--- a/packages/plugins/eslint-plugin/src/index.ts
+++ b/packages/plugins/eslint-plugin/src/index.ts
@@ -83,6 +83,7 @@ const allPreset = {
 
   // Part: Hooks Extra
   "hooks-extra/no-direct-set-state-in-use-effect": "warn",
+  "hooks-extra/no-direct-set-state-in-use-layout-effect": "warn",
   "hooks-extra/no-redundant-custom-hook": "warn",
   "hooks-extra/no-unnecessary-use-callback": "warn",
   "hooks-extra/no-unnecessary-use-memo": "warn",

--- a/website/next.config.mjs
+++ b/website/next.config.mjs
@@ -64,11 +64,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: "/docs/rules/hooks-extra-no-direct-set-state-in-use-layout-effect",
-        destination: "/docs/rules/hooks-extra-no-direct-set-state-in-use-effect",
-        permanent: true,
-      },
-      {
         source: "/docs/rules/debug-react-hooks",
         destination: "/docs/rules/debug-hook",
         permanent: true,

--- a/website/pages/docs/rules/_meta.ts
+++ b/website/pages/docs/rules/_meta.ts
@@ -72,6 +72,7 @@ export default {
   "hooks-extra-no-unnecessary-use-callback": "hooks-extra/no-unnecessary-use-callback",
   "hooks-extra-no-unnecessary-use-memo": "hooks-extra/no-unnecessary-use-memo",
   "hooks-extra-no-direct-set-state-in-use-effect": "hooks-extra/no-direct-set-state-in-use-effect",
+  "hooks-extra-no-direct-set-state-in-use-layout-effect": "hooks-extra/no-direct-set-state-in-use-layout-effect",
   "hooks-extra-prefer-use-state-lazy-initialization": "hooks-extra/prefer-use-state-lazy-initialization",
   "naming-convention-component-name": "naming-convention/component-name",
   "naming-convention-filename": "naming-convention/filename",

--- a/website/pages/docs/rules/hooks-extra-no-direct-set-state-in-use-layout-effect.mdx
+++ b/website/pages/docs/rules/hooks-extra-no-direct-set-state-in-use-layout-effect.mdx
@@ -1,0 +1,244 @@
+import { Info } from "#/components/callout"
+
+# no-direct-set-state-in-use-layout-effect
+
+## Rule category
+
+Correctness.
+
+## What it does
+
+<Info>
+This rule only checks for **direct** calls to the `set` function of `useState` in `useLayoutEffect`. It does not check for calls to `set` function in callbacks, event handlers, or `Promise.then` functions.
+</Info>
+
+Disallow **direct** calls to the [`set` function](https://react.dev/reference/react/useState#setstate) of `useState` in `useLayoutEffect`.
+
+## Examples
+
+<Info>
+The first three cases are common valid use cases because they are not called the `set` function directly in `useLayoutEffect`.
+</Info>
+
+### Passing
+
+```tsx
+import { useState, useLayoutEffect } from "react";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  useLayoutEffect(() => {
+    const handler = () => setCount(c => c + 1);
+    window.addEventListener("click", handler);
+    return () => window.removeEventListener("click", handler);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+```
+
+### Passing
+
+```tsx
+import { useState, useLayoutEffect } from "react";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+
+  useLayoutEffect(() => {
+    const intervalId = setInterval(() => {
+      setCount(c => c + 1);
+    }, 1000);
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+```
+
+### Passing
+
+```tsx
+import { useState, useLayoutEffect } from "react";
+
+export default function RemoteContent() {
+  const [content, setContent] = useState("");
+
+  useLayoutEffect(() => {
+    let discarded = false;
+    fetch("https://example.com/content")
+      .then(resp => resp.text())
+      .then(text => {
+        if (discarded) return;
+        setContent(text);
+      });
+    return () => {
+      discarded = true;
+    };
+  }, []);
+
+  return <h1>{count}</h1>;
+}
+```
+
+### Failing
+
+```tsx
+import { useLayoutEffect, useState } from 'react';
+
+function Form() {
+  const [firstName, setFirstName] = useState('Taylor');
+  const [lastName, setLastName] = useState('Swift');
+
+  // 🔴 Avoid: redundant state and unnecessary Effect
+  const [fullName, setFullName] = useState('');
+  useLayoutEffect(() => {
+    setFullName(firstName + ' ' + lastName);
+  }, [firstName, lastName]);
+  // ...
+}
+```
+
+### Passing
+
+```tsx
+import { useState } from 'react';
+
+function Form() {
+  const [firstName, setFirstName] = useState('Taylor');
+  const [lastName, setLastName] = useState('Swift');
+  // ✅ Good: calculated during rendering
+  const fullName = firstName + ' ' + lastName;
+  // ...
+}
+```
+
+### Failing
+
+```tsx
+import { useLayoutEffect, useState } from 'react';
+
+function TodoList({ todos, filter }) {
+  const [newTodo, setNewTodo] = useState('');
+
+  // 🔴 Avoid: redundant state and unnecessary Effect
+  const [visibleTodos, setVisibleTodos] = useState([]);
+  useLayoutEffect(() => {
+    setVisibleTodos(getFilteredTodos(todos, filter));
+  }, [todos, filter]);
+
+  // ...
+}
+```
+
+### Passing
+
+```tsx
+import { useMemo, useState } from 'react';
+
+function TodoList({ todos, filter }) {
+  const [newTodo, setNewTodo] = useState('');
+  // ✅ Does not re-run getFilteredTodos() unless todos or filter change
+  const visibleTodos = useMemo(() => getFilteredTodos(todos, filter), [todos, filter]);
+  // ...
+}
+```
+
+### Failing
+
+```tsx
+import { useLayoutEffect, useState } from 'react';
+
+export default function ProfilePage({ userId }) {
+  const [comment, setComment] = useState('');
+
+  // 🔴 Avoid: Resetting state on prop change in an Effect
+  useLayoutEffect(() => {
+    setComment('');
+  }, [userId]);
+  // ...
+}
+```
+
+### Passing
+
+```tsx
+import { useState } from 'react';
+
+export default function ProfilePage({ userId }) {
+  return (
+    <Profile
+      userId={userId}
+      key={userId}
+    />
+  );
+}
+
+function Profile({ userId }) {
+  // ✅ This and any other state below will reset on key change automatically
+  const [comment, setComment] = useState('');
+  // ...
+}
+```
+
+### Failing
+
+```tsx
+import { useLayoutEffect, useState } from 'react';
+
+function List({ items }) {
+  const [isReverse, setIsReverse] = useState(false);
+  const [selection, setSelection] = useState(null);
+
+  // 🔴 Avoid: Adjusting state on prop change in an Effect
+  useLayoutEffect(() => {
+    setSelection(null);
+  }, [items]);
+  // ...
+}
+```
+
+### Passing
+
+```tsx
+import { useState } from 'react';
+
+function List({ items }) {
+  const [isReverse, setIsReverse] = useState(false);
+  const [selection, setSelection] = useState(null);
+
+  // Better: Adjust the state while rendering
+  const [prevItems, setPrevItems] = useState(items);
+  if (items !== prevItems) {
+    setPrevItems(items);
+    setSelection(null);
+  }
+  // ...
+}
+```
+
+```tsx
+import { useState } from 'react';
+
+function List({ items }) {
+  const [isReverse, setIsReverse] = useState(false);
+  const [selectedId, setSelectedId] = useState(null);
+  // ✅ Best: Calculate everything during rendering
+  const selection = items.find(item => item.id === selectedId) ?? null;
+  // ...
+}
+```
+
+## Known limitations
+
+- The `set` call to `useState` in the `cleanup` function of `useLayoutEffect` will not be checked.
+- The current implementation does not support determining whether a `set` function called in an `async` function is actually at least one `await` after.
+
+The limitation may be lifted in the future.
+
+### Further Reading
+
+- [React: useState](https://react.dev/reference/react/useState#setstate)
+- [React: useLayoutEffect](https://react.dev/reference/react/useLayoutEffect)
+- [React: You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)

--- a/website/pages/docs/rules/overview.md
+++ b/website/pages/docs/rules/overview.md
@@ -97,13 +97,14 @@
 
 ## Hooks Extra Rules
 
-| Rule                                                                                                   | Description                                                               | 💼  | 💭  |     |
-| :----------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------ | :-: | :-: | :-: |
-| [`hooks-extra/no-direct-set-state-in-use-effect`](hooks-extra-no-direct-set-state-in-use-effect)       | Disallow direct calls to the `set` function of `useState` in `useEffect`. |  ✔️  |     | 📐  |
-| [`hooks-extra/no-redundant-custom-hook`](hooks-extra-no-redundant-custom-hook)                         | Warns when custom Hooks that don't use other Hooks.                       |  ✔️  |     |     |
-| [`hooks-extra/no-unnecessary-use-callback`](hooks-extra-no-unnecessary-use-callback)                   | Disallow unnecessary usage of `useCallback`.                              |  ✔️  |     | 📐  |
-| [`hooks-extra/no-unnecessary-use-memo`](hooks-extra-no-unnecessary-use-memo)                           | Disallow unnecessary usage of `useMemo`.                                  |  ✔️  |     | 📐  |
-| [`hooks-extra/prefer-use-state-lazy-initialization`](hooks-extra-prefer-use-state-lazy-initialization) | Warns function calls made inside `useState` calls.                        | 🚀  |     |     |
+| Rule                                                                                                           | Description                                                                     | 💼  | 💭  |     |
+| :------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :-: | :-: | :-: |
+| [`hooks-extra/no-direct-set-state-in-use-effect`](hooks-extra-no-direct-set-state-in-use-effect)               | Disallow direct calls to the `set` function of `useState` in `useEffect`.       |  ✔️  |     | 📐  |
+| [`hooks-extra/no-direct-set-state-in-use-layout-effect`](hooks-extra-no-direct-set-state-in-use-layout-effect) | Disallow direct calls to the `set` function of `useState` in `useLayoutEffect`. |  ✔️  |     | 📐  |
+| [`hooks-extra/no-redundant-custom-hook`](hooks-extra-no-redundant-custom-hook)                                 | Warns when custom Hooks that don't use other Hooks.                             |  ✔️  |     |     |
+| [`hooks-extra/no-unnecessary-use-callback`](hooks-extra-no-unnecessary-use-callback)                           | Disallow unnecessary usage of `useCallback`.                                    |  ✔️  |     | 📐  |
+| [`hooks-extra/no-unnecessary-use-memo`](hooks-extra-no-unnecessary-use-memo)                                   | Disallow unnecessary usage of `useMemo`.                                        |  ✔️  |     | 📐  |
+| [`hooks-extra/prefer-use-state-lazy-initialization`](hooks-extra-prefer-use-state-lazy-initialization)         | Warns function calls made inside `useState` calls.                              | 🚀  |     |     |
 
 ## Naming Convention Rules
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
