### PR TITLE
fix: allow string style prop on non-host elements in `dom/no-string-style-prop`, closes #1217

### DIFF
--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.spec.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.spec.ts
@@ -54,5 +54,10 @@ ruleTester.run(RULE_NAME, rule, {
         return <div style={someStyle} />;
       }
     `,
+    tsx`
+      function Component() {
+        return <StatusBar style="auto" />;
+      }
+    `,
   ],
 });

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.ts
@@ -31,6 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXElement(node) {
+      if (!ER.isHostElement(context, node)) return;
       const getAttribute = ER.getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
       const attribute = getAttribute("style");
       if (attribute == null) return;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
