### PR TITLE
refactor(naming-convention): remove React 19 version restriction from `context-name` rule

### DIFF
--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
@@ -26,7 +26,7 @@ react-naming-convention/context-name
 
 ## Rule Details
 
-In React 19, you can render `<Context>` as a provider instead of `<Context.Provider>`. This rule enforces that the context has a valid component name with the suffix `Context`.
+Enforces that the context has a valid component name with the suffix `Context`.
 
 ## Common Violations
 

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.spec.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.spec.ts
@@ -81,15 +81,5 @@ ruleTester.run(RULE_NAME, rule, {
     tsx`
       ctxs.ThemeContext = createContext("");
     `,
-    {
-      code: tsx`
-        const themecontext = React.createContext("");
-      `,
-      settings: {
-        "react-x": {
-          version: "18.2.0",
-        },
-      },
-    },
   ],
 });

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.ts
@@ -2,7 +2,6 @@ import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener, getSettingsFromContext } from "@eslint-react/shared";
 import { findEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import { compare } from "compare-versions";
 import { P, match } from "ts-pattern";
 
 import { createRule } from "../../utils";
@@ -32,9 +31,6 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `createContext` is not present in the file
   if (!context.sourceCode.text.includes("createContext")) return {};
-  const { version } = getSettingsFromContext(context);
-  // Skip if React version is less than 19.0.0
-  if (compare(version, "19.0.0", "<")) return {};
   return defineRuleListener(
     {
       CallExpression(node) {

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
@@ -26,6 +26,8 @@ react-naming-convention/id-name
 
 ## Rule Details
 
+Enforces identifier names assigned from `useId` calls to be either `id` or end with `Id`.
+
 ## Common Violations
 
 ### Invalid

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
@@ -26,6 +26,8 @@ react-naming-convention/ref-name
 
 ## Rule Details
 
+Enforces identifier names assigned from `useRef` calls to be either `ref` or end with `Ref`.
+
 ## Common Violations
 
 ### Invalid


### PR DESCRIPTION
- Remove version check from context-name rule (now works with all React versions)
- Delete React 18.2.0 test case and compare-versions dependency
- Update context-name documentation to be version-agnostic
- Add rule details to id-name and ref-name documentation

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #___
- [ ] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
