### PR TITLE
feat(core): `ComponentCollector` adds options to skip the collection of…

### DIFF
--- a/packages/core/docs/README.md
+++ b/packages/core/docs/README.md
@@ -6,6 +6,7 @@
 
 ## Interfaces
 
+- [ComponentCollectorOptions](interfaces/ComponentCollectorOptions.md)
 - [ERClassComponent](interfaces/ERClassComponent.md)
 - [ERFunctionComponent](interfaces/ERFunctionComponent.md)
 - [ERHook](interfaces/ERHook.md)
@@ -30,6 +31,7 @@
 
 ## Variables
 
+- [DEFAULT\_COMPONENT\_COLLECT\_OPTIONS](variables/DEFAULT_COMPONENT_COLLECT_OPTIONS.md)
 - [DEFAULT\_COMPONENT\_HINT](variables/DEFAULT_COMPONENT_HINT.md)
 - [ERClassComponentFlag](variables/ERClassComponentFlag.md)
 - [ERComponentHint](variables/ERComponentHint.md)

--- a/packages/core/docs/functions/useComponentCollector.md
+++ b/packages/core/docs/functions/useComponentCollector.md
@@ -6,7 +6,7 @@
 
 # Function: useComponentCollector()
 
-> **useComponentCollector**(`context`, `hint`): `object`
+> **useComponentCollector**(`context`, `hint`, `options`): `object`
 
 ## Parameters
 
@@ -17,6 +17,10 @@
 ### hint
 
 `bigint` = `DEFAULT_COMPONENT_HINT`
+
+### options
+
+[`ComponentCollectorOptions`](../interfaces/ComponentCollectorOptions.md) = `DEFAULT_COMPONENT_COLLECT_OPTIONS`
 
 ## Returns
 
@@ -84,7 +88,7 @@
 
 `void`
 
-#### listeners.AssignmentExpression\[type\]\[operator='='\]\[left.type='MemberExpression'\]\[left.property.name='displayName'\]()
+#### listeners.AssignmentExpression\[type\]\[operator='='\]\[left.type='MemberExpression'\]\[left.property.name='displayName'\]()?
 
 ##### Parameters
 
@@ -96,7 +100,7 @@
 
 `void`
 
-#### listeners.CallExpression\[type\]:exit()
+#### listeners.CallExpression\[type\]:exit()?
 
 ##### Parameters
 

--- a/packages/core/docs/interfaces/ComponentCollectorOptions.md
+++ b/packages/core/docs/interfaces/ComponentCollectorOptions.md
@@ -1,0 +1,19 @@
+[**@eslint-react/core**](../README.md)
+
+***
+
+[@eslint-react/core](../README.md) / ComponentCollectorOptions
+
+# Interface: ComponentCollectorOptions
+
+## Properties
+
+### collectDisplayName
+
+> **collectDisplayName**: `boolean`
+
+***
+
+### collectHookCalls
+
+> **collectHookCalls**: `boolean`

--- a/packages/core/docs/variables/DEFAULT_COMPONENT_COLLECT_OPTIONS.md
+++ b/packages/core/docs/variables/DEFAULT_COMPONENT_COLLECT_OPTIONS.md
@@ -1,0 +1,9 @@
+[**@eslint-react/core**](../README.md)
+
+***
+
+[@eslint-react/core](../README.md) / DEFAULT\_COMPONENT\_COLLECT\_OPTIONS
+
+# Variable: DEFAULT\_COMPONENT\_COLLECT\_OPTIONS
+
+> `const` **DEFAULT\_COMPONENT\_COLLECT\_OPTIONS**: [`ComponentCollectorOptions`](../interfaces/ComponentCollectorOptions.md)

--- a/packages/core/src/hook/hook-collector.ts
+++ b/packages/core/src/hook/hook-collector.ts
@@ -57,13 +57,7 @@ export function useHookCollector() {
       if (hook == null) {
         return;
       }
-      hooks.set(hook.key, {
-        ...hook,
-        hookCalls: [
-          ...hook.hookCalls,
-          node,
-        ],
-      });
+      hook.hookCalls.push(node);
     },
   } as const satisfies ESLintUtils.RuleListener;
   return { ctx, listeners } as const;

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.spec.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.spec.ts
@@ -15,6 +15,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "App",
+          displayName: `"TestDisplayName"`,
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -33,6 +34,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "App",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -48,6 +50,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "App",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: true,
@@ -66,6 +69,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "App",
+          displayName: '`${"TestDisplayName"}`',
           forwardRef: false,
           hookCalls: 0,
           memo: true,
@@ -86,6 +90,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "App",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 1,
           memo: true,
@@ -100,6 +105,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "App",
+          displayName: "none",
           forwardRef: true,
           hookCalls: 0,
           memo: false,
