### PR TITLE
Fix readonly type detection for class and interface extends, closes #1326

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-read-only-props.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-read-only-props.spec.ts
@@ -727,5 +727,32 @@ ruleTesterWithTypes.run(RULE_NAME, rule, {
             }
           }
     `,
+    tsx`
+      type DeepReadOnly<T> = {
+        readonly [P in keyof T]: T[P] extends (infer U)[]
+          ? ReadonlyArray<DeepReadOnly<U>>
+          : T[P] extends ReadonlyArray<infer U>
+            ? ReadonlyArray<DeepReadOnly<U>>
+            : T[P] extends object
+              ? DeepReadOnly<T[P]>
+              : T[P];
+      };
+
+      interface PressableProps {
+        testID: string;
+      }
+
+      type ReadonlyPressableProps = DeepReadOnly<PressableProps>;
+
+      interface ComponentProps extends ReadonlyPressableProps {
+        readonly name: string;
+      }
+
+      export function Component(props: ComponentProps) {
+        const { name, testID } = props;
+
+        return <div data-testid={testID}>{name}</div>
+      }
+    `,
   ],
 });


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
