### PR TITLE
feat: resolve function identifiers through conditional expressions

### DIFF
--- a/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.spec.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/function-component.spec.ts
@@ -1734,6 +1734,39 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    {
+      code: tsx`
+        const Component = type === 'button'
+          ? () => <button>Click</button>
+          : () => <div>Text</div>;
+      `,
+      errors: [
+        {
+          messageId: "default",
+          data: {
+            json: stringify({
+              name: "Component",
+              displayName: "none",
+              forwardRef: false,
+              hookCalls: 0,
+              memo: false,
+            }),
+          },
+        },
+        {
+          messageId: "default",
+          data: {
+            json: stringify({
+              name: "Component",
+              displayName: "none",
+              forwardRef: false,
+              hookCalls: 0,
+              memo: false,
+            }),
+          },
+        },
+      ],
+    },
   ],
   valid: [
     ...allFunctions,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions.spec.ts
@@ -7,6 +7,56 @@ ruleTester.run(RULE_NAME, rule, {
   invalid: [
     {
       code: tsx`
+        // ❌ Component defined inside component
+        function Parent() {
+          const ChildComponent = () => { // New component every render!
+            const [count, setCount] = useState(0);
+            return <button onClick={() => setCount(count + 1)}>{count}</button>;
+          };
+
+          return <ChildComponent />; // State resets every render
+        }
+      `,
+      errors: [
+        {
+          messageId: "default",
+          data: {
+            name: "ChildComponent",
+            suggestion: "Move it to the top level.",
+          },
+        },
+      ],
+    },
+    {
+      code: tsx`
+        // ❌ Dynamic component creation
+        function Parent({type}) {
+          const Component = type === 'button'
+            ? () => <button>Click</button>
+            : () => <div>Text</div>;
+
+          return <Component />;
+        }
+      `,
+      errors: [
+        {
+          messageId: "default",
+          data: {
+            name: "Component",
+            suggestion: "Move it to the top level.",
+          },
+        },
+        {
+          messageId: "default",
+          data: {
+            name: "Component",
+            suggestion: "Move it to the top level.",
+          },
+        },
+      ],
+    },
+    {
+      code: tsx`
         function ParentComponent() {
           function UnstableNestedFunctionComponent() {
             return <div />;

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.ts
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
     type: "problem",
     docs: {
       description:
-        "Disallows unconditional calls to the ['set' function](https://react.dev/reference/react/useState#setstate) of 'useState' during render.",
+        "Validates against unconditionally setting state during render, which can trigger additional renders and potential infinite render loops.",
     },
     messages: {
       default:

--- a/packages/utilities/ast/src/function-id.test.ts
+++ b/packages/utilities/ast/src/function-id.test.ts
@@ -58,6 +58,9 @@ describe("get function identifier from function expression", () => {
     ["class Clazz { Foo() {} }", "Foo"],
     ["class Clazz { Foo = function() {} }", "Foo"],
     ["class Clazz { Foo = () => {} }", "Foo"],
+    ["const Foo = condition ? () => {} : () => {};", "Foo"],
+    ["const Foo = condition ? function() {} : function() {};", "Foo"],
+    ["const Foo = a ? b ? () => {} : () => {} : () => {};", "Foo"],
   ])("should return the function name from %s", (code, expected) => {
     let n: null | TSESTreeFunction = null;
     simpleTraverse(parse(code).ast, {

--- a/packages/utilities/ast/src/function-id.ts
+++ b/packages/utilities/ast/src/function-id.ts
@@ -47,6 +47,9 @@ export function getFunctionId(node: TSESTree.Expression | TSESTreeFunction) {
     case node.parent.type === AST.AssignmentPattern
       && node.parent.right === node:
       return node.parent.left;
+    // const MaybeComponent = condition ? () => {} : () => {};
+    case node.parent.type === AST.ConditionalExpression:
+      return getFunctionId(node.parent);
     // const MaybeComponent = (() => {})!;
     // const MaybeComponent = (() => {}) as FunctionComponent;
     // const MaybeComponent = (() => {}) satisfies FunctionComponent;


### PR DESCRIPTION
Add a new case to `getFunctionId` to recursively resolve identifiers when functions are defined inside ternary expressions (e.g., `const Component = condition ? () => <A/> : () => <B/>`).

This improves detection of React components created via conditional expressions in `function-component` and `no-nested-component-definitions` rules. Also refine the `set-state-in-render` rule description.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [x] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
