### PR TITLE
feat: rename `core` preset to `x`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A series of composable ESLint rules for React and friends.
 
 ### Modular
 
-- [`eslint-plugin-react-x`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) - Core rules (renderer-agnostic, compatible with x-platform).
+- [`eslint-plugin-react-x`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) - X Rules (renderer-agnostic, compatible with x-platform).
 - [`eslint-plugin-react-dom`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) - DOM specific rules for React DOM.
 - [`eslint-plugin-react-web-api`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-web-api) - Rules for interacting with Web APIs.
 - [`eslint-plugin-react-hooks-extra`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-hooks-extra) - Extra React Hooks rules.

--- a/apps/website/content/docs/deprecated.md
+++ b/apps/website/content/docs/deprecated.md
@@ -24,4 +24,5 @@ full: true
 
 | Preset    | Replaced by   | Deprecated in |
 | :-------- | :------------ | :------------ |
+| `core`    | `x`           | 1.42.0        |
 | `off-dom` | `disable-dom` | 1.10.0        |

--- a/apps/website/content/docs/presets.mdx
+++ b/apps/website/content/docs/presets.mdx
@@ -8,7 +8,7 @@ The following presets are available in `@eslint-react/eslint-plugin`:
 
 ## Bare Bones
 
-- `core`\
+- `x`\
   Enable rules for `"react"`.
 - `dom`\
   Enable rules for `"react-dom"`.
@@ -19,7 +19,7 @@ The following presets are available in `@eslint-react/eslint-plugin`:
 
 - `recommended`\
   Enforce rules that are recommended by ESLint React for general purpose React + React DOM projects.\
-  _This preset includes the `core`, `dom`, and `web-api` presets._
+  _This preset includes the `x`, `dom`, and `web-api` presets._
 
 ## TypeScript Specialized
 

--- a/apps/website/content/docs/roadmap.md
+++ b/apps/website/content/docs/roadmap.md
@@ -20,7 +20,7 @@ Minimum supported versions:
 
 ### Plugins (with ecological niche explanation)
 
-- [x] `eslint-plugin-react-x` - Core rules (renderer-agnostic, compatible with x-platform)
+- [x] `eslint-plugin-react-x` - X Rules (renderer-agnostic, compatible with x-platform)
 - [x] `eslint-plugin-react-dom` - DOM Specific rules for React DOM
 - [x] `eslint-plugin-react-web-api` - Rules for interacting with Web APIs
 - [x] `eslint-plugin-react-hooks-extra` - Extra rules for `eslint-plugin-react-hooks`

