### PR TITLE
Allow "ref" as a ref name

### DIFF
--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.mdx
@@ -25,7 +25,7 @@ react-naming-convention/ref-name
 
 ## Description
 
-Enforces that variables assigned from `useRef` calls have names ending with `Ref`.
+Enforces variable names assigned from `useRef` calls to be either `ref` or end with `Ref`.
 
 ## Examples
 
@@ -44,6 +44,10 @@ const value = useRef(null);
 ```
 
 ### Passing
+
+```tsx
+const ref = useRef(0);
+```
 
 ```tsx
 const countRef = useRef(0);

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.spec.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.spec.ts
@@ -50,6 +50,10 @@ ruleTester.run(RULE_NAME, rule, {
     ...allFunctions,
     tsx`
       import { useRef } from "react";
+      const ref = useRef(0);
+    `,
+    tsx`
+      import { useRef } from "react";
       const countRef = useRef(0);
     `,
     tsx`

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.ts
@@ -44,7 +44,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         .with({ type: T.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
         .otherwise(() => [null, null] as const);
       if (id == null) return;
-      if (name.endsWith("Ref")) return;
+      if (name.endsWith("Ref") || name === 'ref') return;
       context.report({
         messageId: "invalidRefName",
         node: id,


### PR DESCRIPTION
The variable name `ref` in `const ref = useRef(null)` should be allowed, as it's commonly used, for example, in the [React's docs](https://github.com/reactjs/react.dev/blob/2da4f7fbd90ddc09835c9f85d61fd5644a271abc/src/content/learn/reusing-logic-with-custom-hooks.md?plain=1#L1545).

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
