### PR TITLE
Replace star imports with direct imports

### DIFF
--- a/packages/core/src/jsx/jsx-attribute.ts
+++ b/packages/core/src/jsx/jsx-attribute.ts
@@ -1,9 +1,9 @@
 import type * as AST from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/kit";
-import * as VAR from "@eslint-react/var";
+import { findProperty, findVariable, getVariableDefinitionNode } from "@eslint-react/var";
 import type { Scope } from "@typescript-eslint/scope-manager";
-
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
+
 import { getAttributeName } from "./jsx-attribute-name";
 
 export function getAttribute(context: RuleContext, attributes: AST.TSESTreeJSXAttributeLike[], initialScope?: Scope) {
@@ -18,16 +18,16 @@ export function getAttribute(context: RuleContext, attributes: AST.TSESTreeJSXAt
       switch (attr.argument.type) {
         // Case 2: Spread from variable (e.g., {...props})
         case T.Identifier: {
-          const variable = VAR.findVariable(attr.argument.name, initialScope);
-          const variableNode = VAR.getVariableDefinitionNode(variable, 0);
+          const variable = findVariable(attr.argument.name, initialScope);
+          const variableNode = getVariableDefinitionNode(variable, 0);
           if (variableNode?.type === T.ObjectExpression) {
-            return VAR.findProperty(name, variableNode.properties, initialScope) != null;
+            return findProperty(name, variableNode.properties, initialScope) != null;
           }
           return false;
         }
         // Case 3: Spread from object literal (e.g., {{...{prop: value}}})
         case T.ObjectExpression:
-          return VAR.findProperty(name, attr.argument.properties, initialScope) != null;
+          return findProperty(name, attr.argument.properties, initialScope) != null;
       }
       return false;
     });

--- a/packages/core/src/jsx/jsx-detection.ts
+++ b/packages/core/src/jsx/jsx-detection.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import * as AST from "@eslint-react/ast";
 import type { unit } from "@eslint-react/eff";
-import * as VAR from "@eslint-react/var";
+import { findVariable, getVariableDefinitionNode } from "@eslint-react/var";
 import type { Scope } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { TSESTree } from "@typescript-eslint/utils";
@@ -185,9 +185,9 @@ export function isJsxLike(
         return true;
       }
       // Resolve variables to their values and check if they're JSX-like
-      const variable = VAR.findVariable(name, code.getScope(node));
+      const variable = findVariable(name, code.getScope(node));
       const variableNode = variable
-        && VAR.getVariableDefinitionNode(variable, 0);
+        && getVariableDefinitionNode(variable, 0);
       return !!variableNode
         && isJsxLike(code, variableNode, hint);
     }

--- a/packages/core/src/utils/is-from-react.ts
+++ b/packages/core/src/utils/is-from-react.ts
@@ -1,6 +1,6 @@
 import * as AST from "@eslint-react/ast";
 import { identity } from "@eslint-react/eff";
