### PR TITLE
fix: disable-conflict-eslint-plugin-react config

### DIFF
--- a/packages/plugins/eslint-plugin/src/configs/disable-conflict-eslint-plugin-react.ts
+++ b/packages/plugins/eslint-plugin/src/configs/disable-conflict-eslint-plugin-react.ts
@@ -55,5 +55,5 @@ const conflictingRules = [
 export const name = "@eslint-react/disable-conflict-eslint-plugin-react";
 
 export const rules: RulePreset = Object.fromEntries(
-  Object.entries(conflictingRules).map(([key]) => [key, "off"] as const),
+  conflictingRules.map((key) => [key, "off"] as const),
 );


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Currently, `disable-conflict-eslint-plugin-react` config is broken, as it uses numeric indices instead of rule names.