### PR TITLE
Fix `jsx-key-before-spread` should only be enabled in JSX automatic runtime & Update related docs and tests, closes #1381

### DIFF
--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.ts
@@ -44,7 +44,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         .with({ type: T.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
         .otherwise(() => [null, null] as const);
       if (id == null) return;
-      if (name.endsWith("Ref") || name === 'ref') return;
+      if (name.endsWith("Ref") || name === "ref") return;
       context.report({
         messageId: "invalidRefName",
         node: id,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.mdx
@@ -26,7 +26,7 @@ react-x/jsx-key-before-spread
 
 ## Description
 
-Enforces that the 'key' prop is placed before the spread prop in JSX elements.
+Enforces that the 'key' prop is placed before the spread prop in JSX elements when using the new JSX transform (automatic runtime).
 
 When using the JSX automatic runtime, `key` is a special prop in the JSX transform. See the [Babel repl](https://babeljs.io/repl#?browsers=last%202%20chrome%20versions\&build=\&builtIns=false\&corejs=3.21\&spec=false\&loose=false\&code_lz=DwEwlgbgBA1gpgTwLwCICMKoG8B0eAOATgPb4DOAvlAPQB8A3AFCiTZ45GmWyKoBMmOkxbR4yFAGZMAYwA2AQzJkAcvIC2cVIIbNw0OYpXrNKTGNRSaDIA\&forceAllTransforms=false\&modules=false\&shippedProposals=false\&evaluate=true\&fileSize=false\&timeTravel=false\&sourceType=module\&lineWrap=true\&presets=react\&prettier=false\&targets=\&version=7.27.0\&externalPlugins=\&assumptions=%7B%7D) and [TypeScript playground](https://www.typescriptlang.org/play/?target=99\&jsx=4#code/DwEwlgbgBA1gpgTwLwCICMKoG8B0eAOATgPb4DOAvlAPQB8A3ALABQok2eORplsiqAJkx0mrcNHjIUAZkwBjADYBDMmQBySgLZxUwhizbRFK9Vp0pMk1ABY99IA).
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.spec.ts
@@ -1,6 +1,8 @@
+import { JsxEmit } from "@eslint-react/core";
+import { RuleTester } from "@typescript-eslint/rule-tester";
 import tsx from "dedent";
 
-import { allValid, ruleTester } from "../../../../../test";
+import { allValid, defaultLanguageOptionsWithTypes, getProjectForJsxEmit, ruleTester } from "../../../../../test";
 import rule, { RULE_NAME } from "./jsx-key-before-spread";
 
 ruleTester.run(RULE_NAME, rule, {
@@ -83,9 +85,88 @@ ruleTester.run(RULE_NAME, rule, {
       };
     `,
     tsx`
+      /** @jsxRuntime automatic */
+      const App = (props) => {
+          return [
+                  <div key="1" {...props}>1</div>,
+                  <div key="2" {...props}>2</div>,
+                  <div key="3" {...props}>3</div>,
+               ]
+      };
+    `,
+    tsx`
       const App = (props) => {
           return [1, 2, 3].map((item) => <div key={Math.random()}>{item}</div>)
       };
     `,
+    tsx`
+      /** @jsxRuntime classic */
+      const App = (props) => {
+          return [
+                  <div {...props} key="1">1</div>,
+                  <div {...props} key="1">2</div>,
+                  <div {...props} key="1">3</div>,
+               ]
+      };
+    `,
   ],
+});
+
+const ruleTesterWithJsxClassicRuntime = new RuleTester({
+  languageOptions: {
+    ...defaultLanguageOptionsWithTypes,
+    parserOptions: {
+      ...defaultLanguageOptionsWithTypes.parserOptions,
+      project: getProjectForJsxEmit(JsxEmit.React),
+      projectService: false,
+    },
+  },
+});
+
+ruleTesterWithJsxClassicRuntime.run(RULE_NAME, rule, {
+  invalid: [],
+  valid: [
+    tsx`
+      const App = (props) => {
+        return [
+          <div {...props} key="1">1</div>,
+          <div {...props} key="1">2</div>,
+          <div {...props} key="1">3</div>,
+        ]
+      };
+    `,
+  ],
+});
+
+const ruleTesterWithJsxAutomaticRuntime = new RuleTester({
+  languageOptions: {
+    ...defaultLanguageOptionsWithTypes,
+    parserOptions: {
+      ...defaultLanguageOptionsWithTypes.parserOptions,
+      project: getProjectForJsxEmit(JsxEmit.ReactJSX),
+      projectService: false,
+    },
+  },
+});
+
+ruleTesterWithJsxAutomaticRuntime.run(RULE_NAME, rule, {
+  invalid: [
+    {
+      code: tsx`
+        const App = (props) => {
+            return [
+                    <div {...props} key="1">1</div>,
+                    <div {...props} key="1">2</div>,
+                    <div {...props} key="1">3</div>,
+                 ]
+        };
+      `,
+      errors: [
+        { messageId: "jsxKeyBeforeSpread" },
+        { messageId: "jsxKeyBeforeSpread" },
+        { messageId: "jsxKeyBeforeSpread" },
+      ],
+    },
+  ],
+  valid: [],
 });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.ts
@@ -1,8 +1,9 @@
+import { JsxEmit, getJsxConfigFromAnnotation, getJsxConfigFromContext } from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/shared";
+import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import type { RuleListener } from "@typescript-eslint/utils/ts-eslint";
 import type { CamelCase } from "string-ts";
 
-import { AST_NODE_TYPES as T } from "@typescript-eslint/types";
 import { createRule } from "../utils";
 
 export const RULE_NAME = "jsx-key-before-spread";
@@ -17,10 +18,12 @@ export default createRule<[], MessageID>({
   meta: {
     type: "problem",
     docs: {
-      description: "Enforces that the 'key' prop is placed before the spread prop in JSX elements.",
+      description:
+        "Enforces that the 'key' prop is placed before the spread prop in JSX elements when using the new JSX transform (automatic runtime).",
     },
     messages: {
-      jsxKeyBeforeSpread: "The 'key' prop must be placed before any spread props.",
+      jsxKeyBeforeSpread:
+        "The 'key' prop must be placed before any spread props when using the new JSX transform (automatic runtime).",
     },
     schema: [],
   },
@@ -30,6 +33,14 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
+  const { jsx } = {
+    ...getJsxConfigFromContext(context),
+    ...getJsxConfigFromAnnotation(context),
+  };
+
+  // This rule is only applicable for the new JSX transform (automatic runtime)
+  if (jsx !== JsxEmit.ReactJSX && jsx !== JsxEmit.ReactJSXDev) return {};
+
   return {
     JSXOpeningElement(node) {
       let firstSpreadPropIndex: null | number = null;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.ts
@@ -36,7 +36,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
 
   const { jsx, jsxFactory, jsxFragmentFactory } = jsxConfig;
 
-  // If using the new JSX transform (React 17+), this rule is not needed
+  // If using the new JSX transform (automatic runtime), this rule is not needed
   if (jsx === JsxEmit.ReactJSX || jsx === JsxEmit.ReactJSXDev) return {};
 
   // Marks the JSX factory (e.g., 'React') as used when a JSX element is found


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [x] Docs
- [x] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