--- a/apps/website/content/docs/rules/meta.json
+++ b/apps/website/content/docs/rules/meta.json
@@ -1,7 +1,7 @@
 {
   "pages": [
     "overview",
-    "---Core Rules---",
+    "---X Rules---",
     "jsx-no-duplicate-props",
     "jsx-no-undef",
     "jsx-uses-react",

--- a/apps/website/content/docs/rules/overview.mdx
+++ b/apps/website/content/docs/rules/overview.mdx
@@ -21,7 +21,7 @@ Linter rules can have false positives, false negatives, and some rules are depen
 - 2️⃣ - Severity 2
 - ✅ - Severity in recommended presets
 
-## Core Rules
+## X Rules
 
 | Rule                                                                                 | ✅ |    🌟    | Description                                                                                           | `react` |
 | :----------------------------------------------------------------------------------- | :- | :------: | :---------------------------------------------------------------------------------------------------- | :-----: |

--- a/apps/website/migration/index.ts
+++ b/apps/website/migration/index.ts
@@ -11,6 +11,11 @@ export const redirects = [
     destination: "/docs/using-an-alternative-parser/ts-blank-eslint-parser",
     permanent: true,
   },
+  {
+    source: "https://eslint-react.xyz/docs/rules/overview#core-rules",
+    destination: "https://eslint-react.xyz/docs/rules/overview#x-rules",
+    permanent: true,
+  },
   // Redirects for old rule names
   {
     source: "/docs/rules/use-jsx-vars",

--- a/packages/plugins/eslint-plugin-react-x/README.md
+++ b/packages/plugins/eslint-plugin-react-x/README.md
@@ -42,4 +42,4 @@ export default tseslint.config({
 
 ## Rules
 
-<https://eslint-react.xyz/docs/rules/overview#core-rules>
+<https://eslint-react.xyz/docs/rules/overview#x-rules>

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.md
@@ -16,7 +16,7 @@ react-x/jsx-no-duplicate-props
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 
 ## Description

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.md
@@ -16,7 +16,7 @@ react-x/jsx-uses-react
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 
 ## Description

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.md
@@ -16,7 +16,7 @@ react-x/jsx-uses-vars
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 
 ## Description

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate.md
@@ -16,7 +16,7 @@ react-x/no-access-state-in-setstate
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key.md
@@ -16,7 +16,7 @@ react-x/no-array-index-key
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-count.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-count.md
@@ -16,7 +16,7 @@ react-x/no-children-count
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-for-each.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-for-each.md
@@ -16,7 +16,7 @@ react-x/no-children-for-each
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-map.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-map.md
@@ -16,7 +16,7 @@ react-x/no-children-map
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-only.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-only.md
@@ -16,7 +16,7 @@ react-x/no-children-only
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-to-array.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-to-array.md
@@ -16,7 +16,7 @@ react-x/no-children-to-array
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-class-component.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-class-component.md
@@ -16,7 +16,7 @@ react-x/no-class-component
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-clone-element.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-clone-element.md
@@ -16,7 +16,7 @@ react-x/no-clone-element
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-comment-textnodes.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-comment-textnodes.md
@@ -16,7 +16,7 @@ react-x/no-comment-textnodes
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount.md
@@ -20,7 +20,7 @@ react-x/no-component-will-mount
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props.md
@@ -20,7 +20,7 @@ react-x/no-component-will-receive-props
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-update.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-update.md
@@ -20,7 +20,7 @@ react-x/no-component-will-update
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider.md
@@ -20,7 +20,7 @@ react-x/no-context-provider
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-create-ref.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-create-ref.md
@@ -16,7 +16,7 @@ react-x/no-create-ref
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-default-props.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-default-props.md
@@ -16,7 +16,7 @@ react-x/no-default-props
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state.md
@@ -16,7 +16,7 @@ react-x/no-direct-mutation-state
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key.md
@@ -16,7 +16,7 @@ react-x/no-duplicate-key
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref.md
@@ -20,7 +20,7 @@ react-x/no-forward-ref
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.md
@@ -20,7 +20,7 @@ react-x/no-implicit-key
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-key.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-key.md
@@ -16,7 +16,7 @@ react-x/no-missing-key
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.md
@@ -16,7 +16,7 @@ react-x/no-nested-component-definitions
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-prop-types.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-prop-types.md
@@ -16,7 +16,7 @@ react-x/no-prop-types
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update.md
@@ -16,7 +16,7 @@ react-x/no-redundant-should-component-update
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.md
@@ -16,7 +16,7 @@ react-x/no-set-state-in-component-did-mount
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.md
@@ -16,7 +16,7 @@ react-x/no-set-state-in-component-did-update
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.md
@@ -16,7 +16,7 @@ react-x/no-set-state-in-component-will-update
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-string-refs.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-string-refs.md
@@ -16,7 +16,7 @@ react-x/no-string-refs
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.md
@@ -16,7 +16,7 @@ react-x/no-unsafe-component-will-mount
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.md
@@ -16,7 +16,7 @@ react-x/no-unsafe-component-will-receive-props
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.md
@@ -16,7 +16,7 @@ react-x/no-unsafe-component-will-update
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.md
@@ -16,7 +16,7 @@ react-x/no-unstable-context-value
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.md
@@ -16,7 +16,7 @@ react-x/no-unstable-default-props
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.md
@@ -16,7 +16,7 @@ react-x/no-unused-class-component-members
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.md
@@ -16,7 +16,7 @@ react-x/no-unused-state
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context.md
@@ -20,7 +20,7 @@ react-x/no-use-context
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-forward-ref.md
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-forward-ref.md
@@ -16,7 +16,7 @@ react-x/no-useless-forward-ref
 
 **Presets**
 
-- `core`
+- `x`
 - `recommended`
 - `recommended-typescript`
 - `recommended-type-checked`

--- a/packages/plugins/eslint-plugin/README.md
+++ b/packages/plugins/eslint-plugin/README.md
@@ -18,7 +18,7 @@ A series of composable ESLint rules for React and friends.
 
 ### Modular
 
-- [`eslint-plugin-react-x`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) - Core rules (renderer-agnostic, compatible with x-platform).
+- [`eslint-plugin-react-x`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) - X Rules (renderer-agnostic, compatible with x-platform).
 - [`eslint-plugin-react-dom`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) - DOM specific rules for React DOM.
 - [`eslint-plugin-react-web-api`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-web-api) - Rules for interacting with Web APIs.
 - [`eslint-plugin-react-hooks-extra`](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-hooks-extra) - Extra React Hooks rules.


### PR DESCRIPTION
Rebrands "Core Rules" as "X Rules" across documentation and references

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
