### PR TITLE
Convert React 19 migration rules from auto-fix to suggestions, closes #1549

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.spec.ts
@@ -10,9 +10,14 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`<Context />`,
+            },
+          ],
         },
       ],
-      output: tsx`<Context />`,
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -24,9 +29,14 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`<ThemeContext><App /></ThemeContext>`,
+            },
+          ],
         },
       ],
-      output: tsx`<ThemeContext><App /></ThemeContext>`,
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -38,9 +48,14 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`<Context>{children}</Context>`,
+            },
+          ],
         },
       ],
-      output: tsx`<Context>{children}</Context>`,
       settings: {
         "react-x": {
           version: "19.0.0",

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.spec.ts
@@ -26,13 +26,22 @@ ruleTester.run(RULE_NAME, rule, {
           return null;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import { forwardRef } from 'react'
-        const Component = ({ ref, ...props }) => {
-          return null;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import { forwardRef } from 'react'
+                const Component = ({ ref, ...props }) => {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -44,11 +53,20 @@ ruleTester.run(RULE_NAME, rule, {
         import { forwardRef } from 'react'
         const Component = forwardRef((props) => null);
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import { forwardRef } from 'react'
-        const Component = ({ ref, ...props }) => null;
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import { forwardRef } from 'react'
+                const Component = ({ ref, ...props }) => null;
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -62,13 +80,22 @@ ruleTester.run(RULE_NAME, rule, {
           return null;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import { forwardRef } from 'react'
-        const Component = function ({ ref, ...props }) {
-          return null;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import { forwardRef } from 'react'
+                const Component = function ({ ref, ...props }) {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -82,13 +109,22 @@ ruleTester.run(RULE_NAME, rule, {
           return null;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import { forwardRef } from 'react'
-        const Component = function Component({ ref, ...props }) {
-          return null;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import { forwardRef } from 'react'
+                const Component = function Component({ ref, ...props }) {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -102,13 +138,22 @@ ruleTester.run(RULE_NAME, rule, {
           return null;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = ({ ref, ...props }) => {
-          return null;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = ({ ref, ...props }) => {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -120,11 +165,20 @@ ruleTester.run(RULE_NAME, rule, {
         import * as React from 'react'
         const Component = React.forwardRef((props) => null);
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = ({ ref, ...props }) => null;
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = ({ ref, ...props }) => null;
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -138,13 +192,22 @@ ruleTester.run(RULE_NAME, rule, {
           return null;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = function ({ ref, ...props }) {
-          return null;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = function ({ ref, ...props }) {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -158,13 +221,22 @@ ruleTester.run(RULE_NAME, rule, {
           return null;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = function Component({ ref, ...props }) {
-          return null;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = function Component({ ref, ...props }) {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -178,13 +250,22 @@ ruleTester.run(RULE_NAME, rule, {
           return <div ref={ref} />;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = function Component({ ref, ...props }) {
-          return <div ref={ref} />;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = function Component({ ref, ...props }) {
+                  return <div ref={ref} />;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -201,16 +282,25 @@ ruleTester.run(RULE_NAME, rule, {
           return <div ref={ref} />;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        interface ComponentProps {
-          foo: string;
-        }
-        const Component = function Component({ ref, ...props }: ComponentProps & { ref?: React.RefObject<HTMLElement | null> }) {
-          return <div ref={ref} />;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                interface ComponentProps {
+                  foo: string;
+                }
+                const Component = function Component({ ref, ...props }: ComponentProps & { ref?: React.RefObject<HTMLElement | null> }) {
+                  return <div ref={ref} />;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -224,13 +314,22 @@ ruleTester.run(RULE_NAME, rule, {
           return <div ref={ref}>{props.foo}</div>;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = function Component({ ref, ...props }: { foo: string } & { ref?: React.RefObject<HTMLElement | null> }) {
-          return <div ref={ref}>{props.foo}</div>;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = function Component({ ref, ...props }: { foo: string } & { ref?: React.RefObject<HTMLElement | null> }) {
+                  return <div ref={ref}>{props.foo}</div>;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -244,13 +343,22 @@ ruleTester.run(RULE_NAME, rule, {
           return <div ref={ref}>{foo}</div>;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = function Component({ ref, foo }: { foo: string } & { ref?: React.RefObject<HTMLElement | null> }) {
-          return <div ref={ref}>{foo}</div>;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = function Component({ ref, foo }: { foo: string } & { ref?: React.RefObject<HTMLElement | null> }) {
+                  return <div ref={ref}>{foo}</div>;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -264,13 +372,22 @@ ruleTester.run(RULE_NAME, rule, {
           return <div ref={r}>{foo}</div>;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = function Component({ ref: r, foo }: { foo: string } & { ref?: React.RefObject<HTMLElement | null> }) {
-          return <div ref={r}>{foo}</div>;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = function Component({ ref: r, foo }: { foo: string } & { ref?: React.RefObject<HTMLElement | null> }) {
+                  return <div ref={r}>{foo}</div>;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -284,13 +401,22 @@ ruleTester.run(RULE_NAME, rule, {
           return <div ref={r}>{foo}</div>;
         });
       `,
-      errors: [{ messageId: "default" }],
-      output: tsx`
-        import * as React from 'react'
-        const Component = function Component({ ref: r, foo, ...rest }: { foo: string, bar: number } & { ref?: React.RefObject<HTMLElement | null> }) {
-          return <div ref={r}>{foo}</div>;
-        };
-      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = function Component({ ref: r, foo, ...rest }: { foo: string, bar: number } & { ref?: React.RefObject<HTMLElement | null> }) {
+                  return <div ref={r}>{foo}</div>;
+                };
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
@@ -15,17 +15,19 @@ export const RULE_FEATURES = [
   "MOD",
 ] as const satisfies RuleFeature[];
 
-export type MessageID = "default";
+export type MessageID = "default" | "replace";
 
 export default createRule<[], MessageID>({
   meta: {
-    type: "problem",
+    type: "suggestion",
     docs: {
       description: "Replaces usage of 'forwardRef' with passing 'ref' as a prop.",
     },
     fixable: "code",
+    hasSuggestions: true,
     messages: {
       default: "In React 19, 'forwardRef' is no longer necessary. Pass 'ref' as a prop instead.",
+      replace: "Replace 'forwardRef' with passing 'ref' as a prop.",
     },
     schema: [],
   },
@@ -52,11 +54,18 @@ export function create(context: RuleContext<MessageID, []>) {
           return;
         }
         const id = ast.getFunctionId(node);
-        const fix = canFix(context, node) ? getFix(context, node) : null;
+        const suggest = canFix(context, node)
+          ? [
+            {
+              messageId: "replace" as const,
+              fix: getFix(context, node),
+            },
+          ]
+          : [];
         context.report({
           messageId: "default",
           node: id ?? node,
-          fix,
+          suggest,
         });
       },
     },

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.spec.ts
@@ -15,125 +15,23 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
-        { messageId: "default" },
-        { messageId: "default" },
-      ],
-      output: tsx`
-        import { use } from 'react'
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import { useContext } from 'react'
 
-        export const Component = () => {
-          const value = use(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      settings: {
-        "react-x": {
-          version: "19.0.0",
+                export const Component = () => {
+                  const value = use(MyContext)
+                  return <div>{value}</div>
+                }
+              `,
+            },
+          ],
         },
-      },
-    },
-    {
-      code: tsx`
-        import { useContext } from 'react'
-
-        export const Component = () => {
-          const value = useContext<MyContext>(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      errors: [
-        { messageId: "default" },
-        { messageId: "default" },
       ],
-      output: tsx`
-        import { use } from 'react'
-
-        export const Component = () => {
-          const value = use<MyContext>(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      settings: {
-        "react-x": {
-          version: "19.0.0",
-        },
-      },
-    },
-    {
-      code: tsx`
-        import { use, useContext } from 'react'
-
-        export const Component = () => {
-          const value = useContext(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      errors: [
-        { messageId: "default" },
-        { messageId: "default" },
-      ],
-      output: tsx`
-        import { use } from 'react'
-
-        export const Component = () => {
-          const value = use(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      settings: {
-        "react-x": {
-          version: "19.0.0",
-        },
-      },
-    },
-    {
-      code: tsx`
-        import { use, useContext, useState } from 'react'
-
-        export const Component = () => {
-          const value = useContext(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      errors: [
-        { messageId: "default" },
-        { messageId: "default" },
-      ],
-      output: tsx`
-        import { use, useState } from 'react'
-
-        export const Component = () => {
-          const value = use(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      settings: {
-        "react-x": {
-          version: "19.0.0",
-        },
-      },
-    },
-    {
-      code: tsx`
-        import {use,useContext,useState} from 'react'
-
-        export const Component = () => {
-          const value = useContext(MyContext)
-          return <div>{value}</div>
-        }
-      `,
-      errors: [
-        { messageId: "default" },
-        { messageId: "default" },
-      ],
-      output: tsx`
-        import {use,useState} from 'react'
-
-        export const Component = () => {
-          const value = use(MyContext)
-          return <div>{value}</div>
-        }
-      `,
       settings: {
         "react-x": {
           version: "19.0.0",
@@ -150,16 +48,23 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
-        { messageId: "default" },
-      ],
-      output: tsx`
-        import React from 'react'
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import React from 'react'
 
-        export const Component = () => {
-          const value = React.use(MyContext)
-          return <div>{value}</div>
-        }
-      `,
+                export const Component = () => {
+                  const value = React.use(MyContext)
+                  return <div>{value}</div>
+                }
+              `,
+            },
+          ],
+        },
+      ],
       settings: {
         "react-x": {
           version: "19.0.0",

--- a/packages/plugins/eslint-plugin-react-x/src/rules/prefer-destructuring-assignment/prefer-destructuring-assignment.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/prefer-destructuring-assignment/prefer-destructuring-assignment.ts
@@ -11,7 +11,7 @@ export type MessageID = "default";
 
 export default createRule<[], MessageID>({
   meta: {
-    type: "problem",
+    type: "suggestion",
     docs: {
       description: "Enforces destructuring assignment for component props and context.",
     },


### PR DESCRIPTION
- Change no-context-provider, no-forward-ref, no-use-context to use suggestions instead of auto-fixes
- Update rule type from 'problem' to 'suggestion' for migration rules
- Simplify no-use-context implementation by removing import handling
- Update test cases to reflect suggestions API structure

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Once these fixes have proven sufficiently stable in their implementation, we may consider bringing back their automatic fixes
