### PR TITLE
fix: regression in `no-unstable-context-value` in `1.29.0` 

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.spec.ts
@@ -265,5 +265,10 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    /* tsx */ `
+      const Provider = ({foo, children}: {foo: {}, children: React.ReactNode}) => {
+        return <Context value={foo}>{children}</Context>;
+      };
+    `
   ],
 });


### PR DESCRIPTION
No actual fix, but a repro demonstrating the issue.

```
{
    ruleId: '@rule-tester/no-unstable-context-value',
    severity: 2,
    message: "A/an 'arrow function expression' passed as the value prop to the context provider should not be constructed. It will change on every render. Consider wrapping it in a useCallback hook.",
    line: 2,
    column: 24,
    nodeType: 'ArrowFunctionExpression',
    messageId: 'unstableContextValue',
    endLine: 4,
    endColumn: 8
  }
```

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
