### PR TITLE
feat: add use-ref-name rule

### DIFF
--- a/apps/website/content/docs/rules/meta.json
+++ b/apps/website/content/docs/rules/meta.json
@@ -95,6 +95,7 @@
     "naming-convention-context-name",
     "naming-convention-filename",
     "naming-convention-filename-extension",
+    "naming-convention-use-ref-name",
     "naming-convention-use-state",
     "---Debug Rules---",
     "debug-class-component",

--- a/apps/website/content/docs/rules/overview.mdx
+++ b/apps/website/content/docs/rules/overview.mdx
@@ -140,6 +140,7 @@ full: true
 | [`context-name`](naming-convention-context-name)             | 1️⃣ 1️⃣ |      | Enforces the context name to be a valid component name with the suffix `Context`    |
 | [`filename`](naming-convention-filename)                     | 0️⃣ 0️⃣ | `⚙️` | Enforces consistent file naming conventions                                         |
 | [`filename-extension`](naming-convention-filename-extension) | 0️⃣ 0️⃣ | `⚙️` | Enforces consistent use of the JSX file extension                                   |
+| [`use-ref-name`](naming-convention-use-ref-name)             | 0️⃣ 0️⃣ |      | Enforces that variables assigned from useRef calls have names ending with `Ref`     |
 | [`use-state`](naming-convention-use-state)                   | 1️⃣ 1️⃣ | `⚙️` | Enforces destructuring and symmetric naming of the `useState` hook value and setter |
 
 ## Debug Rules

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/plugin.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/plugin.ts
@@ -7,6 +7,7 @@ import contextName from "./rules/context-name";
 import filename from "./rules/filename";
 import filenameExtension from "./rules/filename-extension";
 import useState from "./rules/use-state";
+import useRefName from "./rules/use-ref-name";
 
 export const plugin: CompatiblePlugin = {
   meta: {
@@ -18,6 +19,7 @@ export const plugin: CompatiblePlugin = {
     ["context-name"]: contextName,
     ["filename"]: filename,
     ["filename-extension"]: filenameExtension,
+    ["use-ref-name"]: useRefName,
     ["use-state"]: useState,
   },
 };

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.mdx
@@ -1,0 +1,54 @@
+---
+title: use-ref-name
+---
+
+**Full Name in `@eslint-react/eslint-plugin`**
+
+```plain copy
+@eslint-react/naming-convention/use-ref-name
+```
+
+**Full Name in `eslint-plugin-react-naming-convention`**
+
+```plain copy
+react-naming-convention/use-ref-name
+```
+
+## Description
+
+Enforces that variables assigned from useRef calls have names ending with `Ref`.
+
+## Examples
+
+### Failing
+
+```tsx
+const count = useRef(0);
+```
+
+```tsx
+const input = useRef<HTMLInputElement>(null);
+```
+
+```tsx
+const value = useRef(null);
+```
+
+### Passing
+
+```tsx
+const countRef = useRef(0);
+```
+
+```tsx
+const inputRef = useRef<HTMLInputElement>(null);
+```
+
+```tsx
+const valueRef = useRef(null);
+```
+
+## Implementation
+
+- [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.ts)
+- [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.spec.ts)

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.spec.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.spec.ts
@@ -1,0 +1,57 @@
+import tsx from "dedent";
+
+import { allFunctions, ruleTester } from "../../../../../test";
+import rule, { RULE_NAME } from "./use-ref-name";
+
+ruleTester.run(RULE_NAME, rule, {
+  invalid: [
+    {
+      code: tsx`
+        import { useRef } from "react";
+        const count = useRef(0);
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+    {
+      code: tsx`
+        import { useRef } from "react";
+        const input = useRef<HTMLInputElement>(null);
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+    {
+      code: tsx`
+        import React from "react";
+        const count = React.useRef(0);
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+    {
+      code: tsx`
+        import React from "react";
+        const input = React.useRef<HTMLInputElement>(null);
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+    {
+      code: tsx`
+        const value = useRef(null);
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+  ],
+  valid: [
+    ...allFunctions,
+    tsx`
+      import { useRef } from "react";
+      const countRef = useRef(0);
+    `,
+    tsx`
+      import React from "react";
+      const inputRef = React.useRef<HTMLInputElement>(null);
+    `,
+    tsx`
+      const valueRef = useRef(null);
+    `,
+  ],
+});

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/use-ref-name.ts
@@ -1,0 +1,53 @@
+import { getInstanceId, isUseRefCall } from "@eslint-react/core";
+import { identity } from "@eslint-react/eff";
+import type { RuleContext, RuleFeature } from "@eslint-react/shared";
+import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
+import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
+import { P, match } from "ts-pattern";
+import type { TSESTree } from "@typescript-eslint/types";
+import { createRule } from "../utils";
+
+export const RULE_NAME = "use-ref-name";
+
+export const RULE_FEATURES = [] as const satisfies RuleFeature[];
+
+export type MessageID = "invalidRefName";
+
+export default createRule<[], MessageID>({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforces that variables assigned from useRef calls have names ending with 'Ref'.",
+    },
+    messages: {
+      invalidRefName: "Ref variables should have names ending with 'Ref', e.g., 'inputRef'.",
+    },
+    schema: [],
+  },
+  name: RULE_NAME,
+  create,
+  defaultOptions: [],
+});
+
+export function create(context: RuleContext<MessageID, []>): RuleListener {
+  if (!context.sourceCode.text.includes("useRef")) return {};
+  return {
+    CallExpression(node: TSESTree.CallExpression) {
+      if (!isUseRefCall(node)) return;
+
+      const id = getInstanceId(node);
+      if (id == null) return;
+
+      const name = match(id)
+      .with({ type: T.Identifier, name: P.select() }, identity)
+      .otherwise(() => null);
+
+      if (name != null && name.endsWith("Ref")) return;
+
+      context.report({
+        messageId: "invalidRefName",
+        node: id,
+      });
+    },
+  };
+}

--- a/packages/plugins/eslint-plugin/src/configs/all.ts
+++ b/packages/plugins/eslint-plugin/src/configs/all.ts
@@ -102,6 +102,7 @@ export const rules = {
   "@eslint-react/naming-convention/context-name": "warn",
   "@eslint-react/naming-convention/filename": "off",
   "@eslint-react/naming-convention/filename-extension": "off",
+  "@eslint-react/naming-convention/use-ref-name": "off",
   "@eslint-react/naming-convention/use-state": "warn",
 } as const satisfies Record<string, RuleConfig>;
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [x] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Adds a new `naming-convention` rule `use-ref-name` to enforce that variables from `useRef` end with `Ref` for readability.