### PR TITLE
Skip unstable value checks when `'use memo';` is present

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.spec.ts
@@ -187,6 +187,20 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     tsx`
         function App() {
+          "use memo";
+          const foo = {}
+          return <Context.Provider value={foo}></Context.Provider>;
+      }
+    `,
+    tsx`
+        "use memo";
+        function App() {
+          const foo = {}
+          return <Context.Provider value={foo}></Context.Provider>;
+      }
+    `,
+    tsx`
+        function App() {
           const foo = useMemo(() => [], [])
           return <Context.Provider value={foo}></Context.Provider>
       }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.spec.ts
@@ -219,6 +219,24 @@ ruleTester.run(RULE_NAME, rule, {
   ],
   valid: [
     ...allValid,
+    tsx`
+      "use memo";
+      const App = ({
+          a = {},
+          b = ['one', 'two'],
+          c = /regex/i,
+          d = () => {},
+          e = function() {},
+          f = class {},
+          g = new Thing(),
+          h = <Thing />,
+          i = Symbol('foo'),
+          j = unknownFunction(),
+          k = window.name
+      }) => {
+          return null
+      }
+    `,
     {
       code: tsx`
         function MyComponent({ position = new Vector3(0, 0, 0) }) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.ts
@@ -76,6 +76,9 @@ function extractIdentifier(node: TSESTree.Node): string | null {
 }
 
 export function create(context: RuleContext<MessageID, Options>, [options]: Options): RuleListener {
+  // If "use memo" directive is present in the file, skip analysis
+  if (AST.getProgramDirectives(context.sourceCode.ast).some((d) => d.value === "use memo")) return {};
+
   const { ctx, visitor } = useComponentCollector(context);
   const declarators = new WeakMap<AST.TSESTreeFunction, AST.ObjectDestructuringVariableDeclarator[]>();
   const { safeDefaultProps = [] } = options;

--- a/packages/utilities/ast/src/index.ts
+++ b/packages/utilities/ast/src/index.ts
@@ -13,6 +13,7 @@ export * from "./is";
 export * from "./literal";
 export * from "./misc";
 export * from "./process-env-node-env";
+export * from "./program-directives";
 export * from "./property-name";
 export * from "./selectors";
 export * from "./traverse";

--- a/packages/utilities/ast/src/program-directives.ts
+++ b/packages/utilities/ast/src/program-directives.ts
@@ -1,0 +1,20 @@
+import { AST_NODE_TYPES as T, type TSESTree } from "@typescript-eslint/types";
+
+import { getUnderlyingExpression } from "./expression-base";
+import { isLiteral } from "./literal";
+
+/**
+ * Get all directive string literals from a program node
+ * @param node The program AST node
+ * @returns The array of directive string literals (e.g., "use strict")
+ */
+export function getProgramDirectives(node: TSESTree.Program): TSESTree.StringLiteral[] {
+  const directives: TSESTree.StringLiteral[] = [];
+  for (const stmt of node.body) {
+    if (stmt.type !== T.ExpressionStatement) continue;
+    const expr = getUnderlyingExpression(stmt.expression);
+    if (!isLiteral(expr, "string")) continue;
+    directives.push(expr);
+  }
+  return directives;
+}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
