### PR TITLE
feat(react-x): enhance `jsx-uses-react` rule to support inline jsx annotation

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.spec.ts
@@ -1,27 +1,81 @@
+import { RuleTester } from "@typescript-eslint/rule-tester";
 import tsx from "dedent";
 
-import { allValid, ruleTester } from "../../../../../test";
-import rule from "./jsx-uses-react";
+import { JsxEmit } from "typescript";
+import { defaultLanguageOptionsWithTypes, getProjectForJsxRuntime } from "../../../../../test";
+import rule, { debug, RULE_NAME } from "./jsx-uses-react";
 
-ruleTester.run("no-unused-vars", rule, {
-  // TODO: Add invalid test cases
-  invalid: [],
-  valid: [
-    ...allValid,
-    {
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ...defaultLanguageOptionsWithTypes,
+    parserOptions: {
+      ...defaultLanguageOptionsWithTypes.parserOptions,
+      project: getProjectForJsxRuntime(JsxEmit.React),
+      projectService: false,
+    },
+  },
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions, @typescript-eslint/no-unnecessary-condition
+debug
+  ? ruleTester.run(RULE_NAME, rule, {
+    invalid: [
+      {
+        code: tsx`
+          import React from "react";
+
+          const Hello = <div>Hello</div>;
+
+          console.log(Hello);
+        `,
+        errors: [
+          {
+            messageId: "jsxUsesReact",
+            data: { name: "React" },
+          },
+          {
+            messageId: "jsxUsesReact",
+            data: { name: "React.createElement" },
+          },
+        ],
+      },
+      {
+        code: tsx`
+          /** @jsx Foo */
+          import Foo from "foo";
+
+          const Hello = <div>Hello</div>;
+
+          console.log(Hello);
+        `,
+        errors: [
+          {
+            messageId: "jsxUsesReact",
+            data: { name: "Foo" },
+          },
+        ],
+      },
+    ],
+    valid: [],
+  })
+  : ruleTester.run(RULE_NAME, rule, {
+    invalid: [],
+    valid: [{
       code: tsx`
         import React from "react";
 
         const Hello = <div>Hello</div>;
+
+        console.log(Hello);
       `,
-    },
-    {
+    }, {
       code: tsx`
         /** @jsx Foo */
         import Foo from "foo";
 
         const Hello = <div>Hello</div>;
+
+        console.log(Hello);
       `,
-    },
-  ],
-});
+    }],
+  });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.spec.ts
@@ -1,98 +1,10 @@
-import tsx from "dedent";
+import { ruleTester } from "../../../../../test";
+import rule, { RULE_NAME } from "./jsx-uses-vars";
 
