### PR TITLE
fix: Re-add missing rule '@eslint-react/jsx-key-before-spread', closes #1290

### DIFF
--- a/packages/plugins/eslint-plugin/src/configs/x.ts
+++ b/packages/plugins/eslint-plugin/src/configs/x.ts
@@ -5,6 +5,7 @@ import react from "eslint-plugin-react-x";
 export const name = "@eslint-react/x";
 
 export const rules = {
+  "@eslint-react/jsx-key-before-spread": "warn",
   "@eslint-react/jsx-no-comment-textnodes": "warn",
   "@eslint-react/jsx-no-duplicate-props": "warn",
   "@eslint-react/jsx-uses-react": "warn",


### PR DESCRIPTION
Bugfix to fix the missing rule described in issue https://github.com/Rel1cx/eslint-react/issues/1290

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
