### PR TITLE
fix: the requested module 'ts-api-utils' does not provide an export named 'unionConstituents', closes #1009

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering.ts
@@ -10,7 +10,7 @@ import { ESLintUtils } from "@typescript-eslint/utils";
 import type { ReportDescriptor, RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import { compare } from "compare-versions";
 import type { CamelCase } from "string-ts";
-import { isFalseLiteralType, isTrueLiteralType, isTypeFlagSet, unionConstituents } from "ts-api-utils";
+import { isFalseLiteralType, isTrueLiteralType, isTypeFlagSet, unionTypeParts } from "ts-api-utils";
 import { isMatching, match, P } from "ts-pattern";
 import ts from "typescript";
 
@@ -235,7 +235,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           } as const;
         }
         const leftType = getConstrainedTypeAtLocation(services, left);
-        const leftTypeVariants = inspectVariantTypes(unionConstituents(leftType));
+        const leftTypeVariants = inspectVariantTypes(unionTypeParts(leftType)); // eslint-disable-line @typescript-eslint/no-deprecated
         const isLeftValid = Array
           .from(leftTypeVariants.values())
           .every((type) => allowedVariants.some((allowed) => allowed === type));


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
