### PR TITLE
fix: fixed jsx detection method not respect SkipEmptyArray hint, closes #1122

### DIFF
--- a/packages/core/src/jsx/jsx-detection.ts
+++ b/packages/core/src/jsx/jsx-detection.ts
@@ -53,6 +53,9 @@ export function isJsxLike(
       return !(hint & JSXDetectionHint.SkipStringLiteral);
     }
     case T.ArrayExpression: {
+      if (node.elements.length === 0) {
+        return !(hint & JSXDetectionHint.SkipEmptyArray);
+      }
       if (hint & JSXDetectionHint.StrictArray) {
         return node.elements.every((n) => isJsxLike(code, n, hint));
       }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-read-only-props.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-read-only-props.spec.ts
@@ -686,5 +686,46 @@ ruleTesterWithTypes.run(RULE_NAME, rule, {
 
       export { ItemsListElementSkeleton }
     `,
+    // https://github.com/Rel1cx/eslint-react/issues/1122
+    tsx`
+      import { useState } from 'react';
+
+          type Book = {
+            title: string,
+            author: string,
+          }
+          export default function MyComponent() {
+            const [books, setBooks] = useState<Book[]>([]);
+            const dropFirstBook = () => {
+              setBooks(
+                // Error in next line: A function component's props should be read-only.
+                // Source: @eslint-react/prefer-read-only-props
+                (currentBooks: Book[]) => {
+                  const newBooks: Book[] = [];
+                  // Considerable additional logic is found here in a non-toy example;
+                  // suggestions to just rewrite this as e.g.,
+                  // return [...currentBooks.slice(1)];
+                  // which gets the above line reported as compliant with the rule
+                  // are not nearly as helpful as they might seem,
+                  // though knowing about them might help find the root cause of the bug.
+                  newBooks.push(...currentBooks.slice(1));
+                  return newBooks;
+                }
+              );
+            };
+            //Please assume there's more that was simplified away for this bug demonstration.
+            if(books.length > 0) {
+              return(<>
+                The first book is {books[0].title}.
+                <button
+                  type='button'
+                  onClick={dropFirstBook}
+                > Remove it. </button>
+              </>);
+            } else {
+              return null;
+            }
+          }
+    `,
   ],
 });


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