-import * as VAR from "@eslint-react/var";
+import { findVariable } from "@eslint-react/var";
 import type { Scope } from "@typescript-eslint/scope-manager";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -34,7 +34,7 @@ export function isInitializedFromReact(
   initialScope: Scope,
 ): boolean {
   if (name.toLowerCase() === "react") return true;
-  const latestDef = VAR.findVariable(name, initialScope)?.defs.at(-1);
+  const latestDef = findVariable(name, initialScope)?.defs.at(-1);
   if (latestDef == null) return false;
   const { node, parent } = latestDef;
   if (node.type === T.VariableDeclarator && node.init != null) {

--- a/packages/core/src/utils/is-instance-id-equal.ts
+++ b/packages/core/src/utils/is-instance-id-equal.ts
@@ -1,12 +1,12 @@
 /* eslint-disable jsdoc/require-param */
 import * as AST from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/kit";
-import * as VAR from "@eslint-react/var";
+import { isNodeValueEqual } from "@eslint-react/var";
 import type { TSESTree } from "@typescript-eslint/types";
 
 /** @internal */
 export function isInstanceIdEqual(context: RuleContext, a: TSESTree.Node, b: TSESTree.Node) {
-  return AST.isNodeEqual(a, b) || VAR.isNodeValueEqual(a, b, [
+  return AST.isNodeEqual(a, b) || isNodeValueEqual(a, b, [
     context.sourceCode.getScope(a),
     context.sourceCode.getScope(b),
   ]);

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/class-component.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/class-component.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
   return {
     ...listeners,
     "Program:exit"(program) {

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { ComponentFlag, DEFAULT_COMPONENT_DETECTION_HINT, useComponentCollector } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -32,12 +32,12 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
-  const { ctx, listeners } = ER.useComponentCollector(
+  const { ctx, listeners } = useComponentCollector(
     context,
     {
       collectDisplayName: true,
       collectHookCalls: true,
-      hint: ER.DEFAULT_COMPONENT_DETECTION_HINT,
+      hint: DEFAULT_COMPONENT_DETECTION_HINT,
     },
   );
   return {
@@ -54,9 +54,9 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
               displayName: displayName == null
                 ? "none"
                 : context.sourceCode.getText(displayName),
-              forwardRef: (flag & ER.ComponentFlag.ForwardRef) > 0n,
+              forwardRef: (flag & ComponentFlag.ForwardRef) > 0n,
               hookCalls: hookCalls.length,
-              memo: (flag & ER.ComponentFlag.Memo) > 0n,
+              memo: (flag & ComponentFlag.Memo) > 0n,
             }),
           },
         });

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/hook.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/hook.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { useHookCollector } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
-  const { ctx, listeners } = ER.useHookCollector();
+  const { ctx, listeners } = useHookCollector();
 
   return {
     ...listeners,

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-react.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-react.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isInitializedFromReact } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import type { Scope } from "@typescript-eslint/scope-manager";
@@ -79,12 +79,12 @@ function isFromReact(
     case node.parent.type === T.MemberExpression
       && node.parent.property === node
       && node.parent.object.type === T.Identifier:
-      return ER.isInitializedFromReact(node.parent.object.name, importSource, initialScope);
+      return isInitializedFromReact(node.parent.object.name, importSource, initialScope);
     case node.parent.type === T.JSXMemberExpression
       && node.parent.property === node
       && node.parent.object.type === T.JSXIdentifier:
-      return ER.isInitializedFromReact(node.parent.object.name, importSource, initialScope);
+      return isInitializedFromReact(node.parent.object.name, importSource, initialScope);
     default:
-      return ER.isInitializedFromReact(name, importSource, initialScope);
+      return isInitializedFromReact(name, importSource, initialScope);
   }
 }

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.ts
@@ -1,9 +1,9 @@
-import * as ER from "@eslint-react/core";
+import { hasAttribute, isJsxText } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
+import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
 
-import { AST_NODE_TYPES, type TSESTree } from "@typescript-eslint/types";
 import { createRule } from "../utils";
 
 export const RULE_NAME = "no-dangerously-set-innerhtml-with-children";
@@ -40,8 +40,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const attributes = node.openingElement.attributes;
       const initialScope = context.sourceCode.getScope(node);
       const hasChildren = node.children.some(isSignificantChildren)
-        || ER.hasAttribute(context, "children", attributes, initialScope);
-      if (hasChildren && ER.hasAttribute(context, dangerouslySetInnerHTML, attributes, initialScope)) {
+        || hasAttribute(context, "children", attributes, initialScope);
+      if (hasChildren && hasAttribute(context, dangerouslySetInnerHTML, attributes, initialScope)) {
         context.report({
           messageId: "noDangerouslySetInnerhtmlWithChildren",
           node,
@@ -66,7 +66,7 @@ function isWhiteSpace(node: TSESTree.JSXText | TSESTree.Literal) {
  * @returns boolean
  */
 function isPaddingSpaces(node: TSESTree.Node) {
-  return ER.isJsxText(node)
+  return isJsxText(node)
     && isWhiteSpace(node)
     && node.raw.includes("\n");
 }

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getAttribute } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -35,8 +35,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes(dangerouslySetInnerHTML)) return {};
   return {
     JSXElement(node) {
-      const getAttribute = ER.getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
-      const attribute = getAttribute(dangerouslySetInnerHTML);
+      const getAttributeEx = getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
+      const attribute = getAttributeEx(dangerouslySetInnerHTML);
       if (attribute == null) return;
       context.report({
         messageId: "noDangerouslySetInnerhtml",

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getAttribute, resolveAttributeValue } from "@eslint-react/core";
 import type { RuleContext, RuleFeature, RuleSuggest } from "@eslint-react/kit";
 import type { RuleFixer, RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -42,8 +42,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     JSXElement(node) {
       const { domElementType } = resolver.resolve(node);
       if (domElementType !== "button") return;
-      const getAttribute = ER.getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
-      const typeAttribute = getAttribute("type");
+      const getAttributeEx = getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
+      const typeAttribute = getAttributeEx("type");
       if (typeAttribute == null) {
         context.report({
           messageId: "noMissingButtonType",
@@ -54,7 +54,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         });
         return;
       }
-      if (typeof ER.resolveAttributeValue(context, typeAttribute).toStatic("type") === "string") return;
+      if (typeof resolveAttributeValue(context, typeAttribute).toStatic("type") === "string") return;
       context.report({
         messageId: "noMissingButtonType",
         node: typeAttribute,

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getAttribute, resolveAttributeValue } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -41,8 +41,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     JSXElement(node) {
       const { domElementType } = resolver.resolve(node);
       if (domElementType !== "iframe") return;
-      const getAttribute = ER.getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
-      const sandboxAttribute = getAttribute("sandbox");
+      const getAttributeEx = getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
+      const sandboxAttribute = getAttributeEx("sandbox");
       if (sandboxAttribute == null) {
         context.report({
           messageId: "noMissingIframeSandbox",
@@ -57,7 +57,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         });
         return;
       }
-      const sandboxAttributeValue = ER.resolveAttributeValue(context, sandboxAttribute);
+      const sandboxAttributeValue = resolveAttributeValue(context, sandboxAttribute);
       if (typeof sandboxAttributeValue.toStatic("sandbox") === "string") return;
       context.report({
         messageId: "noMissingIframeSandbox",

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-namespace.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-namespace.ts
@@ -1,7 +1,8 @@
-import * as ER from "@eslint-react/core";
+import { getElementType } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
+
 import { createRule } from "../utils";
 
 export const RULE_NAME = "no-namespace";
@@ -30,7 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXElement(node) {
-      const name = ER.getElementType(context, node);
+      const name = getElementType(context, node);
       if (typeof name !== "string" || !name.includes(":")) {
         return;
       }

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-script-url.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-script-url.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { resolveAttributeValue } from "@eslint-react/core";
 import { RE_JAVASCRIPT_PROTOCOL, type RuleContext, type RuleFeature } from "@eslint-react/kit";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
@@ -33,7 +33,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXAttribute(node) {
       if (node.name.type !== T.JSXIdentifier || node.value == null) return;
-      const value = ER.resolveAttributeValue(context, node).toStatic();
+      const value = resolveAttributeValue(context, node).toStatic();
       if (typeof value === "string" && RE_JAVASCRIPT_PROTOCOL.test(value)) {
         context.report({
           messageId: "noScriptUrl",

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getAttribute, isHostElement, resolveAttributeValue } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,11 +31,11 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXElement(node) {
-      if (!ER.isHostElement(context, node)) return;
-      const getAttribute = ER.getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
-      const attribute = getAttribute("style");
+      if (!isHostElement(context, node)) return;
+      const getAttributeEx = getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
+      const attribute = getAttributeEx("style");
       if (attribute == null) return;
-      const attributeValue = ER.resolveAttributeValue(context, attribute);
+      const attributeValue = resolveAttributeValue(context, attribute);
       if (typeof attributeValue.toStatic() === "string") {
         context.report({
           messageId: "noStringStyleProp",

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getAttribute, resolveAttributeValue } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -45,10 +45,10 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     JSXElement(node) {
       const { domElementType } = resolver.resolve(node);
       if (domElementType !== "iframe") return;
-      const getAttribute = ER.getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
-      const sandboxAttribute = getAttribute("sandbox");
+      const getAttributeEx = getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
+      const sandboxAttribute = getAttributeEx("sandbox");
       if (sandboxAttribute == null) return;
-      const sandboxValue = ER.resolveAttributeValue(context, sandboxAttribute);
+      const sandboxValue = resolveAttributeValue(context, sandboxAttribute);
       const sandboxValueStatic = sandboxValue.toStatic("sandbox");
       if (!isSafeSandbox(sandboxValueStatic)) {
         context.report({

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getAttribute, resolveAttributeValue } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
@@ -71,28 +71,28 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (domElementType !== "a") return;
 
       // Get access to the component attributes
-      const getAttributes = ER.getAttribute(
+      const getAttributeEx = getAttribute(
         context,
         node.openingElement.attributes,
         context.sourceCode.getScope(node),
       );
 
       // Check if target="_blank" is present
-      const targetAttribute = getAttributes("target");
+      const targetAttribute = getAttributeEx("target");
       if (targetAttribute == null) return;
 
-      const targetAttributeValue = ER.resolveAttributeValue(context, targetAttribute).toStatic("target");
+      const targetAttributeValue = resolveAttributeValue(context, targetAttribute).toStatic("target");
       if (targetAttributeValue !== "_blank") return;
 
       // Check if href points to an external resource
-      const hrefAttribute = getAttributes("href");
+      const hrefAttribute = getAttributeEx("href");
       if (hrefAttribute == null) return;
 
-      const hrefAttributeValue = ER.resolveAttributeValue(context, hrefAttribute).toStatic("href");
+      const hrefAttributeValue = resolveAttributeValue(context, hrefAttribute).toStatic("href");
       if (!isExternalLinkLike(hrefAttributeValue)) return;
 
       // Check if rel attribute exists and is secure
-      const relAttribute = getAttributes("rel");
+      const relAttribute = getAttributeEx("rel");
 
       // No rel attribute case - suggest adding one
       if (relAttribute == null) {
@@ -113,7 +113,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       }
 
       // Check if existing rel attribute is secure
-      const relAttributeValue = ER.resolveAttributeValue(context, relAttribute).toStatic("rel");
+      const relAttributeValue = resolveAttributeValue(context, relAttribute).toStatic("rel");
       if (isSafeRel(relAttributeValue)) return;
 
       // Existing rel attribute is not secure - suggest replacing it

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { hasAttribute } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -67,8 +67,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       }
       const { attributes } = node.openingElement;
       const initialScope = context.sourceCode.getScope(node);
-      const hasAttribute = (name: string) => ER.hasAttribute(context, name, attributes, initialScope);
-      if (hasAttribute("children") || hasAttribute("dangerouslySetInnerHTML")) {
+      const hasAttributeEx = (name: string) => hasAttribute(context, name, attributes, initialScope);
+      if (hasAttributeEx("children") || hasAttributeEx("dangerouslySetInnerHTML")) {
         // e.g. <br children="Foo" />
         context.report({
           messageId: "noVoidElementsWithChildren",

--- a/packages/plugins/eslint-plugin-react-dom/src/utils/create-jsx-element-resolver.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/utils/create-jsx-element-resolver.ts
@@ -1,8 +1,7 @@
+import { getAttribute, getElementType, resolveAttributeValue } from "@eslint-react/core";
 import type { RuleContext } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/types";
-
-import * as ER from "@eslint-react/core";
 import { getSettingsFromContext } from "@eslint-react/shared";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /**
  * Creates a resolver for JSX elements that determines both the JSX element type
@@ -27,7 +26,7 @@ export function createJsxElementResolver(context: RuleContext) {
      */
     resolve(node: TSESTree.JSXElement) {
       // Get the element name/type (e.g., 'div', 'Button', etc.)
-      const elementName = ER.getElementType(context, node);
+      const elementName = getElementType(context, node);
 
       // Create the base result with element types
       const result = {
@@ -43,12 +42,12 @@ export function createJsxElementResolver(context: RuleContext) {
       }
 
       // Look for the polymorphic prop (e.g., 'as', 'component') in the element's attributes
-      const getAttribute = ER.getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
-      const polymorphicProp = getAttribute(polymorphicPropName);
+      const getAttributeEx = getAttribute(context, node.openingElement.attributes, context.sourceCode.getScope(node));
+      const polymorphicProp = getAttributeEx(polymorphicPropName);
 
       // If the polymorphic prop exists, try to determine its static value
       if (polymorphicProp != null) {
-        const polymorphicPropValue = ER.resolveAttributeValue(context, polymorphicProp);
+        const polymorphicPropValue = resolveAttributeValue(context, polymorphicProp);
         const staticValue = polymorphicPropValue.toStatic(polymorphicPropName);
 
         // If we have a string value, use it as the DOM element type

--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/utils/is-variable-declarator-from-hook-call.ts
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/utils/is-variable-declarator-from-hook-call.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isReactHookName } from "@eslint-react/core";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 
@@ -6,10 +6,10 @@ function isInitFromHookCall(init: TSESTree.Expression | null) {
   if (init?.type !== T.CallExpression) return false;
   switch (init.callee.type) {
     case T.Identifier:
-      return ER.isReactHookName(init.callee.name);
+      return isReactHookName(init.callee.name);
     case T.MemberExpression:
       return init.callee.property.type === T.Identifier
-        && ER.isReactHookName(init.callee.property.name);
+        && isReactHookName(init.callee.property.name);
     default:
       return false;
   }

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/component-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/component-name.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { useComponentCollector, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { unit } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { RE_CONSTANT_CASE, RE_PASCAL_CASE, toRegExp } from "@eslint-react/kit";
@@ -82,8 +82,8 @@ export default createRule<Options, MessageID>({
 export function create(context: RuleContext<MessageID, Options>): RuleListener {
   const options = normalizeOptions(context.options);
   const { rule } = options;
-  const collector = ER.useComponentCollector(context);
-  const collectorLegacy = ER.useComponentCollectorLegacy();
+  const collector = useComponentCollector(context);
+  const collectorLegacy = useComponentCollectorLegacy();
 
   return {
     ...collector.listeners,

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getInstanceId, isComponentName, isCreateContextCall } from "@eslint-react/core";
 import { identity } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -33,14 +33,14 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("createContext")) return {};
   return {
     CallExpression(node) {
-      if (!ER.isCreateContextCall(context, node)) return;
-      const id = ER.getInstanceId(node);
+      if (!isCreateContextCall(context, node)) return;
+      const id = getInstanceId(node);
       if (id == null) return;
       const name = match(id)
         .with({ type: T.Identifier, name: P.select() }, identity)
         .with({ type: T.MemberExpression, property: { name: P.select(P.string) } }, identity)
         .otherwise(() => null);
-      if (name != null && ER.isComponentName(name) && name.endsWith("Context")) return;
+      if (name != null && isComponentName(name) && name.endsWith("Context")) return;
       context.report({
         messageId: "invalidContextName",
         node: id,

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.ts
@@ -1,11 +1,11 @@
-import * as ER from "@eslint-react/core";
+import { getInstanceId, isUseStateCall } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import { snakeCase } from "string-ts";
-
 import { match } from "ts-pattern";
+
 import { createRule } from "../utils";
 
 export const RULE_NAME = "use-state";
@@ -37,7 +37,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node: TSESTree.CallExpression) {
-      if (!ER.isUseStateCall(node)) {
+      if (!isUseStateCall(node)) {
         return;
       }
       if (node.parent.type !== T.VariableDeclarator) {
@@ -47,7 +47,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         });
         return;
       }
-      const id = ER.getInstanceId(node);
+      const id = getInstanceId(node);
       if (id?.type !== T.ArrayPattern) {
         context.report({
           messageId: "invalidAssignment",

--- a/packages/plugins/eslint-plugin-react-web-api/src/types/EventListener/EventListenerEntry.ts
+++ b/packages/plugins/eslint-plugin-react-web-api/src/types/EventListener/EventListenerEntry.ts
@@ -1,4 +1,4 @@
-import type * as ER from "@eslint-react/core";
+import type { SemanticEntry } from "@eslint-react/core";
 import type { unit } from "@eslint-react/eff";
 import type { TSESTree } from "@typescript-eslint/types";
 
@@ -11,7 +11,7 @@ export type EventListenerEntry =
     capture: boolean | unit;
     listener: TSESTree.Node;
     signal: TSESTree.Node | unit;
-  } & ER.SemanticEntry
+  } & SemanticEntry
   | {
     kind: "removeEventListener";
     type: TSESTree.Node;
@@ -19,4 +19,4 @@ export type EventListenerEntry =
     callee: TSESTree.Node;
     capture: boolean | unit;
     listener: TSESTree.Node;
-  } & ER.SemanticEntry;
+  } & SemanticEntry;

--- a/packages/plugins/eslint-plugin-react-web-api/src/types/Observer/ObserverEntry.ts
+++ b/packages/plugins/eslint-plugin-react-web-api/src/types/Observer/ObserverEntry.ts
@@ -1,5 +1,5 @@
 /* eslint-disable perfectionist/sort-object-types */
-import type * as ER from "@eslint-react/core";
+import type { SemanticEntry } from "@eslint-react/core";
 import type { TSESTree } from "@typescript-eslint/types";
 
 import type { ObserverKind } from "./ObserverKind";
@@ -11,7 +11,7 @@ export type ObserverEntry =
     callee: TSESTree.Node;
     observer: TSESTree.Node;
     observerKind: ObserverKind;
-  } & ER.SemanticEntry
+  } & SemanticEntry
   | {
     kind: "observe";
     node: TSESTree.CallExpression;
@@ -19,7 +19,7 @@ export type ObserverEntry =
     callee: TSESTree.Node;
     observer: TSESTree.Node;
     observerKind: ObserverKind;
-  } & ER.SemanticEntry
+  } & SemanticEntry
   | {
     kind: "unobserve";
     node: TSESTree.CallExpression;
@@ -27,4 +27,4 @@ export type ObserverEntry =
     callee: TSESTree.Node;
     observer: TSESTree.Node;
     observerKind: ObserverKind;
-  } & ER.SemanticEntry;
+  } & SemanticEntry;

--- a/packages/plugins/eslint-plugin-react-web-api/src/types/Timer/TimerEntry.ts
+++ b/packages/plugins/eslint-plugin-react-web-api/src/types/Timer/TimerEntry.ts
@@ -1,9 +1,9 @@
-import type * as ER from "@eslint-react/core";
+import type { SemanticEntry } from "@eslint-react/core";
 import type { TSESTree } from "@typescript-eslint/types";
 
 import type { TimerKind } from "./TimerKind";
 
-export interface TimerEntry extends ER.SemanticEntry {
+export interface TimerEntry extends SemanticEntry {
   kind: TimerKind;
   node: TSESTree.CallExpression;
   callee: TSESTree.Node;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-undef.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-undef.ts
@@ -1,10 +1,10 @@
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
+import { findVariable } from "@eslint-react/var";
+import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
-
-import * as VAR from "@eslint-react/var";
-import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import { match } from "ts-pattern";
+
 import { createRule } from "../utils";
 
 export const RULE_NAME = "jsx-no-undef";
@@ -41,7 +41,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (name === "this") return;
       // Skip JsxIntrinsicElements
       if (/^[a-z]/u.test(name)) return;
-      if (VAR.findVariable(name, context.sourceCode.getScope(node)) == null) {
+      if (findVariable(name, context.sourceCode.getScope(node)) == null) {
         context.report({
           messageId: "jsxNoUndef",
           node,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-boolean.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-boolean.ts
@@ -1,13 +1,12 @@
+import { getAttributeName } from "@eslint-react/core";
 import type { unit } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature, RulePolicy } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
-import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
-
-import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
-
-import * as ER from "@eslint-react/core";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
+import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
+import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
+
 import { createRule } from "../utils";
 
 export const RULE_NAME = "jsx-shorthand-boolean";
@@ -56,7 +55,7 @@ export function create(context: RuleContext<MessageID, Options>): RuleListener {
   return {
     JSXAttribute(node: TSESTree.JSXAttribute) {
       const { value } = node;
-      const propName = ER.getAttributeName(context, node);
+      const propName = getAttributeName(context, node);
 
       switch (true) {
         case policy === 1

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-fragment.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-fragment.ts
@@ -1,12 +1,12 @@
+import { getJsxConfigFromAnnotation, getJsxConfigFromContext, isFragmentElement } from "@eslint-react/core";
 import type { unit } from "@eslint-react/eff";
+import { type RuleContext, type RuleFeature, type RulePolicy } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
-
-import * as ER from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, type RulePolicy } from "@eslint-react/kit";
 import { match } from "ts-pattern";
+
 import { createRule } from "../utils";
 
 export const RULE_NAME = "jsx-shorthand-fragment";
@@ -53,8 +53,8 @@ export default createRule<Options, MessageID>({
 export function create(context: RuleContext<MessageID, Options>): RuleListener {
   const policy = context.options[0] ?? defaultOptions[0];
   const jsxConfig = {
-    ...ER.getJsxConfigFromContext(context),
-    ...ER.getJsxConfigFromAnnotation(context),
+    ...getJsxConfigFromContext(context),
+    ...getJsxConfigFromAnnotation(context),
   };
 
   const { jsxFragmentFactory } = jsxConfig;
@@ -62,7 +62,7 @@ export function create(context: RuleContext<MessageID, Options>): RuleListener {
   return match<number, RuleListener>(policy)
     .with(1, () => ({
       JSXElement(node: TSESTree.JSXElement) {
-        if (!ER.isFragmentElement(context, node)) return;
+        if (!isFragmentElement(context, node)) return;
         const hasAttributes = node.openingElement.attributes.length > 0;
         if (hasAttributes) return;
         context.report({
@@ -92,12 +92,18 @@ export function create(context: RuleContext<MessageID, Options>): RuleListener {
             const { closingFragment, openingFragment } = node;
             return [
               fixer.replaceTextRange(
-                [openingFragment.range[0], openingFragment.range[1]],
-                "<" + jsxFragmentFactory + ">",
+                [
+                  openingFragment.range[0],
+                  openingFragment.range[1],
+                ],
+                `<${jsxFragmentFactory}>`,
               ),
               fixer.replaceTextRange(
-                [closingFragment.range[0], closingFragment.range[1]],
-                "</" + jsxFragmentFactory + ">",
+                [
+                  closingFragment.range[0],
+                  closingFragment.range[1],
+                ],
+                `</${jsxFragmentFactory}>`,
               ),
             ];
           },

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.ts
@@ -1,11 +1,10 @@
-import * as ER from "@eslint-react/core";
+import { JsxEmit, getJsxConfigFromAnnotation, getJsxConfigFromContext } from "@eslint-react/core";
 import { type RuleContext, type RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
-import { createRule } from "../utils";
 
-const JsxEmit = ER.JsxEmit;
+import { createRule } from "../utils";
 
 export const RULE_NAME = "jsx-uses-react";
 
@@ -32,8 +31,8 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   const jsxConfig = {
-    ...ER.getJsxConfigFromContext(context),
-    ...ER.getJsxConfigFromAnnotation(context),
+    ...getJsxConfigFromContext(context),
+    ...getJsxConfigFromAnnotation(context),
   };
 
   const { jsx, jsxFactory, jsxFragmentFactory } = jsxConfig;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isClassComponent, isThisSetState } from "@eslint-react/core";
 import { constFalse, constTrue } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -66,25 +66,25 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   ][] = [];
   return {
     CallExpression(node) {
-      if (!ER.isThisSetState(node)) {
+      if (!isThisSetState(node)) {
         return;
       }
       setStateEntries.push([node, false]);
     },
     "CallExpression:exit"(node) {
-      if (!ER.isThisSetState(node)) {
+      if (!isThisSetState(node)) {
         return;
       }
       setStateEntries.pop();
     },
     ClassDeclaration(node) {
-      classEntries.push([node, ER.isClassComponent(node)]);
+      classEntries.push([node, isClassComponent(node)]);
     },
     "ClassDeclaration:exit"() {
       classEntries.pop();
     },
     ClassExpression(node) {
-      classEntries.push([node, ER.isClassComponent(node)]);
+      classEntries.push([node, isClassComponent(node)]);
     },
     "ClassExpression:exit"() {
       classEntries.pop();

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isCloneElementCall, isCreateElementCall, isInitializedFromReact } from "@eslint-react/core";
 import { unit } from "@eslint-react/eff";
 import { type RuleContext, type RuleFeature, report } from "@eslint-react/kit";
 import { coerceSettings } from "@eslint-react/shared";
@@ -37,7 +37,7 @@ function isUsingReactChildren(context: RuleContext, node: TSESTree.CallExpressio
     return true;
   }
   if (callee.object.type === T.MemberExpression && "name" in callee.object.object) {
-    return ER.isInitializedFromReact(callee.object.object.name, importSource, initialScope);
+    return isInitializedFromReact(callee.object.object.name, importSource, initialScope);
   }
   return false;
 }
@@ -117,7 +117,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   }
 
   function isCreateOrCloneElementCall(node: TSESTree.Node): node is TSESTree.CallExpression {
-    return ER.isCreateElementCall(context, node) || ER.isCloneElementCall(context, node);
+    return isCreateElementCall(context, node) || isCloneElementCall(context, node);
   }
 
   function getReportDescriptors(node: TSESTree.Node): ReportDescriptor<MessageID>[] {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-count.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-count.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isChildrenCount } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
-      if (ER.isChildrenCount(context, node)) {
+      if (isChildrenCount(context, node)) {
         context.report({
           messageId: "noChildrenCount",
           node: node.property,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-for-each.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-for-each.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isChildrenForEach } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
-      if (ER.isChildrenForEach(context, node)) {
+      if (isChildrenForEach(context, node)) {
         context.report({
           messageId: "noChildrenForEach",
           node: node.property,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-map.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-map.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isChildrenMap } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
-      if (ER.isChildrenMap(context, node)) {
+      if (isChildrenMap(context, node)) {
         context.report({
           messageId: "noChildrenMap",
           node: node.property,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-only.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-only.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isChildrenOnly } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
-      if (ER.isChildrenOnly(context, node)) {
+      if (isChildrenOnly(context, node)) {
         context.report({
           messageId: "noChildrenOnly",
           node: node.property,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-prop.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-prop.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { getAttribute } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,12 +31,12 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXElement(node) {
-      const getAttribute = ER.getAttribute(
+      const getAttributeEx = getAttribute(
         context,
         node.openingElement.attributes,
         context.sourceCode.getScope(node),
       );
-      const childrenProp = getAttribute("children");
+      const childrenProp = getAttributeEx("children");
       if (childrenProp != null) {
         context.report({
           messageId: "noChildrenProp",

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-to-array.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-to-array.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isChildrenToArray } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
-      if (ER.isChildrenToArray(context, node)) {
+      if (isChildrenToArray(context, node)) {
         context.report({
           messageId: "noChildrenToArray",
           node: node.property,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-class-component.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-class-component.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isComponentDidCatch, isGetDerivedStateFromError, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -30,13 +30,13 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("Component")) return {};
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
   return {
     ...listeners,
     "Program:exit"(program) {
       const components = ctx.getAllComponents(program);
       for (const { name = "anonymous", node: component } of components.values()) {
-        if (component.body.body.some((m) => ER.isComponentDidCatch(m) || ER.isGetDerivedStateFromError(m))) {
+        if (component.body.body.some((m) => isComponentDidCatch(m) || isGetDerivedStateFromError(m))) {
           continue;
         }
         context.report({

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-clone-element.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-clone-element.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isCloneElementCall } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
-      if (ER.isCloneElementCall(context, node)) {
+      if (isCloneElementCall(context, node)) {
         context.report({
           messageId: "noCloneElement",
           node,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isComponentWillMount, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("componentWillMount")) return {};
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
 
   return {
     ...listeners,
@@ -42,7 +42,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       for (const { node: component } of components.values()) {
         const { body } = component.body;
         for (const member of body) {
-          if (ER.isComponentWillMount(member)) {
+          if (isComponentWillMount(member)) {
             context.report({
               messageId: "noComponentWillMount",
               node: member,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isComponentWillReceiveProps, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("componentWillReceiveProps")) return {};
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
   return {
     ...listeners,
     "Program:exit"(program) {
@@ -41,7 +41,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       for (const { node: component } of components.values()) {
         const { body } = component.body;
         for (const member of body) {
-          if (ER.isComponentWillReceiveProps(member)) {
+          if (isComponentWillReceiveProps(member)) {
             context.report({
               messageId: "noComponentWillReceiveProps",
               node: member,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-update.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isComponentWillUpdate, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("componentWillUpdate")) return {};
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
 
   return {
     ...listeners,
@@ -42,7 +42,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       for (const { node: component } of components.values()) {
         const { body } = component.body;
         for (const member of body) {
-          if (ER.isComponentWillUpdate(member)) {
+          if (isComponentWillUpdate(member)) {
             context.report({
               messageId: "noComponentWillUpdate",
               node: member,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider.ts
@@ -1,10 +1,9 @@
-import * as ER from "@eslint-react/core";
+import { getElementType, isComponentNameLoose } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
-import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
-import type { CamelCase } from "string-ts";
-
 import { getSettingsFromContext } from "@eslint-react/shared";
+import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import { compare } from "compare-versions";
+import type { CamelCase } from "string-ts";
 
 import { createRule } from "../utils";
 
@@ -40,7 +39,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (compare(version, "19.0.0", "<")) return {};
   return {
     JSXElement(node) {
-      const fullName = ER.getElementType(context, node);
+      const fullName = getElementType(context, node);
       const parts = fullName.split(".");
       const selfName = parts.pop();
       const contextFullName = parts.join(".");
@@ -51,7 +50,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         messageId: "noContextProvider",
         node,
         fix(fixer) {
-          if (!ER.isComponentNameLoose(contextSelfName)) return null;
+          if (!isComponentNameLoose(contextSelfName)) return null;
           const openingElement = node.openingElement;
           const closingElement = node.closingElement;
           if (closingElement == null) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-create-ref.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-create-ref.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isClassComponent, isCreateRefCall } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -32,7 +32,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
-      if (ER.isCreateRefCall(context, node) && AST.findParentNode(node, ER.isClassComponent) == null) {
+      if (isCreateRefCall(context, node) && AST.findParentNode(node, isClassComponent) == null) {
         context.report({ messageId: "noCreateRef", node });
       }
     },

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-default-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-default-props.ts
@@ -1,7 +1,7 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isComponentNameLoose } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
-import * as VAR from "@eslint-react/var";
+import { findVariable, getVariableDefinitionNode } from "@eslint-react/var";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -45,11 +45,11 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (property.type !== T.Identifier || property.name !== "defaultProps") {
         return;
       }
-      if (!ER.isComponentNameLoose(object.name)) {
+      if (!isComponentNameLoose(object.name)) {
         return;
       }
-      const variable = VAR.findVariable(object.name, context.sourceCode.getScope(node));
-      const variableNode = VAR.getVariableDefinitionNode(variable, 0);
+      const variable = findVariable(object.name, context.sourceCode.getScope(node));
+      const variableNode = getVariableDefinitionNode(variable, 0);
       if (variableNode == null) return;
       if (!AST.isFunction(variableNode)) return;
       context.report({ messageId: "noDefaultProps", node: property });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isAssignmentToThisState, isClassComponent } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { TSESTree } from "@typescript-eslint/utils";
@@ -43,7 +43,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     AssignmentExpression(node: TSESTree.AssignmentExpression) {
-      if (!ER.isAssignmentToThisState(node)) return;
+      if (!isAssignmentToThisState(node)) return;
       const parentClass = AST.findParentNode(
         node,
         AST.isOneOf([
@@ -53,7 +53,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       );
       if (parentClass == null) return;
       if (
-        ER.isClassComponent(parentClass)
+        isClassComponent(parentClass)
         && context.sourceCode.getScope(node).block !== AST.findParentNode(node, isConstructorFunction)
       ) {
         context.report({

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isForwardRefCall, isInitializedFromReact } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import type { TSESTree } from "@typescript-eslint/types";
@@ -47,7 +47,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   }
   return {
     CallExpression(node) {
-      if (!ER.isForwardRefCall(context, node)) {
+      if (!isForwardRefCall(context, node)) {
         return;
       }
       const id = AST.getFunctionId(node);
@@ -74,10 +74,10 @@ function canFix(context: RuleContext, node: TSESTree.CallExpression) {
   const initialScope = context.sourceCode.getScope(node);
   switch (node.callee.type) {
     case T.Identifier:
-      return ER.isInitializedFromReact(node.callee.name, importSource, initialScope);
+      return isInitializedFromReact(node.callee.name, importSource, initialScope);
     case T.MemberExpression:
       return node.callee.object.type === T.Identifier
-        && ER.isInitializedFromReact(node.callee.object.name, importSource, initialScope);
+        && isInitializedFromReact(node.callee.object.name, importSource, initialScope);
     default:
       return false;
   }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.ts
@@ -1,11 +1,9 @@
+import { getAttribute } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
-
-import * as ER from "@eslint-react/core";
-
-import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 
 import { createRule } from "../utils";
 
@@ -39,7 +37,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXOpeningElement(node: TSESTree.JSXOpeningElement) {
       const initialScope = context.sourceCode.getScope(node);
-      const keyProp = ER.getAttribute(context, node.attributes, initialScope)("key");
+      const keyProp = getAttribute(context, node.attributes, initialScope)("key");
       const isKeyPropOnElement = node.attributes
         .some((n) =>
           n.type === T.JSXAttribute

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering.ts
@@ -2,7 +2,7 @@ import * as AST from "@eslint-react/ast";
 import { flow, unit } from "@eslint-react/eff";
 import { type RuleContext, type RuleFeature, report } from "@eslint-react/kit";
 import { getSettingsFromContext } from "@eslint-react/shared";
-import * as VAR from "@eslint-react/var";
+import { findVariable } from "@eslint-react/var";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -108,7 +108,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         return getReportDescriptor(consequent) ?? getReportDescriptor(alternate);
       })
       .with({ type: T.Identifier }, (n) => {
-        const variable = VAR.findVariable(n.name, context.sourceCode.getScope(n));
+        const variable = findVariable(n.name, context.sourceCode.getScope(n));
         const variableDefNode = variable?.defs.at(0)?.node;
         return match(variableDefNode)
           .with({ init: P.select({ type: P.not(T.VariableDeclaration) }) }, getReportDescriptor)

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { ComponentFlag, DEFAULT_COMPONENT_DETECTION_HINT, useComponentCollector } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -34,12 +34,12 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   const {
     ctx,
     listeners,
-  } = ER.useComponentCollector(
+  } = useComponentCollector(
     context,
     {
       collectDisplayName: true,
       collectHookCalls: false,
-      hint: ER.DEFAULT_COMPONENT_DETECTION_HINT,
+      hint: DEFAULT_COMPONENT_DETECTION_HINT,
     },
   );
   return {
@@ -47,7 +47,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     "Program:exit"(program) {
       const components = ctx.getAllComponents(program);
       for (const { node, displayName, flag } of components.values()) {
-        const isMemoOrForwardRef = (flag & (ER.ComponentFlag.ForwardRef | ER.ComponentFlag.Memo)) > 0n;
+        const isMemoOrForwardRef = (flag & (ComponentFlag.ForwardRef | ComponentFlag.Memo)) > 0n;
         if (AST.getFunctionId(node) != null) {
           continue;
         }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { getInstanceId, isCreateContextCall, isInstanceIdEqual } from "@eslint-react/core";
 import { type RuleContext, type RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -45,12 +45,12 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       displayNameAssignments.push(node);
     },
     CallExpression(node) {
-      if (!ER.isCreateContextCall(context, node)) return;
+      if (!isCreateContextCall(context, node)) return;
       createCalls.push(node);
     },
     "Program:exit"() {
       for (const call of createCalls) {
-        const id = ER.getInstanceId(call);
+        const id = getInstanceId(call);
         if (id == null) {
           context.report({
             messageId: "noMissingContextDisplayName",
@@ -63,7 +63,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
             const left = node.left;
             if (left.type !== T.MemberExpression) return false;
             const object = left.object;
-            return ER.isInstanceIdEqual(context, id, object);
+            return isInstanceIdEqual(context, id, object);
           });
         if (!hasDisplayNameAssignment) {
           context.report({

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-key.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-key.ts
@@ -1,12 +1,11 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
-import type { TSESTree } from "@typescript-eslint/types";
-import type { ReportDescriptor, RuleListener } from "@typescript-eslint/utils/ts-eslint";
-
+import { hasAttribute, isChildrenToArrayCall } from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, report } from "@eslint-react/kit";
-
+import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
+import type { ReportDescriptor, RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import { match } from "ts-pattern";
+
 import { createRule } from "../utils";
 
 export const RULE_NAME = "no-missing-key";
@@ -42,7 +41,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     switch (node.type) {
       case T.JSXElement: {
         const initialScope = context.sourceCode.getScope(node);
-        if (!ER.hasAttribute(context, "key", node.openingElement.attributes, initialScope)) {
+        if (!hasAttribute(context, "key", node.openingElement.attributes, initialScope)) {
           return {
             messageId: "missingKey",
             node,
@@ -102,7 +101,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       }
       const initialScope = context.sourceCode.getScope(node);
       for (const element of elements) {
-        if (!ER.hasAttribute(context, "key", element.openingElement.attributes, initialScope)) {
+        if (!hasAttribute(context, "key", element.openingElement.attributes, initialScope)) {
           context.report({
             messageId: "missingKey",
             node: element,
@@ -111,7 +110,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       }
     },
     CallExpression(node) {
-      state.isWithinChildrenToArray ||= ER.isChildrenToArrayCall(context, node);
+      state.isWithinChildrenToArray ||= isChildrenToArrayCall(context, node);
       if (state.isWithinChildrenToArray) return;
       const callback = match(node)
         .when(AST.isArrayMapCall, (n) => n.arguments[0])
@@ -127,7 +126,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       report(context)(checkExpression(body));
     },
     "CallExpression:exit"(node) {
-      if (!ER.isChildrenToArrayCall(context, node)) {
+      if (!isChildrenToArrayCall(context, node)) {
         return;
       }
       state.isWithinChildrenToArray = false;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isCaptureOwnerStackCall } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as T, type TSESTree } from "@typescript-eslint/types";
@@ -45,7 +45,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
 
   return {
     CallExpression(node) {
-      if (!ER.isCaptureOwnerStackCall(context, node)) return;
+      if (!isCaptureOwnerStackCall(context, node)) return;
       if (AST.findParentNode(node, isDevelopmentOnlyCheck) == null) {
         context.report({
           messageId: "missingDevelopmentOnlyCheck",

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.ts
@@ -1,11 +1,21 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import {
+  ComponentDetectionHint,
+  findParentAttribute,
+  isClassComponent,
+  isCreateElementCall,
+  isDeclaredInRenderPropLoose,
+  isDirectValueOfRenderPropertyLoose,
+  isRenderMethodLike,
+  useComponentCollector,
+  useComponentCollectorLegacy,
+} from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
 
-import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import { createRule } from "../utils";
 
 export const RULE_NAME = "no-nested-component-definitions";
@@ -33,17 +43,17 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
-  const hint = ER.ComponentDetectionHint.SkipArrayMapArgument
-    | ER.ComponentDetectionHint.SkipNullLiteral
-    | ER.ComponentDetectionHint.SkipUndefined
-    | ER.ComponentDetectionHint.SkipBooleanLiteral
-    | ER.ComponentDetectionHint.SkipStringLiteral
-    | ER.ComponentDetectionHint.SkipNumberLiteral
-    | ER.ComponentDetectionHint.StrictLogical
-    | ER.ComponentDetectionHint.StrictConditional;
+  const hint = ComponentDetectionHint.SkipArrayMapArgument
+    | ComponentDetectionHint.SkipNullLiteral
+    | ComponentDetectionHint.SkipUndefined
+    | ComponentDetectionHint.SkipBooleanLiteral
+    | ComponentDetectionHint.SkipStringLiteral
+    | ComponentDetectionHint.SkipNumberLiteral
+    | ComponentDetectionHint.StrictLogical
+    | ComponentDetectionHint.StrictConditional;
 
-  const collector = ER.useComponentCollector(context, { hint });
-  const collectorLegacy = ER.useComponentCollectorLegacy();
+  const collector = useComponentCollector(context, { hint });
+  const collectorLegacy = useComponentCollectorLegacy();
 
   return {
     ...collector.listeners,
@@ -73,9 +83,9 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         // Do not mark anonymous function components to reduce false positives
         if (name == null) continue;
         // Do not mark objects containing render methods
-        if (ER.isDirectValueOfRenderPropertyLoose(component)) continue;
+        if (isDirectValueOfRenderPropertyLoose(component)) continue;
         if (isInsideJSXAttributeValue(component)) {
-          if (!ER.isDeclaredInRenderPropLoose(component)) {
+          if (!isDeclaredInRenderPropLoose(component)) {
             context.report({
               messageId: "noNestedComponentDefinitions",
               node: component,
@@ -101,7 +111,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           continue;
         }
         const parentComponent = AST.findParentNode(component, isFunctionComponent);
-        if (parentComponent != null && !ER.isDirectValueOfRenderPropertyLoose(parentComponent)) {
+        if (parentComponent != null && !isDirectValueOfRenderPropertyLoose(parentComponent)) {
           context.report({
             messageId: "noNestedComponentDefinitions",
             node: component,
@@ -152,7 +162,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
  */
 function isInsideJSXAttributeValue(node: AST.TSESTreeFunction) {
   return node.parent.type === T.JSXAttribute
-    || ER.findParentAttribute(node, (n) => n.value?.type === T.JSXExpressionContainer) != null;
+    || findParentAttribute(node, (n) => n.value?.type === T.JSXExpressionContainer) != null;
 }
 
 /**
@@ -171,7 +181,7 @@ function isInsideJSXAttributeValue(node: AST.TSESTreeFunction) {
  * @returns `true` if node is inside class component's render block, `false` if not
  */
 function isInsideRenderMethod(node: TSESTree.Node) {
-  return AST.findParentNode(node, (n) => ER.isRenderMethodLike(n) && ER.isClassComponent(n.parent.parent)) != null;
+  return AST.findParentNode(node, (n) => isRenderMethodLike(n) && isClassComponent(n.parent.parent)) != null;
 }
 
 /**
@@ -181,7 +191,7 @@ function isInsideRenderMethod(node: TSESTree.Node) {
  * @returns `true` if the node is inside createElement's props
  */
 function isInsideCreateElementProps(context: RuleContext, node: TSESTree.Node) {
-  const call = AST.findParentNode(node, ER.isCreateElementCall(context));
+  const call = AST.findParentNode(node, isCreateElementCall(context));
   if (call == null) return false;
   const prop = AST.findParentNode(node, AST.is(T.ObjectExpression));
   if (prop == null) return false;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-prop-types.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-prop-types.ts
@@ -1,7 +1,7 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isClassComponent, isComponentNameLoose } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
-import * as VAR from "@eslint-react/var";
+import { findVariable, getVariableDefinitionNode } from "@eslint-react/var";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -48,17 +48,17 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (property.type !== T.Identifier || property.name !== "propTypes") {
         return;
       }
-      if (!ER.isComponentNameLoose(object.name)) {
+      if (!isComponentNameLoose(object.name)) {
         return;
       }
-      const variable = VAR.findVariable(object.name, context.sourceCode.getScope(node));
-      const variableNode = VAR.getVariableDefinitionNode(variable, 0);
-      if (variableNode != null && (AST.isFunction(variableNode) || ER.isClassComponent(variableNode))) {
+      const variable = findVariable(object.name, context.sourceCode.getScope(node));
+      const variableNode = getVariableDefinitionNode(variable, 0);
+      if (variableNode != null && (AST.isFunction(variableNode) || isClassComponent(variableNode))) {
         context.report({ messageId: "noPropTypes", node: property });
       }
     },
     PropertyDefinition(node) {
-      if (!ER.isClassComponent(node.parent.parent)) {
+      if (!isClassComponent(node.parent.parent)) {
         return;
       }
       if (!node.static || node.key.type !== T.Identifier || node.key.name !== "propTypes") {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { ComponentFlag, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { TSESTree } from "@typescript-eslint/utils";
@@ -40,7 +40,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("shouldComponentUpdate")) return {};
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
 
   return {
     ...listeners,
@@ -48,7 +48,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const components = ctx.getAllComponents(program);
 
       for (const { name = "PureComponent", node: component, flag } of components.values()) {
-        if ((flag & ER.ComponentFlag.PureComponent) === 0n) {
+        if ((flag & ComponentFlag.PureComponent) === 0n) {
           continue;
         }
         const { body } = component.body;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isClassComponent, isComponentDidMount, isThisSetState } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
@@ -35,11 +35,11 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("componentDidMount")) return {};
   return {
     CallExpression(node: TSESTree.CallExpression) {
-      if (!ER.isThisSetState(node)) {
+      if (!isThisSetState(node)) {
         return;
       }
-      const clazz = AST.findParentNode(node, ER.isClassComponent);
-      const method = AST.findParentNode(node, (n) => n === clazz || ER.isComponentDidMount(n));
+      const clazz = AST.findParentNode(node, isClassComponent);
+      const method = AST.findParentNode(node, (n) => n === clazz || isComponentDidMount(n));
       if (clazz == null || method == null || method === clazz) return;
       const methodScope = context.sourceCode.getScope(method);
       const upperScope = context.sourceCode.getScope(node).upper;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isClassComponent, isComponentDidUpdate, isThisSetState } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
@@ -35,11 +35,11 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("componentDidUpdate")) return {};
   return {
     CallExpression(node: TSESTree.CallExpression) {
-      if (!ER.isThisSetState(node)) {
+      if (!isThisSetState(node)) {
         return;
       }
-      const clazz = AST.findParentNode(node, ER.isClassComponent);
-      const method = AST.findParentNode(node, (n) => n === clazz || ER.isComponentDidUpdate(n));
+      const clazz = AST.findParentNode(node, isClassComponent);
+      const method = AST.findParentNode(node, (n) => n === clazz || isComponentDidUpdate(n));
       if (clazz == null || method == null || method === clazz) return;
       const methodScope = context.sourceCode.getScope(method);
       const upperScope = context.sourceCode.getScope(node).upper;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isClassComponent, isComponentWillUpdate, isThisSetState } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
@@ -36,11 +36,11 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("componentWillUpdate")) return {};
   return {
     CallExpression(node: TSESTree.CallExpression) {
-      if (!ER.isThisSetState(node)) {
+      if (!isThisSetState(node)) {
         return;
       }
-      const clazz = AST.findParentNode(node, ER.isClassComponent);
-      const method = AST.findParentNode(node, (n) => n === clazz || ER.isComponentWillUpdate(n));
+      const clazz = AST.findParentNode(node, isClassComponent);
+      const method = AST.findParentNode(node, (n) => n === clazz || isComponentWillUpdate(n));
       if (clazz == null || method == null || method === clazz) return;
       const methodScope = context.sourceCode.getScope(method);
       const upperScope = context.sourceCode.getScope(node).upper;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-string-refs.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-string-refs.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isClassComponent } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -39,7 +39,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   };
 
   function onClassBodyEnter(node: TSESTree.ClassBody) {
-    if (ER.isClassComponent(node.parent)) {
+    if (isClassComponent(node.parent)) {
       state.isWithinClassComponent = true;
     }
   }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.ts
@@ -1,8 +1,8 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isUseMemoCall } from "@eslint-react/core";
 import { identity } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
-import * as VAR from "@eslint-react/var";
+import { findVariable, getChildScopes, getVariableDefinitionNode } from "@eslint-react/var";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -40,7 +40,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
       const initialScope = context.sourceCode.getScope(node);
-      if (!ER.isUseMemoCall(node)) {
+      if (!isUseMemoCall(node)) {
         return;
       }
       const scope = context.sourceCode.getScope(node);
@@ -62,8 +62,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const hasEmptyDeps = match(arg1)
         .with({ type: T.ArrayExpression }, (n) => n.elements.length === 0)
         .with({ type: T.Identifier }, (n) => {
-          const variable = VAR.findVariable(n.name, initialScope);
-          const variableNode = VAR.getVariableDefinitionNode(variable, 0);
+          const variable = findVariable(n.name, initialScope);
+          const variableNode = getVariableDefinitionNode(variable, 0);
           if (variableNode?.type !== T.ArrayExpression) {
             return false;
           }
@@ -83,8 +83,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         })
         .with({ type: T.FunctionExpression }, identity)
         .with({ type: T.Identifier }, (n) => {
-          const variable = VAR.findVariable(n.name, initialScope);
-          const variableNode = VAR.getVariableDefinitionNode(variable, 0);
+          const variable = findVariable(n.name, initialScope);
+          const variableNode = getVariableDefinitionNode(variable, 0);
           if (variableNode?.type !== T.ArrowFunctionExpression && variableNode?.type !== T.FunctionExpression) {
             return null;
           }
@@ -94,7 +94,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (arg0Node == null) return;
 
       const arg0NodeScope = context.sourceCode.getScope(arg0Node);
-      const arg0NodeReferences = VAR.getChildScopes(arg0NodeScope).flatMap((x) => x.references);
+      const arg0NodeReferences = getChildScopes(arg0NodeScope).flatMap((x) => x.references);
       const isReferencedToComponentScope = arg0NodeReferences.some((x) => x.resolved?.scope.block === component);
 
       if (!isReferencedToComponentScope) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { useHookCollector } from "@eslint-react/core";
 import { type RuleContext, type RuleFeature } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
@@ -42,7 +42,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
-  const { ctx, listeners } = ER.useHookCollector();
+  const { ctx, listeners } = useHookCollector();
   return {
     ...listeners,
     "Program:exit"(program) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isUnsafeComponentWillMount, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -30,7 +30,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("UNSAFE_componentWillMount")) return {};
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
 
   return {
     ...listeners,
@@ -41,7 +41,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         const { body } = component.body;
 
         for (const member of body) {
-          if (ER.isUnsafeComponentWillMount(member)) {
+          if (isUnsafeComponentWillMount(member)) {
             context.report({
               messageId: "noUnsafeComponentWillMount",
               node: member,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isUnsafeComponentWillReceiveProps, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -32,7 +32,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("UNSAFE_componentWillReceiveProps")) {
     return {};
   }
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
 
   return {
     ...listeners,
@@ -43,7 +43,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         const { body } = component.body;
 
         for (const member of body) {
-          if (ER.isUnsafeComponentWillReceiveProps(member)) {
+          if (isUnsafeComponentWillReceiveProps(member)) {
             context.report({
               messageId: "noUnsafeComponentWillReceiveProps",
               node: member,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isUnsafeComponentWillUpdate, useComponentCollectorLegacy } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -30,7 +30,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("UNSAFE_componentWillUpdate")) return {};
-  const { ctx, listeners } = ER.useComponentCollectorLegacy();
+  const { ctx, listeners } = useComponentCollectorLegacy();
 
   return {
     ...listeners,
@@ -41,7 +41,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         const { body } = component.body;
 
         for (const member of body) {
-          if (ER.isUnsafeComponentWillUpdate(member)) {
+          if (isUnsafeComponentWillUpdate(member)) {
             context.report({
               messageId: "noUnsafeComponentWillUpdate",
               node: member,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.ts
@@ -1,8 +1,8 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isReactHookCall, useComponentCollector } from "@eslint-react/core";
 import { getOrElseUpdate } from "@eslint-react/eff";
 import { type RuleContext, type RuleFeature } from "@eslint-react/kit";
-import * as VAR from "@eslint-react/var";
+import { ConstructionDetectionHint, getConstruction } from "@eslint-react/var";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -35,7 +35,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
-  const { ctx, listeners } = ER.useComponentCollector(context);
+  const { ctx, listeners } = useComponentCollector(context);
   const declarators = new WeakMap<AST.TSESTreeFunction, AST.ObjectDestructuringVariableDeclarator[]>();
 
   return {
@@ -72,15 +72,15 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           const { value } = prop;
           const { right } = value;
           const initialScope = context.sourceCode.getScope(value);
-          const construction = VAR.getConstruction(
+          const construction = getConstruction(
             value,
             initialScope,
-            VAR.ConstructionDetectionHint.StrictCallExpression,
+            ConstructionDetectionHint.StrictCallExpression,
           );
           if (construction == null) {
             continue;
           }
-          if (ER.isReactHookCall(construction.node)) {
+          if (isReactHookCall(construction.node)) {
             continue;
           }
           const forbiddenType = AST.toDelimiterFormat(right);

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isClassComponent } from "@eslint-react/core";
 import { constFalse, constTrue } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
@@ -77,7 +77,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   const propertyUsages = new WeakMap<AST.TSESTreeClass, Set<string>>();
   function classEnter(node: AST.TSESTreeClass) {
     classEntries.push(node);
-    if (!ER.isClassComponent(node)) {
+    if (!isClassComponent(node)) {
       return;
     }
     propertyDefs.set(node, new Set());
@@ -85,7 +85,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   }
   function classExit() {
     const currentClass = classEntries.pop();
-    if (currentClass == null || !ER.isClassComponent(currentClass)) {
+    if (currentClass == null || !isClassComponent(currentClass)) {
       return;
     }
     const className = AST.getClassId(currentClass)?.name;
@@ -116,7 +116,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   function methodEnter(node: AST.TSESTreeMethodOrProperty) {
     methodEntries.push(node);
     const currentClass = classEntries.at(-1);
-    if (currentClass == null || !ER.isClassComponent(currentClass)) {
+    if (currentClass == null || !isClassComponent(currentClass)) {
       return;
     }
     if (node.static) {
@@ -141,7 +141,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (currentClass == null || currentMethod == null) {
         return;
       }
-      if (!ER.isClassComponent(currentClass) || currentMethod.static) {
+      if (!isClassComponent(currentClass) || currentMethod.static) {
         return;
       }
       if (!AST.isThisExpression(node.object) || !isKeyLiteral(node, node.property)) {
@@ -168,7 +168,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (currentClass == null || currentMethod == null) {
         return;
       }
-      if (!ER.isClassComponent(currentClass) || currentMethod.static) {
+      if (!isClassComponent(currentClass) || currentMethod.static) {
         return;
       }
       // detect `{ foo, bar: baz } = this`

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-props.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { useComponentCollector } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { Reference } from "@typescript-eslint/scope-manager";
 import type { TSESTree } from "@typescript-eslint/types";
@@ -35,7 +35,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   const services = ESLintUtils.getParserServices(context, false);
-  const { ctx, listeners } = ER.useComponentCollector(context);
+  const { ctx, listeners } = useComponentCollector(context);
 
   return {
     ...listeners,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isAssignmentToThisState, isClassComponent, isGetDerivedStateFromProps } from "@eslint-react/core";
 import type { unit } from "@eslint-react/eff";
 import { constFalse, constTrue } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
@@ -59,7 +59,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   }
   function classExit() {
     const currentClass = classEntries.pop();
-    if (currentClass == null || !ER.isClassComponent(currentClass)) {
+    if (currentClass == null || !isClassComponent(currentClass)) {
       return;
     }
     const className = AST.getClassId(currentClass)?.name;
@@ -78,11 +78,11 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   function methodEnter(node: AST.TSESTreeMethodOrProperty) {
     methodEntries.push(node);
     const currentClass = classEntries.at(-1);
-    if (currentClass == null || !ER.isClassComponent(currentClass)) {
+    if (currentClass == null || !isClassComponent(currentClass)) {
       return;
     }
     if (node.static) {
-      if (ER.isGetDerivedStateFromProps(node) && isMatching({ params: [P.nonNullable, ...P.array()] })(node.value)) {
+      if (isGetDerivedStateFromProps(node) && isMatching({ params: [P.nonNullable, ...P.array()] })(node.value)) {
         const defNode = stateDefs.get(currentClass)?.node;
         stateDefs.set(currentClass, { node: defNode, isUsed: true });
       }
@@ -104,11 +104,11 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
 
   return {
     AssignmentExpression(node) {
-      if (!ER.isAssignmentToThisState(node)) {
+      if (!isAssignmentToThisState(node)) {
         return;
       }
       const currentClass = classEntries.at(-1);
-      if (currentClass == null || !ER.isClassComponent(currentClass)) {
+      if (currentClass == null || !isClassComponent(currentClass)) {
         return;
       }
       const currentConstructor = constructorEntries.at(-1);
@@ -131,7 +131,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         return;
       }
       const currentClass = classEntries.at(-1);
-      if (currentClass == null || !ER.isClassComponent(currentClass)) {
+      if (currentClass == null || !isClassComponent(currentClass)) {
         return;
       }
       const currentMethod = methodEntries.at(-1);
@@ -155,7 +155,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     "PropertyDefinition:exit": methodExit,
     VariableDeclarator(node) {
       const currentClass = classEntries.at(-1);
-      if (currentClass == null || !ER.isClassComponent(currentClass)) {
+      if (currentClass == null || !isClassComponent(currentClass)) {
         return;
       }
       const currentMethod = methodEntries.at(-1);

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { isReactHookCall, isUseContextCall } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import type { TSESTree } from "@typescript-eslint/types";
@@ -45,7 +45,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hookCalls = new Set<TSESTree.CallExpression>();
   return {
     CallExpression(node) {
-      if (!ER.isReactHookCall(node)) {
+      if (!isReactHookCall(node)) {
         return;
       }
       hookCalls.add(node);
@@ -85,7 +85,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     },
     "Program:exit"() {
       for (const node of hookCalls) {
-        if (!ER.isUseContextCall(node)) {
+        if (!isUseContextCall(node)) {
           continue;
         }
         context.report({

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-forward-ref.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-forward-ref.ts
@@ -1,6 +1,6 @@
 // Ported from https://github.com/jsx-eslint/eslint-plugin-react/pull/3667
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isForwardRefCall } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
-      if (!ER.isForwardRefCall(context, node)) {
+      if (!isForwardRefCall(context, node)) {
         return;
       }
       const [component] = node.arguments;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-destructuring-assignment.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-destructuring-assignment.ts
@@ -1,5 +1,5 @@
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isComponentNameLoose, useComponentCollector } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { Scope } from "@typescript-eslint/scope-manager";
 import type { TSESTree } from "@typescript-eslint/types";
@@ -39,7 +39,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
-  const { ctx, listeners } = ER.useComponentCollector(context);
+  const { ctx, listeners } = useComponentCollector(context);
   const memberExpressionWithNames: [Scope, MemberExpressionWithObjectName][] = [];
 
   return {
@@ -64,7 +64,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         }
         const id = AST.getFunctionId(block);
         return id != null
-          && ER.isComponentNameLoose(id.name)
+          && isComponentNameLoose(id.name)
           && components.some((component) => component.node === block);
       }
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-read-only-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-read-only-props.ts
@@ -1,4 +1,4 @@
-import * as ER from "@eslint-react/core";
+import { useComponentCollector } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import { getConstrainedTypeAtLocation, isTypeReadonly } from "@typescript-eslint/type-utils";
 import { ESLintUtils, type ParserServicesWithTypeInformation } from "@typescript-eslint/utils";
@@ -37,7 +37,7 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   const services = ESLintUtils.getParserServices(context, false);
-  const { ctx, listeners } = ER.useComponentCollector(context);
+  const { ctx, listeners } = useComponentCollector(context);
   return {
     ...listeners,
     "Program:exit"(program) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-use-state-lazy-initialization.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-use-state-lazy-initialization.ts
@@ -1,6 +1,6 @@
 // Ported from https://github.com/jsx-eslint/eslint-plugin-react/pull/3579/commits/ebb739a0fe99a2ee77055870bfda9f67a2691374
 import * as AST from "@eslint-react/ast";
-import * as ER from "@eslint-react/core";
+import { isReactHookName, isUseCall, isUseStateCall } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/kit";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
@@ -44,7 +44,7 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
-      if (!ER.isUseStateCall(node)) {
+      if (!isUseStateCall(node)) {
         return;
       }
       const [useStateInput] = node.arguments;
@@ -54,7 +54,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       for (const expr of AST.getNestedNewExpressions(useStateInput)) {
         if (!("name" in expr.callee)) continue;
         if (ALLOW_LIST.includes(expr.callee.name)) continue;
-        if (AST.findParentNode(expr, ER.isUseCall) != null) continue;
+        if (AST.findParentNode(expr, isUseCall) != null) continue;
         context.report({
           messageId: "preferUseStateLazyInitialization",
           node: expr,
@@ -62,9 +62,9 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       }
       for (const expr of AST.getNestedCallExpressions(useStateInput)) {
         if (!("name" in expr.callee)) continue;
-        if (ER.isReactHookName(expr.callee.name)) continue;
+        if (isReactHookName(expr.callee.name)) continue;
         if (ALLOW_LIST.includes(expr.callee.name)) continue;
-        if (AST.findParentNode(expr, ER.isUseCall) != null) continue;
+        if (AST.findParentNode(expr, isUseCall) != null) continue;
         context.report({
           messageId: "preferUseStateLazyInitialization",
           node: expr,


### PR DESCRIPTION
This commit replaces `import * as X` statements with direct imports from their respective modules.

The changes primarily affect imports from @eslint-react/core and @eslint-react/var packages, replacing star imports with named imports of just the functions and types being used.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [x] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