@@ -116,6 +122,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "MemoComponent",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: true,
@@ -135,6 +142,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "Component",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: true,
@@ -149,6 +157,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "ForwardRefComponent",
+          displayName: "none",
           forwardRef: true,
           hookCalls: 0,
           memo: false,
@@ -165,6 +174,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "MemoForwardRefComponent",
+          displayName: "none",
           forwardRef: true,
           hookCalls: 0,
           memo: true,
@@ -179,6 +189,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "MemoForwardRefComponent",
+          displayName: "none",
           forwardRef: true,
           hookCalls: 0,
           memo: true,
@@ -197,6 +208,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "ComponentWithHooks",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 1,
           memo: false,
@@ -211,6 +223,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "App",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -236,6 +249,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -245,6 +259,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -271,6 +286,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -280,6 +296,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -306,6 +323,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -315,6 +333,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedVariableComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -341,6 +360,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -350,6 +370,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedVariableComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -376,6 +397,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -385,6 +407,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -411,6 +434,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -420,6 +444,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -446,6 +471,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "anonymous",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -455,6 +481,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -481,6 +508,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "anonymous",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -490,6 +518,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -516,6 +545,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -525,6 +555,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedVariableComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -551,6 +582,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -560,6 +592,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedVariableComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -587,6 +620,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "ParentComponent",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -613,6 +647,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "ParentComponent",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -639,6 +674,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "UnstableNestedFunctionComponent",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -665,6 +701,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "UnstableNestedClassComponent",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -691,6 +728,7 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "functionComponent",
         data: {
           name: "UnstableNestedVariableComponent",
+          displayName: "none",
           forwardRef: false,
           hookCalls: 0,
           memo: false,
@@ -718,6 +756,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedClassComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -748,6 +787,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -757,6 +797,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "NestedUnstableFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -783,6 +824,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -792,6 +834,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "NestedUnstableFunctionComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -821,6 +864,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ComponentWithProps",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -830,6 +874,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -856,6 +901,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ComponentWithProps",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -865,6 +911,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -874,6 +921,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "SomeFooter",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -898,6 +946,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ComponentWithProps",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -907,6 +956,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -931,6 +981,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ComponentWithProps",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -940,6 +991,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -976,6 +1028,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -985,6 +1038,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1009,6 +1063,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ComponentForProps",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1018,6 +1073,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1042,6 +1098,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ComponentForProps",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1051,6 +1108,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1071,6 +1129,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1080,6 +1139,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "Header",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1104,6 +1164,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "List",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1135,6 +1196,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "List",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1163,6 +1225,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1190,6 +1253,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1215,6 +1279,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1241,6 +1306,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1250,6 +1316,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: true,
@@ -1276,6 +1343,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1285,6 +1353,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: true,
@@ -1313,6 +1382,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1322,6 +1392,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: true,
@@ -1350,6 +1421,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "ParentComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1359,6 +1431,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "UnstableNestedComponent",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: true,
@@ -1379,6 +1452,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "MyComponent1",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1388,6 +1462,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "MyComponent2",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1397,6 +1472,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "MyComponent3",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1406,6 +1482,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "MyComponent4",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,
@@ -1415,6 +1492,7 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "functionComponent",
           data: {
             name: "MyComponent5",
+            displayName: "none",
             forwardRef: false,
             hookCalls: 0,
             memo: false,

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.ts
@@ -1,4 +1,9 @@
-import { isReactHookCallWithNameLoose, isUseStateCall, useComponentCollector } from "@eslint-react/core";
+import {
+  DEFAULT_COMPONENT_HINT,
+  isReactHookCallWithNameLoose,
+  isUseStateCall,
+  useComponentCollector,
+} from "@eslint-react/core";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import type { RuleFeature } from "@eslint-react/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -37,7 +42,17 @@ export default createRule<[], MessageID>({
   name: RULE_NAME,
   create(context) {
     const alias = getSettingsFromContext(context).additionalHooks?.useState ?? [];
-    const { ctx, listeners } = useComponentCollector(context);
+    const {
+      ctx,
+      listeners,
+    } = useComponentCollector(
+      context,
+      DEFAULT_COMPONENT_HINT,
+      {
+        collectDisplayName: false,
+        collectHookCalls: true,
+      },
+    );
 
     return {
       ...listeners,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import { ERFunctionComponentFlag, useComponentCollector } from "@eslint-react/core";
+import { DEFAULT_COMPONENT_HINT, ERFunctionComponentFlag, useComponentCollector } from "@eslint-react/core";
 import type { RuleFeature } from "@eslint-react/types";
 import type { CamelCase } from "string-ts";
 
@@ -30,8 +30,17 @@ export default createRule<[], MessageID>({
     if (!context.sourceCode.text.includes("memo") && !context.sourceCode.text.includes("forwardRef")) {
       return {};
     }
-    const { ctx, listeners } = useComponentCollector(context);
-
+    const {
+      ctx,
+      listeners,
+    } = useComponentCollector(
+      context,
+      DEFAULT_COMPONENT_HINT,
+      {
+        collectDisplayName: true,
+        collectHookCalls: false,
+      },
+    );
     return {
       ...listeners,
       "Program:exit"(node) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.ts
@@ -5,6 +5,7 @@ import * as VAR from "@eslint-react/var";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 
 import { createRule } from "../utils";
+import { getOrUpdate } from "@eslint-react/eff";
 
 export const RULE_NAME = "no-unstable-context-value";
 
@@ -67,8 +68,7 @@ export default createRule<[], MessageID>({
         if (isReactHookCall(construction.node)) {
           return;
         }
-        const prevs = constructions.get(functionEntry.node) ?? [];
-        constructions.set(functionEntry.node, [...prevs, construction]);
+        getOrUpdate(constructions, functionEntry.node, () => []).push(construction);
       },
       "Program:exit"(node) {
         const components = ctx.getAllComponents(node).values();

--- a/packages/utilities/eff/docs/README.md
+++ b/packages/utilities/eff/docs/README.md
@@ -26,6 +26,7 @@
 - [flip](functions/flip.md)
 - [flow](functions/flow.md)
 - [fromEntries](functions/fromEntries.md)
+- [getOrUpdate](functions/getOrUpdate.md)
 - [identity](functions/identity.md)
 - [isArray](functions/isArray.md)
 - [isObject](functions/isObject.md)
@@ -36,3 +37,4 @@
 - [returnFalse](functions/returnFalse.md)
 - [returnTrue](functions/returnTrue.md)
 - [returnVoid](functions/returnVoid.md)
+- [tryAddToSet](functions/tryAddToSet.md)

--- a/packages/utilities/eff/docs/functions/getOrUpdate.md
+++ b/packages/utilities/eff/docs/functions/getOrUpdate.md
@@ -1,0 +1,33 @@
+[**@eslint-react/eff**](../README.md)
+
+***
+
+[@eslint-react/eff](../README.md) / getOrUpdate
+
+# Function: getOrUpdate()
+
+> **getOrUpdate**\<`K`, `V`\>(`map`, `key`, `callback`): `V`
+
+## Type Parameters
+
+• **K**
+
+• **V**
+
+## Parameters
+
+### map
+
+`Map`\<`K`, `V`\>
+
+### key
+
+`K`
+
+### callback
+
+() => `V`
+
+## Returns
+
+`V`

--- a/packages/utilities/eff/docs/functions/tryAddToSet.md
+++ b/packages/utilities/eff/docs/functions/tryAddToSet.md
@@ -1,0 +1,27 @@
+[**@eslint-react/eff**](../README.md)
+
+***
+
+[@eslint-react/eff](../README.md) / tryAddToSet
+
+# Function: tryAddToSet()
+
+> **tryAddToSet**\<`T`\>(`set`, `value`): `boolean`
+
+## Type Parameters
+
+• **T**
+
+## Parameters
+
+### set
+
+`Set`\<`T`\>
+
+### value
+
+`T`
+
+## Returns
+
+`boolean`

--- a/packages/utilities/eff/src/collection.ts
+++ b/packages/utilities/eff/src/collection.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable @susisu/safe-typescript/no-type-assertion */
 // export function zipWith<T, U, V>(
 //   arrayA: readonly T[],
@@ -29,22 +30,22 @@ import type { Pretty } from "./type";
 //   return result;
 // }
 
-// export function getOrUpdate<K, V>(map: Map<K, V>, key: K, callback: () => V): V {
-//   if (map.has(key)) {
-//     return map.get(key)!;
-//   }
-//   const value = callback();
-//   map.set(key, value);
-//   return value;
-// }
+export function getOrUpdate<K, V>(map: Map<K, V>, key: K, callback: () => V): V {
+  if (map.has(key)) {
+    return map.get(key)!;
+  }
+  const value = callback();
+  map.set(key, value);
+  return value;
+}
 
-// export function tryAddToSet<T>(set: Set<T>, value: T): boolean {
-//   if (!set.has(value)) {
-//     set.add(value);
-//     return true;
-//   }
-//   return false;
-// }
+export function tryAddToSet<T>(set: Set<T>, value: T): boolean {
+  if (!set.has(value)) {
+    set.add(value);
+    return true;
+  }
+  return false;
+}
 
 // /** @internal */
 // export function concatenate<T>(array1: T[], array2: T[]): T[];


### PR DESCRIPTION
… semantic nodes that are not relevant to the current linting task

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
