### PR TITLE
Enhance `no-unnecessary-use-ref` to allow previous refs by convention, closes #1406

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-ref.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-ref.spec.ts
@@ -177,5 +177,29 @@ ruleTester.run(RULE_NAME, rule, {
         return <input ref={inputRef} />;
       }
     `,
+    tsx`
+      import { useEffect, useRef } from "react";
+
+      export function useBooleanTrigger(
+        value: boolean,
+        { turnedTrue, turnedFalse }: { turnedTrue?: () => void; turnedFalse?: () => void },
+      ) {
+        const previousValueRef = useRef(value);
+
+        useEffect(() => {
+          const { current: previousValue } = previousValueRef;
+
+          if (value !== previousValue) {
+            previousValueRef.current = value;
+
+            if (value) {
+              turnedTrue?.();
+            } else {
+              turnedFalse?.();
+            }
+          }
+        }, [turnedFalse, turnedTrue, value]);
+      }
+    `,
   ],
 });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-ref.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-ref.ts
@@ -41,6 +41,8 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const [ref, ...rest] = context.sourceCode.getDeclaredVariables(node);
       // Skip non-standard `useRef()` usages to prevent false positives
       if (ref == null || rest.length > 0) return;
+      // Skip `previous*` refs by convention https://github.com/Rel1cx/eslint-react/issues/1406
+      if (ref.name.toLowerCase().startsWith("prev")) return;
       const effects = new Set<TSESTree.Node>();
       let globalUsages = 0;
       for (const { identifier, init } of ref.references) {


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] Test
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