-import { allValid, ruleTester } from "../../../../../test";
-import rule from "./jsx-uses-vars";
-
-ruleTester.run("no-unused-vars", rule, {
-  // TODO: Add invalid test cases
+// TODO: Add tests
+ruleTester.run(RULE_NAME, rule, {
   invalid: [],
   valid: [
-    ...allValid,
-    {
-      code: tsx`
-        function foo() {
-          var App;
-          var bar = React.render(<App/>);
-          return bar;
-        };
-        foo()
-      `,
-    },
-    {
-      code: tsx`
-        var App;
-        React.render(<App/>);
-      `,
-    },
-    {
-      code: tsx`
-        var a = 1;
-        React.render(<img src={a} />);
-      `,
-    },
-    {
-      code: tsx`
-        var App;
-        function f() {
-          return <App />;
-        }
-        f();
-      `,
-    },
-    {
-      code: tsx`
-        var App;
-        <App.Hello />
-      `,
-    },
-    {
-      code: tsx`
-        class HelloMessage {};
-        <HelloMessage />
-      `,
-    },
-    {
-      code: tsx`
-        class HelloMessage {
-          render() {
-            var HelloMessage = <div>Hello</div>;
-            return HelloMessage;
-          }
-        };
-        <HelloMessage />
-      `,
-    },
-    {
-      code: tsx`
-        function foo() {
-          var App = { Foo: { Bar: {} } };
-          var bar = React.render(<App.Foo.Bar/>);
-          return bar;
-        };
-        foo()
-      `,
-    },
-    {
-      code: tsx`
-        function foo() {
-          var App = { Foo: { Bar: { Baz: {} } } };
-          var bar = React.render(<App.Foo.Bar.Baz/>);
-          return bar;
-        };
-        foo()
-      `,
-    },
-    {
-      code: tsx`
-        var object;
-        React.render(<object.Tag />);
-      `,
-    },
-    {
-      code: tsx`
-        var object;
-        React.render(<object.tag />);
-      `,
-    },
+    "const a = <div />;",
   ],
 });

--- a/packages/utilities/kit/src/JsxRuntime/JsxRuntimeOptions.ts
+++ b/packages/utilities/kit/src/JsxRuntime/JsxRuntimeOptions.ts
@@ -22,6 +22,7 @@ export type JsxRuntimeOptions = Pick<
  */
 export function getJsxRuntimeOptionsFromContext(context: RuleContext) {
   const options = context.sourceCode.parserServices?.program?.getCompilerOptions() ?? {};
+  console.log(options);
   return {
     jsx: options.jsx ?? JsxEmit.ReactJSX,
     jsxFactory: options.jsxFactory ?? "React.createElement",

--- a/packages/utilities/kit/src/RegExp.ts
+++ b/packages/utilities/kit/src/RegExp.ts
@@ -39,9 +39,14 @@ export const RE_CONSTANT_CASE = /^[A-Z][\d_A-Z]*$/u;
 export const RE_JAVASCRIPT_PROTOCOL = /^[\u0000-\u001F ]*j[\t\n\r]*a[\t\n\r]*v[\t\n\r]*a[\t\n\r]*s[\t\n\r]*c[\t\n\r]*r[\t\n\r]*i[\t\n\r]*p[\t\n\r]*t[\t\n\r]*:/iu;
 
 /**
- * Regular expression for matching a JSX pragma comment.
+ * Regular expression for matching a `@jsx` annotation comment.
  */
-export const RE_JSX_ANNOTATION = /@jsx\s+(\S+)/;
+export const RE_JSX_ANNOTATION = /@jsx\s+(\S+)/u;
+
+/**
+ * Regular expression for matching a `@jsxFrag` annotation comment.
+ */
+export const RE_JSX_FRAG_ANNOTATION = /@jsxFrag\s+(\S+)/u;
 
 /**
  * Regular expression for matching a valid JavaScript identifier.

--- a/test/fixtures/tsconfig.jsx-preserve.json
+++ b/test/fixtures/tsconfig.jsx-preserve.json
@@ -1,0 +1,35 @@
+{
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json"
+  ],
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ES2021",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "preserve",
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noFallthroughCasesInSwitch": true,
+    "incremental": false
+  },
+  "include": [
+    "*.ts",
+    "*.tsx"
+  ]
+}

--- a/test/fixtures/tsconfig.jsx-react-native.json
+++ b/test/fixtures/tsconfig.jsx-react-native.json
@@ -1,0 +1,35 @@
+{
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json"
+  ],
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ES2021",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-native",
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noFallthroughCasesInSwitch": true,
+    "incremental": false
+  },
+  "include": [
+    "*.ts",
+    "*.tsx"
+  ]
+}

--- a/test/fixtures/tsconfig.jsx-react.json
+++ b/test/fixtures/tsconfig.jsx-react.json
@@ -1,0 +1,35 @@
+{
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json"
+  ],
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ES2021",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleDetection": "force",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react",
+    "strict": true,
+    "erasableSyntaxOnly": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noFallthroughCasesInSwitch": true,
+    "incremental": false
+  },
+  "include": [
+    "*.ts",
+    "*.tsx"
+  ]
+}

--- a/test/rule-tester.ts
+++ b/test/rule-tester.ts
@@ -1,6 +1,7 @@
 import { RuleTester, type RuleTesterConfig } from "@typescript-eslint/rule-tester";
 import * as vitest from "vitest";
 import { getFixturesRootDir } from "./helpers";
+import { JsxEmit } from "typescript";
 
 RuleTester.it = vitest.it;
 RuleTester.itOnly = vitest.it.only;
@@ -37,3 +38,18 @@ export const ruleTester = new RuleTester({
 export const ruleTesterWithTypes = new RuleTester({
   languageOptions: defaultLanguageOptionsWithTypes,
 });
+
+export function getProjectForJsxRuntime(jsxRuntime: JsxEmit) {
+  switch (jsxRuntime) {
+    case JsxEmit.None:
+    case JsxEmit.ReactJSX:
+    case JsxEmit.ReactJSXDev:
+      return "tsconfig.json";
+    case JsxEmit.React:
+      return "tsconfig.jsx-react.json";
+    case JsxEmit.ReactNative:
+      return "tsconfig.jsx-react-native.json";
+    case JsxEmit.Preserve:
+      return "tsconfig.jsx-preserve.json";
+  }
+}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
