### PR TITLE
Fix `no-useless-fragment` False positive when passing a `ref` to a `Fragment`, closes #1567

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-fragment/no-useless-fragment.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-fragment/no-useless-fragment.spec.ts
@@ -370,5 +370,23 @@ ruleTester.run(RULE_NAME, rule, {
       code: tsx`<Foo bar={<><Bar/><Baz/></>} />`,
       options: [{ allowExpressions: false }],
     },
+    {
+      code: tsx`
+        import { Fragment, useRef } from "react";
+
+              export function Foo({ children }) {
+                  const ref = useRef();
+                  return (
+                      <div>
+                          {/* ... */}
+                          <Fragment ref={ref}>
+                              {children}
+                          </Fragment>
+                          {/* ... */}
+                      </div>
+                  );
+              }
+      `,
+    },
   ],
 });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-fragment/no-useless-fragment.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-useless-fragment/no-useless-fragment.ts
@@ -75,11 +75,6 @@ export function create(context: RuleContext<MessageID, Options>, [option]: Optio
    * Check if a fragment node is useless and should be reported
    */
   function checkNode(context: RuleContext, node: TSESTree.JSXElement | TSESTree.JSXFragment) {
-    // Skip if the fragment has a key prop (indicates it's needed for lists)
-    if (node.type === AST.JSXElement && core.getJsxAttribute(context, node)("key") != null) {
-      return;
-    }
-
     // Report fragment placed inside a host component (e.g., <div><></></div>)
     if (core.isJsxHostElement(context, node.parent)) {
       context.report({
@@ -199,6 +194,8 @@ export function create(context: RuleContext<MessageID, Options>, [option]: Optio
       // Check JSX elements that might be fragments
       JSXElement(node) {
         if (!core.isJsxFragmentElement(context, node, jsxConfig)) return;
+        if (core.getJsxAttribute(context, node)("key") != null) return;
+        if (core.getJsxAttribute(context, node)("ref") != null) return;
         checkNode(context, node);
       },
       // Check JSX fragments

--- a/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
@@ -62,6 +62,8 @@ export function create(context: RuleContext<MessageID, []>) {
   /**
    * Check if a test expression is a null check on `ref.current` for a given ref name.
    * Matches forms like `ref.current === null`, `null === ref.current`, and their != variants.
+   * @param test
+   * @param refName
    */
   function isRefCurrentNullCheck(test: TSESTree.Expression, refName: string): boolean {
     if (test.type !== AST.BinaryExpression) return false;


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
