### PR TITLE
Simplify preset lists in React ESLint plugins

### DIFF
--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.mdx
@@ -16,14 +16,7 @@ react-dom/no-dangerously-set-innerhtml-with-children
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow `dangerouslySetInnerHTML` and `children` at the same time.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.mdx
@@ -16,14 +16,7 @@ react-dom/no-dangerously-set-innerhtml
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow `dangerouslySetInnerHTML`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node.mdx
@@ -16,14 +16,7 @@ react-dom/no-find-dom-node
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow `findDOMNode`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync.mdx
@@ -16,14 +16,7 @@ react-dom/no-flush-sync
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow `flushSync`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-hydrate.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-hydrate.mdx
@@ -20,14 +20,7 @@ react-dom/no-hydrate
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Replaces usages of `ReactDom.hydrate()` with `hydrateRoot()`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type.mdx
@@ -20,11 +20,7 @@ react-dom/no-missing-button-type
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`dom`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces explicit `type` attribute for `button` elements.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox.mdx
@@ -20,11 +20,7 @@ react-dom/no-missing-iframe-sandbox
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`dom`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces explicit `sandbox` attribute for `iframe` elements.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-namespace.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-namespace.mdx
@@ -16,14 +16,7 @@ react-dom/no-namespace
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces the absence of a `namespace` in React elements.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value.mdx
@@ -16,14 +16,7 @@ react-dom/no-render-return-value
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow the return value of `ReactDOM.render`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-render.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-render.mdx
@@ -20,14 +20,7 @@ react-dom/no-render
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Replaces usages of `ReactDom.render()` with `createRoot(node).render()`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-script-url.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-script-url.mdx
@@ -16,14 +16,7 @@ react-dom/no-script-url
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow `javascript:` URLs as attribute values.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop.mdx
@@ -16,10 +16,7 @@ react-dom/no-string-style-prop
 
 **Presets**
 
-- `dom`
-- `strict`
-- `recommended`
-
+`dom`, `recommended`, `strict`
 ## Description
 
 Disallow the use of string style prop in JSX. Use an object instead.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox.mdx
@@ -16,11 +16,7 @@ react-dom/no-unsafe-iframe-sandbox
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`dom`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces `sandbox` attribute for `iframe` elements is not set to unsafe combinations.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.mdx
@@ -20,11 +20,7 @@ react-dom/no-unsafe-target-blank
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`dom`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Prevents the use of `target="_blank"` without `rel="noreferrer noopener"`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state.mdx
@@ -20,14 +20,7 @@ react-dom/no-use-form-state
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Replaces usages of `useFormState` with `useActionState`.

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.mdx
@@ -16,14 +16,7 @@ react-dom/no-void-elements-with-children
 
 **Presets**
 
-- `dom`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`dom`, `recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow `children` in void DOM elements.

--- a/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-effect.mdx
+++ b/packages/plugins/eslint-plugin-react-hooks-extra/src/rules/no-direct-set-state-in-use-effect.mdx
@@ -20,13 +20,7 @@ react-hooks-extra/no-direct-set-state-in-use-effect
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow **direct** calls to the [`set` function](https://react.dev/reference/react/useState#setstate) of `useState` in `useEffect`.

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.mdx
@@ -16,13 +16,7 @@ react-naming-convention/context-name
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces context name to be a valid component name with the suffix `Context`.

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.mdx
@@ -16,13 +16,7 @@ react-naming-convention/use-state
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces destructuring and symmetric naming of `useState` hook value and setter.

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener.mdx
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener.mdx
@@ -16,14 +16,7 @@ react-web-api/no-leaked-event-listener
 
 **Presets**
 
-- `web-api`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `web-api`
 ## Description
 
 Enforces that every `addEventListener` in a component or custom Hook has a corresponding `removeEventListener`.

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval.mdx
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval.mdx
@@ -16,14 +16,7 @@ react-web-api/no-leaked-interval
 
 **Presets**
 
-- `web-api`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `web-api`
 ## Description
 
 Enforces that every `setInterval` in a component or custom Hook has a corresponding `clearInterval`.

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer.mdx
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer.mdx
@@ -16,14 +16,7 @@ react-web-api/no-leaked-resize-observer
 
 **Presets**
 
-- `web-api`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `web-api`
 ## Description
 
 Enforces that every `ResizeObserver` created in a component or custom Hook has a corresponding `ResizeObserver.disconnect()`.

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout.mdx
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout.mdx
@@ -16,14 +16,7 @@ react-web-api/no-leaked-timeout
 
 **Presets**
 
-- `web-api`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `web-api`
 ## Description
 
 Enforces that every `setTimeout` in a component or custom Hook has a corresponding `clearTimeout`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.mdx
@@ -16,14 +16,7 @@ react-x/jsx-key-before-spread
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Enforces that the 'key' prop is placed before the spread prop in JSX elements.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-comment-textnodes.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-comment-textnodes.mdx
@@ -16,14 +16,7 @@ react-x/jsx-no-comment-textnodes
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Prevents comment strings (e.g. beginning with `//` or `/*`) from being accidentally inserted into the JSX element's textnodes.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.mdx
@@ -16,10 +16,7 @@ react-x/jsx-no-duplicate-props
 
 **Presets**
 
