### PR TITLE
Move error marker from `dangerouslySetInnerHTML` to children in `dom/no-dangerously-set-innerhtml-with-children` rule

### DIFF
--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.ts
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.ts
@@ -37,7 +37,7 @@ const DSIH = "dangerouslySetInnerHTML";
  * @param node The JSX child node to check.
  * @returns `true` if the node is significant, `false` otherwise.
  */
-function isSignificantChildren(node: TSESTree.JSXElement["children"][number]): boolean {
+function isSignificantChildren(node: TSESTree.JSXElement["children"][number]) {
   if (!isJsxText(node)) {
     return true;
   }
@@ -46,26 +46,6 @@ function isSignificantChildren(node: TSESTree.JSXElement["children"][number]): b
   const isFormattingWhitespace = node.raw.trim() === "" && node.raw.includes("\n");
 
   return !isFormattingWhitespace;
-}
-
-/**
- * Checks if a JSX element has children, either through the `children` prop or as JSX children.
- * @param context The rule context.
- * @param node The JSX element to check.
- * @returns `true` if the element has children, `false` otherwise.
- */
-function hasChildren(context: RuleContext, node: TSESTree.JSXElement): boolean {
-  const findJsxAttribute = getJsxAttribute(
-    context,
-    node.openingElement.attributes,
-    context.sourceCode.getScope(node),
-  );
-
-  if (findJsxAttribute("children") != null) {
-    return true;
-  }
-
-  return node.children.some(isSignificantChildren);
 }
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
@@ -81,18 +61,13 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         node.openingElement.attributes,
         context.sourceCode.getScope(node),
       );
-
-      const DSIHAttr = findJsxAttribute(DSIH);
-      if (DSIHAttr == null) {
-        return;
-      }
-
-      if (hasChildren(context, node)) {
-        context.report({
-          messageId: "noDangerouslySetInnerhtmlWithChildren",
-          node: DSIHAttr,
-        });
-      }
+      if (findJsxAttribute(DSIH) == null) return;
+      const children = findJsxAttribute("children") ?? node.children.find(isSignificantChildren);
+      if (children == null) return;
+      context.report({
+        messageId: "noDangerouslySetInnerhtmlWithChildren",
+        node: children,
+      });
     },
   };
 }


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
