### PR TITLE
Fix `dom/prefer-namespace-import` missing in `react-dom` plugin

### DIFF
--- a/packages/plugins/eslint-plugin-react-dom/src/plugin.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/plugin.ts
@@ -19,6 +19,7 @@ import noUnsafeIframeSandbox from "./rules/no-unsafe-iframe-sandbox";
 import noUnsafeTargetBlank from "./rules/no-unsafe-target-blank";
 import noUseFormState from "./rules/no-use-form-state";
 import noVoidElementsWithChildren from "./rules/no-void-elements-with-children";
+import preferNamespaceImport from "./rules/prefer-namespace-import";
 
 export const plugin: CompatiblePlugin = {
   meta: {
@@ -43,5 +44,6 @@ export const plugin: CompatiblePlugin = {
     "no-unsafe-target-blank": noUnsafeTargetBlank,
     "no-use-form-state": noUseFormState,
     "no-void-elements-with-children": noVoidElementsWithChildren,
+    "prefer-namespace-import": preferNamespaceImport,
   },
 };


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