-- `x`
-- `strict`
-- `recommended`
-
+`recommended`, `strict`, `x`
 ## Description
 
 Disallow duplicate props in JSX elements.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-iife.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-iife.mdx
@@ -22,10 +22,7 @@ react-x/jsx-no-iife
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallows `IIFE` in JSX elements.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.mdx
@@ -16,9 +16,7 @@ react-x/jsx-uses-react
 
 **Presets**
 
-- `x`
-- `recommended`
-
+`recommended`, `x`
 ## Description
 
 Marks React variables as used when JSX is used.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.mdx
@@ -16,10 +16,7 @@ react-x/jsx-uses-vars
 
 **Presets**
 
-- `x`
-- `strict`
-- `recommended`
-
+`recommended`, `strict`, `x`
 ## Description
 
 Marks variables used in JSX elements as used.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate.mdx
@@ -16,14 +16,7 @@ react-x/no-access-state-in-setstate
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow accessing `this.state` inside `setState` calls.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key.mdx
@@ -16,14 +16,7 @@ react-x/no-array-index-key
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow an item's index in the array as its key.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-count.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-count.mdx
@@ -16,14 +16,7 @@ react-x/no-children-count
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow the use of `Children.count` from the `react` package.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-for-each.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-for-each.mdx
@@ -16,14 +16,7 @@ react-x/no-children-for-each
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow the use of `Children.forEach` from the `react` package.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-map.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-map.mdx
@@ -16,14 +16,7 @@ react-x/no-children-map
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow the use of `Children.map` from the `react` package.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-only.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-only.mdx
@@ -16,14 +16,7 @@ react-x/no-children-only
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow the use of `Children.only` from the `react` package.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-prop.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-prop.mdx
@@ -16,10 +16,7 @@ react-x/no-children-prop
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow passing `children` as a prop.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-children-to-array.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-children-to-array.mdx
@@ -16,14 +16,7 @@ react-x/no-children-to-array
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow the use of `Children.toArray` from the `react` package.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-class-component.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-class-component.mdx
@@ -16,10 +16,7 @@ react-x/no-class-component
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow class components except for error boundaries.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-clone-element.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-clone-element.mdx
@@ -16,14 +16,7 @@ react-x/no-clone-element
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow `cloneElement`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount.mdx
@@ -20,14 +20,7 @@ react-x/no-component-will-mount
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Replaces usages of `componentWillMount` with `UNSAFE_componentWillMount`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props.mdx
@@ -20,14 +20,7 @@ react-x/no-component-will-receive-props
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Replaces usages of `componentWillReceiveProps` with `UNSAFE_componentWillReceiveProps`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-component-will-update.mdx
@@ -20,14 +20,7 @@ react-x/no-component-will-update
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Replaces usages of `componentWillUpdate` with `UNSAFE_componentWillUpdate`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider.mdx
@@ -20,14 +20,7 @@ react-x/no-context-provider
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Replaces usages of `<Context.Provider>` with `<Context>`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-create-ref.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-create-ref.mdx
@@ -16,14 +16,7 @@ react-x/no-create-ref
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow `createRef` in function components.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-default-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-default-props.mdx
@@ -16,14 +16,7 @@ react-x/no-default-props
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow `defaultProps` property in favor of ES6 default parameters.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state.mdx
@@ -16,14 +16,7 @@ react-x/no-direct-mutation-state
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow direct mutation of `this.state`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key.mdx
@@ -16,14 +16,7 @@ react-x/no-duplicate-key
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow duplicate `key` on elements in the same array or a list of `children`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref.mdx
@@ -20,14 +20,7 @@ react-x/no-forward-ref
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Replaces usages of `forwardRef` with passing `ref` as a prop.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.mdx
@@ -22,14 +22,7 @@ react-x/no-implicit-key
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Prevents `key` from not being explicitly specified (e.g. spreading `key` from objects).

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering.mdx
@@ -20,9 +20,7 @@ react-x/no-leaked-conditional-rendering
 
 **Presets**
 
-- `strict-type-checked`
-- `recommended-type-checked`
-
+`recommended-type-checked`, `strict-type-checked`
 ## Description
 
 Prevents problematic leaked values from being rendered.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-key.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-key.mdx
