### PR TITLE
Partially revert #1343, keeping the behavior where `enforceSetterExistence` is set to `false`, closes #1342

### DIFF
--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.mdx
@@ -74,15 +74,6 @@ function MyComponent() {
 }
 ```
 
-## Rule Options
-
-This rule accepts an optional configuration object with the following properties:
-
-- `enforceSetterExistence` (boolean, default: `false`): If set to `true`, the rule will enforce that a setter function is always present when destructuring the result of `useState`.
-  ```tsx
-  const [value] = useState(0); // Error: Setter function is missing.
-  ```
-
 ## Implementation
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.ts)

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.spec.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.spec.ts
@@ -16,7 +16,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{
         messageId: "invalidAssignment",
       }],
-      options: [{ enforceSetterExistence: false }],
     },
     {
       code: tsx`
@@ -29,7 +28,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{
         messageId: "invalidAssignment",
       }],
-      options: [{ enforceSetterExistence: false }],
     },
     {
       code: tsx`
@@ -54,19 +52,6 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{
         messageId: "invalidSetterName",
       }],
-    },
-    {
-      code: tsx`
-        function Component() {
-          const [state] = useState(0);
-
-          return <div />;
-        }
-      `,
-      errors: [{
-        messageId: "invalidAssignment",
-      }],
-      options: [{ enforceSetterExistence: true }],
     },
     {
       code: tsx`

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-state.ts
@@ -1,9 +1,7 @@
 import { getInstanceId, isUseStateCall } from "@eslint-react/core";
-import type { unit } from "@eslint-react/eff";
 import type { RuleContext, RuleFeature } from "@eslint-react/shared";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
-import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import { snakeCase } from "string-ts";
 import { match } from "ts-pattern";
@@ -18,28 +16,7 @@ export type MessageID =
   | "invalidAssignment"
   | "invalidSetterName";
 
-type Options = readonly [
-  | unit
-  | {
-    enforceSetterExistence?: boolean;
-  },
-];
-
-const defaultOptions = [
-  {
-    enforceSetterExistence: false,
-  },
-] as const satisfies Options;
-
-const schema = [{
-  type: "object",
-  additionalProperties: false,
-  properties: {
-    enforceSetterExistence: { type: "boolean" },
-  },
-}] satisfies [JSONSchema4];
-
-export default createRule<Options, MessageID>({
+export default createRule<[], MessageID>({
   meta: {
     type: "problem",
     docs: {
@@ -52,16 +29,15 @@ export default createRule<Options, MessageID>({
       invalidSetterName:
         "The setter should be named 'set' followed by the capitalized state variable name, e.g., 'setState' for 'state'.",
     },
-    schema,
+    schema: [],
   },
   name: RULE_NAME,
   create,
-  defaultOptions,
+  defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, Options>): RuleListener {
-  const options = context.options[0] ?? defaultOptions[0];
-  const enforceSetterExistence = options.enforceSetterExistence ?? false;
+export function create(context: RuleContext<MessageID, []>): RuleListener {
+  const enforceSetterExistence = false;
   return {
     CallExpression(node: TSESTree.CallExpression) {
       if (!isUseStateCall(node)) {
@@ -91,6 +67,7 @@ export function create(context: RuleContext<MessageID, Options>): RuleListener {
         return;
       }
       if (setter == null) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (!enforceSetterExistence) return;
         context.report({
           messageId: "invalidAssignment",

--- a/packages/plugins/eslint-plugin/README.md
+++ b/packages/plugins/eslint-plugin/README.md
@@ -191,8 +191,8 @@ This project is and will continue to maintain that 90% of the code is written by
 
 Contributions are welcome!
 
-Please follow our [contributing guidelines](https://github.com/Rel1cx/eslint-react/tree/main/.github/CONTRIBUTING.md).
+Please follow our [contributing guidelines](https://github.com/Rel1cx/eslint-react/tree/naming-convention-use-state-2/.github/CONTRIBUTING.md).
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](https://github.com/Rel1cx/eslint-react/tree/main/LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](https://github.com/Rel1cx/eslint-react/tree/naming-convention-use-state-2/LICENSE) file for details.


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
