### PR TITLE
fix(plugins/hooks-extra): misidentification of 'set' function in IIFE inside of hooks as its inside of 'useEffect', 'useLayoutEffect', closes #967

### DIFF
--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/hooks/use-no-direct-set-state-in-use-effect.ts
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/hooks/use-no-direct-set-state-in-use-effect.ts
@@ -107,8 +107,9 @@ export function useNoDirectSetStateInUseEffect<Ctx extends RuleContext>(
       match(getCallKind(node))
         .with("setState", () => {
           switch (true) {
-            case pEntry.node === setupFunction
-              || pEntry.kind === "immediate": {
+            case pEntry.node === setupFunction:
+            case pEntry.kind === "immediate"
+              && AST.findParentNode(pEntry.node, AST.isFunction) === setupFunction: {
               onViolation(context, node, {
                 name: context.sourceCode.getText(node.callee),
               });

--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-effect.spec.ts
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-effect.spec.ts
@@ -785,5 +785,21 @@ ruleTester.run(RULE_NAME, rule, {
         // ...use tooltipHeight in the rendering logic below...
       }
     `,
+    // https://github.com/Rel1cx/eslint-react/issues/967
+    /* tsx */ `
+      import { useEffect, useState, useCallback } from "react";
+
+      function useCustomHook() {
+        const [something, setSomething] = useState('');
+
+        const test = useCallback(() => {
+          setSomething('') // doesn't trigger the rules
+
+          ;(() => {
+            setSomething('') // trigger the rules
+          })()
+        }, [])
+      }
+    `,
   ],
 });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-prop.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-prop.md
@@ -20,7 +20,7 @@ react-x/no-children-prop
 
 ## What it does
 
-Disallows passing 'children' as a prop.
+Disallows passing `children` as a prop.
 
 Most of the time, `children` should be actual `children`, not passed in as a `prop`.
 


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