@@ -16,14 +16,7 @@ react-x/no-missing-key
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow missing `key` on items in list rendering.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack.mdx
@@ -22,10 +22,7 @@ react-x/no-misused-capture-owner-stack
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Prevents incorrect usage of `captureOwnerStack`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.mdx
@@ -16,14 +16,7 @@ react-x/no-nested-component-definitions
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallows defining React components inside other components.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations.mdx
@@ -16,14 +16,7 @@ react-x/no-nested-lazy-component-declarations
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallows defining React components inside other components.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-prop-types.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-prop-types.mdx
@@ -16,14 +16,7 @@ react-x/no-prop-types
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow `propTypes` in favor of TypeScript or another type-checking solution.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update.mdx
@@ -16,14 +16,7 @@ react-x/no-redundant-should-component-update
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow `shouldComponentUpdate` when extending `React.PureComponent`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.mdx
@@ -16,14 +16,7 @@ react-x/no-set-state-in-component-did-mount
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow calling `this.setState` in `componentDidMount` outside of functions, such as callbacks.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.mdx
@@ -16,14 +16,7 @@ react-x/no-set-state-in-component-did-update
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow calling `this.setState` in `componentDidUpdate` outside of functions, such as callbacks.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.mdx
@@ -16,14 +16,7 @@ react-x/no-set-state-in-component-will-update
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow calling `this.setState` in `componentWillUpdate` outside of functions, such as callbacks.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-string-refs.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-string-refs.mdx
@@ -20,14 +20,7 @@ react-x/no-string-refs
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Replaces string refs with callback refs.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-key.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-key.mdx
@@ -20,10 +20,7 @@ react-x/no-unnecessary-key
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 This rule prevents `key` from being placed on non-top-level elements in a list rendering.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-callback.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-callback.mdx
@@ -20,10 +20,7 @@ react-x/no-unnecessary-use-callback
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow unnecessary usage of `useCallback`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.mdx
@@ -20,10 +20,7 @@ react-x/no-unnecessary-use-memo
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow unnecessary usage of `useMemo`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix.mdx
@@ -20,13 +20,7 @@ react-x/no-unnecessary-use-prefix
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces that a function with the 'use' prefix should use at least one Hook inside of it.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.mdx
@@ -16,14 +16,7 @@ react-x/no-unsafe-component-will-mount
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Warns the usage of `UNSAFE_componentWillMount` in class components.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.mdx
@@ -16,14 +16,7 @@ react-x/no-unsafe-component-will-receive-props
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Warns the usage of `UNSAFE_componentWillReceiveProps` in class components.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.mdx
@@ -16,14 +16,7 @@ react-x/no-unsafe-component-will-update
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Warns the usage of `UNSAFE_componentWillUpdate` in class components.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.mdx
@@ -16,10 +16,7 @@ react-x/no-unstable-context-value
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Prevents non-stable values (i.e. object literals) from being used as a value for `Context.Provider`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.mdx
@@ -16,10 +16,7 @@ react-x/no-unstable-default-props
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Prevents using referential-type values as default props in object destructuring.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.mdx
@@ -16,10 +16,7 @@ react-x/no-unused-class-component-members
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Warns unused class component methods and properties.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-props.mdx
@@ -20,8 +20,7 @@ react-x/no-unused-props
 
 **Presets**
 
-- `strict-type-checked`
-
+`strict-type-checked`
 ## Description
 
 Warns component props that are defined but never used.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.mdx
@@ -16,10 +16,7 @@ react-x/no-unused-state
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Warns unused class component state.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context.mdx
@@ -20,14 +20,7 @@ react-x/no-use-context
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Replaces usages of `useContext` with `use`.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-forward-ref.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-forward-ref.mdx
@@ -16,14 +16,7 @@ react-x/no-useless-forward-ref
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Disallow useless `forwardRef` calls on components that don't use `ref`s.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-fragment.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-fragment.mdx
@@ -20,10 +20,7 @@ react-x/no-useless-fragment
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Disallow useless fragment elements.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-destructuring-assignment.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-destructuring-assignment.mdx
@@ -16,10 +16,7 @@ react-x/prefer-destructuring-assignment
 
 **Presets**
 
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-
+`strict` / `strict-type-checked` / `strict-typescript`
 ## Description
 
 Enforces destructuring assignment for component props and context.

--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-use-state-lazy-initialization.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-use-state-lazy-initialization.mdx
@@ -16,14 +16,7 @@ react-x/prefer-use-state-lazy-initialization
 
 **Presets**
 
-- `x`
-- `strict`
-- `strict-typescript`
-- `strict-type-checked`
-- `recommended`
-- `recommended-typescript`
-- `recommended-type-checked`
-
+`recommended` / `recommended-type-checked` / `recommended-typescript`, `strict` / `strict-type-checked` / `strict-typescript`, `x`
 ## Description
 
 Enforces function calls made inside `useState` to be wrapped in an `initializer function`.


### PR DESCRIPTION
The commit concisely describes the content changes - converting bulleted lists of presets into a more compact inline format, while preserving all the information.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [x] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
