### PR TITLE
docs: unify and standardize Further Reading sections across rule docs

### DIFF
--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.mdx
@@ -61,6 +61,10 @@ function MyComponent() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children.spec.ts)
 
+## Further Reading
+
+- [React Docs: `dangerouslySetInnerHTML`](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.mdx
@@ -49,6 +49,10 @@ function MyComponent() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml.spec.ts)
 
+## Further Reading
+
+- [React Docs: `dangerouslySetInnerHTML`](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node.mdx
@@ -79,4 +79,4 @@ class AutoSelectingInput extends Component {
 
 ## Further Reading
 
-- [React Docs: DOM `findDOMNode`](https://react.dev/reference/react-dom/findDOMNode)
+- [React Docs: `findDOMNode`](https://react.dev/reference/react-dom/findDOMNode)

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync.mdx
@@ -51,4 +51,4 @@ flushSync(() => {
 
 ## Further Reading
 
-- [React Docs: DOM `flushSync`](https://react.dev/reference/react-dom/flushSync)
+- [React Docs: `flushSync`](https://react.dev/reference/react-dom/flushSync)

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-hydrate.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-hydrate.mdx
@@ -60,8 +60,8 @@ hydrateRoot(document.getElementById("app"), <Component />);
 
 ## Further Reading
 
-- [React Docs: DOM `hydrate`](https://18.react.dev/reference/react-dom/hydrate)
-- [React DOM `hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot)
+- [React Docs: `hydrate`](https://18.react.dev/reference/react-dom/hydrate)
+- [React Docs: `hydrateRoot`](https://react.dev/reference/react-dom/client/hydrateRoot)
 
 ---
 

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type.mdx
@@ -63,7 +63,7 @@ function MyComponent() {
 
 ## Further Reading
 
-- [MDN `button` notes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#notes)
+- [MDN: `button`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#notes)
 
 ---
 

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox.mdx
@@ -63,7 +63,7 @@ function MyComponent() {
 
 ## Further Reading
 
-- [MDN `iframe` sandbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attributes)
+- [MDN: `iframe` `sandbox`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attributes)
 
 ---
 

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value.mdx
@@ -63,7 +63,7 @@ ReactDOM.render(<div id="app" ref={doSomethingWithInst} />, document.body);
 
 ## Further Reading
 
-- [React Docs: DOM `render`](https://18.react.dev/reference/react-dom/render)
+- [React Docs: `render`](https://18.react.dev/reference/react-dom/render)
 
 ---
 

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-render.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-render.mdx
@@ -59,8 +59,8 @@ createRoot(document.getElementById("app")).render(<Component />);
 
 ## Further Reading
 
-- [React Docs: DOM `render`](https://18.react.dev/reference/react-dom/render)
-- [React DOM `createRoot`](https://react.dev/reference/react-dom/client/createRoot)
+- [React Docs: `render`](https://18.react.dev/reference/react-dom/render)
+- [React Docs: `createRoot`](https://react.dev/reference/react-dom/client/createRoot)
 
 ---
 

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.mdx
@@ -63,6 +63,12 @@ function MyComponent() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank.spec.ts)
 
+## Further Reading
+
+- [MDN: `target`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target)
+- [MDN: `rel`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel)
+- [MDN: `Window.opener`](https://developer.mozilla.org/en-US/docs/Web/API/Window/opener)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state.mdx
@@ -81,4 +81,4 @@ function StatefulForm({}) {
 
 ## Further Reading
 
-- [React Docs: `useActionState` Hook](https://react.dev/reference/react/useActionState)
+- [React Docs: `useActionState`](https://react.dev/reference/react/useActionState)

--- a/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.mdx
+++ b/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.mdx
@@ -61,6 +61,10 @@ React.createElement('div', { dangerouslySetInnerHTML: { __html: 'HTML' } })
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children.spec.ts)
 
+## Further Reading
+
+- [MDN: Void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/component-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/component-name.mdx
@@ -89,6 +89,10 @@ function API() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-naming-convention/src/rules/component-name.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-naming-convention/src/rules/component-name.spec.ts)
 
+## Further Reading
+
+- [React Docs: Component](https://react.dev/learn/your-first-component)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.mdx
@@ -60,6 +60,11 @@ const ThemeContext = createContext("");
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name.spec.ts)
 
+## Further Reading
+
+- [React Docs: Context](https://react.dev/learn/passing-data-deeply-with-context)
+- [React Docs: `createContext`](https://react.dev/reference/react/createContext)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/id-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/id-name.mdx
@@ -70,4 +70,4 @@ const dialogTitleId = useId();
 
 ## Further Reading
 
-- [React Docs: `useId` Hook](https://react.dev/reference/react/useId)
+- [React Docs: `useId`](https://react.dev/reference/react/useId)

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name.mdx
@@ -74,5 +74,5 @@ const valueRef = useRef(null);
 
 ## Further Reading
 
-- [React Docs: `useRef` Hook](https://react.dev/reference/react/useRef)
+- [React Docs: `useRef`](https://react.dev/reference/react/useRef)
 - [React Docs: Plain Object `.current`](https://react.dev/reference/eslint-plugin-react-hooks/lints/refs#plain-object-current)

--- a/packages/plugins/eslint-plugin-react-x/src/rules/error-boundaries.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/error-boundaries.mdx
@@ -142,5 +142,5 @@ Try/catch is perfectly valid for synchronous operations like `JSON.parse`, `loca
 ## Further Reading
 
 - [React Docs: Error Boundaries](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)
-- [React Docs: `use` Hook](https://react.dev/reference/react/use)
+- [React Docs: `use`](https://react.dev/reference/react/use)
 - [React Docs: `error-boundaries` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/error-boundaries)

--- a/packages/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps.mdx
@@ -245,8 +245,8 @@ Custom effect hooks can also be configured via shared ESLint settings, which app
 
 ## Further Reading
 
-- [React Docs: `exhaustive-deps` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps)
 - [React Docs: Removing Effect Dependencies](https://react.dev/learn/removing-effect-dependencies)
 - [React Docs: `useEffect`](https://react.dev/reference/react/useEffect)
 - [React Docs: `useCallback`](https://react.dev/reference/react/useCallback)
 - [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)
+- [React Docs: `exhaustive-deps` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps)

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-dollar.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-dollar.mdx
@@ -110,6 +110,11 @@ function MyComponent({ price }) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-dollar.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-dollar.spec.ts)
 
+## Further Reading
+
+- [React Docs: JSX](https://react.dev/learn/writing-markup-with-jsx)
+- [MDN: Template literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-key-before-spread.mdx
@@ -60,7 +60,7 @@ If the `key` prop is before any spread props, it is passed as the `key` argument
 
 ## Further Reading
 
-- [Introducing the New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
+- [React Docs: New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
 - [Babel Preset React: runtime](https://babeljs.io/docs/babel-preset-react#runtime)
 - [TSConfig: jsx](https://www.typescriptlang.org/tsconfig/#jsx)
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-comment-textnodes.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-comment-textnodes.mdx
@@ -78,6 +78,10 @@ function MyComponent() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-comment-textnodes.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-comment-textnodes.spec.ts)
 
+## Further Reading
+
+- [React Docs: JSX](https://react.dev/learn/writing-markup-with-jsx)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.mdx
@@ -43,6 +43,10 @@ Disallows duplicate props in JSX elements.
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-duplicate-props.spec.ts)
 
+## Further Reading
+
+- [React Docs: JSX](https://react.dev/learn/writing-markup-with-jsx)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-undef.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-undef.mdx
@@ -44,6 +44,11 @@ const button = <MyButton />;
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-undef.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-no-undef.spec.ts)
 
+## Further Reading
+
+- [React Docs: JSX](https://react.dev/learn/writing-markup-with-jsx)
+- [ESLint Docs: `no-undef`](https://eslint.org/docs/latest/rules/no-undef)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-boolean.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-boolean.mdx
@@ -58,6 +58,10 @@ function MyComponent() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-boolean.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-boolean.spec.ts)
 
+## Further Reading
+
+- [React Docs: JSX](https://react.dev/learn/writing-markup-with-jsx)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-fragment.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-fragment.mdx
@@ -66,6 +66,10 @@ function MyComponent() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-fragment.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-shorthand-fragment.spec.ts)
 
+## Further Reading
+
+- [React Docs: `Fragment`](https://react.dev/reference/react/Fragment)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.mdx
@@ -65,6 +65,11 @@ const Hello = <div>Hello</div>;
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-react.spec.ts)
 
+## Further Reading
+
+- [React Docs: JSX](https://react.dev/learn/writing-markup-with-jsx)
+- [React Docs: New JSX Transform](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.mdx
@@ -48,6 +48,11 @@ import Hello from "./Hello";
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/jsx-uses-vars.spec.ts)
 
+## Further Reading
+
+- [React Docs: JSX](https://react.dev/learn/writing-markup-with-jsx)
+- [ESLint Docs: `no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.mdx
@@ -84,6 +84,11 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-implicit-key.spec.ts)
 
+## Further Reading
+
+- [React Docs: Why does React need keys?](https://react.dev/learn/rendering-lists#why-does-react-need-keys)
+- [React RFC: Deprecate spreading key from objects](https://github.com/reactjs/rfcs/pull/107)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.mdx
@@ -95,6 +95,10 @@ export default function Button() {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name.spec.ts)
 
+## Further Reading
+
+- [React Docs: `displayName`](https://react.dev/reference/react/Component#displayname)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name.mdx
@@ -46,6 +46,11 @@ MyContext.displayName = "MyContext";
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name.spec.ts)
 
+## Further Reading
+
+- [React Docs: `displayName`](https://react.dev/reference/react/Component#displayname)
+- [React Docs: Context](https://react.dev/learn/passing-data-deeply-with-context)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.mdx
@@ -61,6 +61,11 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `componentDidMount`](https://react.dev/reference/react/Component#componentdidmount)
+- [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.mdx
@@ -61,6 +61,11 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `componentDidUpdate`](https://react.dev/reference/react/Component#componentdidupdate)
+- [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.mdx
@@ -61,6 +61,11 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `componentWillUpdate`](https://react.dev/reference/react/Component#componentwillupdate)
+- [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-callback.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-callback.mdx
@@ -96,6 +96,11 @@ function MyComponent({items}: {items: string[]}) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-callback.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-callback.spec.ts)
 
+## Further Reading
+
+- [React Docs: `useCallback`](https://react.dev/reference/react/useCallback)
+- [React Docs: `useEffect`](https://react.dev/reference/react/useEffect)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.mdx
@@ -105,6 +105,11 @@ function MyComponent({ someNumbers }: { someNumbers: number[] }) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-memo.spec.ts)
 
+## Further Reading
+
+- [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)
+- [React Docs: `useEffect`](https://react.dev/reference/react/useEffect)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.mdx
@@ -49,6 +49,10 @@ class MyComponent extends React.Component {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `componentWillMount`](https://react.dev/reference/react/Component#componentwillmount)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.mdx
@@ -49,6 +49,10 @@ class MyComponent extends React.Component {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `componentWillReceiveProps`](https://react.dev/reference/react/Component#componentwillreceiveprops)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.mdx
@@ -49,6 +49,10 @@ class MyComponent extends React.Component {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `componentWillUpdate`](https://react.dev/reference/react/Component#componentwillupdate)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.mdx
@@ -90,6 +90,11 @@ This can be a large performance hit because not only will it cause the context p
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value.spec.ts)
 
+## Further Reading
+
+- [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)
+- [React Docs: Context](https://react.dev/learn/passing-data-deeply-with-context)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.mdx
@@ -331,6 +331,10 @@ function MyComponent({ list = ImmutableList.of("a", "b") }: MyComponentProps) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props.spec.ts)
 
+## Further Reading
+
+- [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.mdx
@@ -63,6 +63,10 @@ class MyComponent extends React.Component {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `Component`](https://react.dev/reference/react/Component)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.mdx
@@ -64,6 +64,10 @@ class MyComponent extends React.Component {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state.spec.ts)
 
+## Further Reading
+
+- [Legacy React APIs: `Component`](https://react.dev/reference/react/Component)
+
 ---
 
 ## See Also

--- a/packages/plugins/eslint-plugin-react-x/src/rules/refs.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/refs.mdx
@@ -248,5 +248,5 @@ function Component() {
 ## Further Reading
 
 - [React Docs: Referencing Values with Refs](https://react.dev/learn/referencing-values-with-refs)
-- [React Docs: `useRef` Hook](https://react.dev/reference/react/useRef)
+- [React Docs: `useRef`](https://react.dev/reference/react/useRef)
 - [React Docs: `refs` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/refs)

--- a/packages/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks.mdx
@@ -246,8 +246,8 @@ Custom effect hooks can also be configured via shared ESLint settings, which app
 
 ## Further Reading
 
-- [React Docs: `rules-of-hooks` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/rules-of-hooks)
 - [React Docs: Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
 - [React Docs: `useState`](https://react.dev/reference/react/useState)
 - [React Docs: `useEffect`](https://react.dev/reference/react/useEffect)
 - [React Docs: `use`](https://react.dev/reference/react/use)
+- [React Docs: `rules-of-hooks` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/rules-of-hooks)

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect.mdx
@@ -340,8 +340,8 @@ function List({ items }) {
 
 ## Further Reading
 
-- [React Docs: `useState` Hook](https://react.dev/reference/react/useState)
-- [React Docs: `useEffect` Hook](https://react.dev/reference/react/useEffect)
+- [React Docs: `useState`](https://react.dev/reference/react/useState)
+- [React Docs: `useEffect`](https://react.dev/reference/react/useEffect)
 - [React Docs: You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)
 - [React Docs: `set-state-in-effect` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect)
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render.mdx
@@ -213,7 +213,7 @@ function Component({ items }) {
 
 ## Further Reading
 
-- [React Docs: `useState` Hook](https://react.dev/reference/react/useState)
+- [React Docs: `useState`](https://react.dev/reference/react/useState)
 - [React Docs: `set-state-in-render` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-render)
 
 ---


### PR DESCRIPTION
- Add missing Further Reading sections to 29 rule documentation files
- Standardize link title formats:
- React Docs: <title>
- Legacy React APIs: <title>
- MDN: <title>
- ESLint Docs: <title>
- Remove redundant prefixes (DOM, Hook suffixes)
- Ensure consistent section order: Implementation → Further Reading → See Also

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
