### PR TITLE
Support detection of hook-using function components

### DIFF
--- a/packages/core/docs/@eslint-react/namespaces/useComponentCollector/type-aliases/Options.md
+++ b/packages/core/docs/@eslint-react/namespaces/useComponentCollector/type-aliases/Options.md
@@ -5,7 +5,6 @@
 ```ts
 type Options = {
   collectDisplayName?: boolean;
-  collectHookCalls?: boolean;
   hint?: ComponentDetectionHint;
 };
 ```
@@ -15,5 +14,4 @@ type Options = {
 | Property | Type |
 | ------ | ------ |
 | <a id="collectdisplayname"></a> `collectDisplayName?` | `boolean` |
-| <a id="collecthookcalls"></a> `collectHookCalls?` | `boolean` |
 | <a id="hint"></a> `hint?` | [`ComponentDetectionHint`](../../../../type-aliases/ComponentDetectionHint.md) |

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.spec.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.spec.ts
@@ -8,6 +8,25 @@ ruleTester.run(RULE_NAME, rule, {
   invalid: [
     {
       code: tsx`
+        function App() {
+            useEffect(() => {});
+        }
+      `,
+      errors: [{
+        messageId: "functionComponent",
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 1,
+            memo: false,
+          }),
+        },
+      }],
+    },
+    {
+      code: tsx`
         function App({ foo }) {
             return <div>foo</div>
         }

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.ts
@@ -35,7 +35,6 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     context,
     {
       collectDisplayName: true,
-      collectHookCalls: true,
       hint: DEFAULT_COMPONENT_DETECTION_HINT,
     },
   );

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.ts
@@ -34,7 +34,6 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
 
   const { ctx, visitor } = useComponentCollector(context, {
     collectDisplayName: true,
-    collectHookCalls: false,
     hint: DEFAULT_COMPONENT_DETECTION_HINT,
   });
 


### PR DESCRIPTION
- Function component detection now supports identifying components that don't return a ReactNode but call React Hooks

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
