### PR TITLE
feat(set-state-in-render): detect `setState` calls in hook body

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.spec.ts
@@ -28,6 +28,25 @@ ruleTester.run(RULE_NAME, rule, {
       code: tsx`
         import { useState } from "react";
 
+        function useHook({ value }) {
+          const [count, setCount] = useState(0);
+          setCount(value);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          messageId: "default",
+          data: {
+            name: "setCount",
+          },
+        },
+      ],
+    },
+    {
+      code: tsx`
+        import { useState } from "react";
+
         function Component() {
           const [count, setCount] = useState(0);
           setCount(1);
@@ -242,6 +261,19 @@ ruleTester.run(RULE_NAME, rule, {
         function Component({ items }) {
           const sorted = [...items].sort();
           return <ul>{sorted.map(item => <li key={item}>{item}</li>)}</ul>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        import { useState } from "react";
+
+        function useHook() {
+          const [count, setCount] = useState(0);
+          const handleClick = () => {
+            setCount(c => c + 1);
+          };
+          return null;
         }
       `,
     },

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.ts
@@ -136,20 +136,20 @@ export function create(context: RuleContext<MessageID, []>) {
     return false;
   }
 
-  function isComponentLikeFunction(node: ast.TSESTreeFunction) {
+  function isComponentOrHookLikeFunction(node: ast.TSESTreeFunction) {
     const id = ast.getFunctionId(node);
     if (id == null) return false;
     if (id.type === AST.Identifier) {
-      return core.isComponentName(id.name);
+      return core.isComponentName(id.name) || core.isHookName(id.name);
     }
     if (id.type === AST.MemberExpression && id.property.type === AST.Identifier) {
-      return core.isComponentName(id.property.name);
+      return core.isComponentName(id.property.name) || core.isHookName(id.property.name);
     }
     return false;
   }
 
   function getFunctionKind(node: ast.TSESTreeFunction): FunctionKind {
-    if (isComponentLikeFunction(node)) {
+    if (isComponentOrHookLikeFunction(node)) {
       return "component";
     }
     const parent = ast.findParentNode(node, not(ast.isTypeExpression)) ?? node.parent;


### PR DESCRIPTION
- Rename isComponentLikeFunction to isComponentOrHookLikeFunction
- Add isHookName check to identify hook-like functions
- Add test cases for setState in custom hooks

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [x] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
