### PR TITLE
feat: add `getRefInit` function to retrieve ref initialization

### DIFF
--- a/packages/core/docs/README.md
+++ b/packages/core/docs/README.md
@@ -124,6 +124,7 @@
 | [getJsxConfigFromAnnotation](functions/getJsxConfigFromAnnotation.md) | Get JsxConfig from pragma comments (annotations) in the source code |
 | [getJsxConfigFromContext](functions/getJsxConfigFromContext.md) | Get JsxConfig from the rule context by reading compiler options |
 | [getJsxElementType](functions/getJsxElementType.md) | Extracts the element type name from a JSX element or fragment For JSX elements, returns the stringified name (e.g., "div", "Button", "React.Fragment") For JSX fragments, returns an empty string |
+| [getRefInit](functions/getRefInit.md) | Get the init expression of a ref variable |
 | [isClassComponent](functions/isClassComponent.md) | Check if a node is a React class component |
 | [isComponentDefinition](functions/isComponentDefinition.md) | Determine if a function node represents a valid React component definition |
 | [isComponentDidMountCallback](functions/isComponentDidMountCallback.md) | Check if the given node is a componentDidMount callback |

--- a/packages/core/docs/functions/getRefInit.md
+++ b/packages/core/docs/functions/getRefInit.md
@@ -1,0 +1,22 @@
+[@eslint-react/core](../README.md) / getRefInit
+
+# Function: getRefInit()
+
+```ts
+function getRefInit(name: string, initialScope: Scope): Expression | undefined;
+```
+
+Get the init expression of a ref variable
+
+## Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `name` | `string` | The variable name |
+| `initialScope` | `Scope` | The initial scope |
+
+## Returns
+
+`Expression` \| `undefined`
+
+The init expression node if the variable is derived from a ref, or null otherwise

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-ref.mdx
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-ref.mdx
@@ -19,23 +19,17 @@ Reports all identifiers initialized or derived from refs in JSON format. Useful 
 ## Examples
 
 ```tsx
-import { useRef, useEffect } from "react";
+import React from "react";
 
 function MyComponent() {
-  const myRef = useRef(null);
+  const myRef = React.useRef(42);
   //    ^^^^^
-  //    - This identifier is derived from a ref.
-  const anotherRef = myRef;
-  //    ^^^^^^^^^^
-  //    - This identifier is derived from a ref.
+  //    - {"name": "myRef", "init": "React.useRef(42)"}
+  const value = myRef.current;
+  //    ^^^^^
+  //    - {"name": "value", "init": "myRef.current"}
 
-  useEffect(() => {
-    const divElement = anotherRef.current;
-    //    ^^^^^^^^^^
-    //    - This identifier is derived from a ref.
-  }, []);
-
-  return <div ref={anotherRef}>Hello, world!</div>;
+  return null;
 }
 ```
 

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-ref.spec.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-ref.spec.ts
@@ -22,6 +22,7 @@ ruleTester.run(RULE_NAME, rule, {
           data: {
             json: stringify({
               name: "myRef",
+              init: "React.useRef(42)",
             }),
           },
         },
@@ -30,6 +31,7 @@ ruleTester.run(RULE_NAME, rule, {
           data: {
             json: stringify({
               name: "value",
+              init: "myRef.current",
             }),
           },
         },
@@ -38,6 +40,7 @@ ruleTester.run(RULE_NAME, rule, {
           data: {
             json: stringify({
               name: "myRef",
+              init: "React.useRef(42)",
             }),
           },
         },
@@ -46,6 +49,7 @@ ruleTester.run(RULE_NAME, rule, {
           data: {
             json: stringify({
               name: "current",
+              init: "React.useRef(42)",
             }),
           },
         },
@@ -54,6 +58,7 @@ ruleTester.run(RULE_NAME, rule, {
           data: {
             json: stringify({
               name: "value",
+              init: "myRef.current",
             }),
           },
         },


### PR DESCRIPTION
Extract `getRefInit` from `isInitializedFromRef` to return the init expression node instead of just a boolean. Update the debug rule to include initialization info in its output.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
