### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-forbidden-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-forbidden-props.ts
@@ -41,6 +41,7 @@ export default createRule<Options, MessageID>({
     },
     schema: [{
       type: "object",
+      additionalProperties: false,
       properties: {
         forbid: {
           type: "array",


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

[no-forbidden-props](https://github.com/Rel1cx/eslint-react/blob/62590fd7579e1c3d63ddbcc56caf9a8fabcde681/packages/plugins/eslint-plugin-react-x/src/rules/no-forbidden-props.ts#L43) rule currently allows extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in this rule's schema.
