### PR TITLE
feat: rename `no-mixing-controlled-and-uncontrolled` to `unstable-rules-of-props`

### DIFF
--- a/apps/website/content/docs/rules/meta.json
+++ b/apps/website/content/docs/rules/meta.json
@@ -64,6 +64,7 @@
     "rules-of-hooks",
     "set-state-in-effect",
     "set-state-in-render",
+    "unstable-rules-of-props",
     "unsupported-syntax",
     "use-memo",
     "use-state",

--- a/packages/plugins/eslint-plugin-react-x/src/configs/disable-experimental.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/configs/disable-experimental.ts
@@ -12,6 +12,7 @@ export const rules: Record<string, RuleConfig> = {
   "react-x/no-unnecessary-use-callback": "off",
   "react-x/no-unnecessary-use-memo": "off",
   "react-x/no-unused-props": "off",
+  "react-x/unstable-rules-of-props": "off",
   "react-x/refs": "off",
   "react-x/rules-of-hooks": "off",
   "react-x/set-state-in-render": "off",

--- a/packages/plugins/eslint-plugin-react-x/src/plugin.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/plugin.ts
@@ -68,6 +68,9 @@ import unsupportedSyntax from "./rules/unsupported-syntax/unsupported-syntax";
 import useMemo from "./rules/use-memo/use-memo";
 import useState from "./rules/use-state/use-state";
 
+// Unstable rules
+import unstableRulesOfProps from "./rules/unstable-rules-of-props/unstable-rules-of-props";
+
 export const plugin = {
   meta: {
     name,
@@ -136,6 +139,7 @@ export const plugin = {
     "rules-of-hooks": rulesOfHooks,
     "set-state-in-effect": setStateInEffect,
     "set-state-in-render": setStateInRender,
+    "unstable-rules-of-props": unstableRulesOfProps,
     "unsupported-syntax": unsupportedSyntax,
     "use-memo": useMemo,
     "use-state": useState,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.mdx
@@ -1,0 +1,106 @@
+---
+title: unstable-rules-of-props
+description: Enforces the Rules of Props.
+---
+
+<Callout type="warning">
+  This rule is currently in beta and only available in v3.0.0 beta releases.
+</Callout>
+
+<Callout type="warning">
+  This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
+</Callout>
+
+**Full Name in [`@eslint-react/eslint-plugin@beta`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
+
+```plain copy
+@eslint-react/unstable-rules-of-props
+```
+
+**Full Name in [`eslint-plugin-react-x@beta`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
+
+```plain copy
+react-x/unstable-rules-of-props
+```
+
+**Features**
+
+`🧪`
+
+**Presets**
+
+-
+
+## Rule Details
+
+Props are the primary interface through which components receive data. Passing props incorrectly — using conflicting prop combinations, supplying the wrong shape, or violating React's own contracts for built-in elements — leads to subtle bugs that are often hard to trace at runtime. This rule enforces a set of named checks, each targeting a distinct category of prop misuse.
+
+## Common Violations
+
+### Using Controlled and Uncontrolled Props Together
+
+Mixing both modes on the same element is a mistake. React will silently ignore the `default*` prop and may emit a console warning. The element behaves as controlled, which causes confusing bugs when the developer expects the initial value to be respected.
+
+The following prop pairs must not appear together on the same element:
+
+| Controlled prop | Uncontrolled prop |
+|---|---|
+| `value` | `defaultValue` |
+| `checked` | `defaultChecked` |
+
+#### Invalid
+
+```tsx
+// ❌ 'defaultValue' is ignored because 'value' makes the input controlled.
+<input value={name} defaultValue="World" />;
+```
+
+```tsx
+// ❌ 'defaultChecked' is ignored because 'checked' makes the checkbox controlled.
+<input type="checkbox" checked={isChecked} defaultChecked />;
+```
+
+```tsx
+// ❌ Order does not matter — the pair is still invalid.
+<textarea defaultValue="fallback" value={content} />;
+```
+
+```tsx
+// ❌ Custom components that follow the same pattern are also flagged.
+<MyInput value={val} defaultValue="fallback" />;
+```
+
+#### Valid
+
+```tsx
+// ✅ Controlled input — value is driven by React state.
+<input value={name} onChange={(e) => setName(e.target.value)} />;
+```
+
+```tsx
+// ✅ Uncontrolled input — host element manages the value; initial value is provided.
+<input defaultValue="World" />;
+```
+
+```tsx
+// ✅ Controlled checkbox.
+<input
+  type="checkbox"
+  checked={isChecked}
+  onChange={(e) => setIsChecked(e.target.checked)}
+/>;
+```
+
+```tsx
+// ✅ Uncontrolled checkbox with an initial checked state.
+<input type="checkbox" defaultChecked />;
+```
+
+## Resources
+
+- [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.ts)
+- [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.spec.ts)
+
+## Further Reading
+
+- [React Docs: Controlled and uncontrolled components](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components)

--- a/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.spec.ts
@@ -1,0 +1,86 @@
+import tsx from "dedent";
+
+import { ruleTester } from "../../../../../../test";
+import rule, { RULE_NAME } from "./unstable-rules-of-props";
+
+ruleTester.run(RULE_NAME, rule, {
+  invalid: [
+    {
+      code: tsx`<input value="hello" defaultValue="world" />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      code: tsx`<input defaultValue="world" value="hello" />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      code: tsx`<input type="checkbox" checked={true} defaultChecked />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      code: tsx`<input type="checkbox" defaultChecked checked={false} />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      code: tsx`<textarea value="hello" defaultValue="world" />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      code: tsx`<select value="a" defaultValue="b" />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      code: tsx`<input value={name} defaultValue="" />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      code: tsx`<input checked={isChecked} defaultChecked={false} />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+    {
+      // Both pairs violated on the same element
+      code: tsx`<input value="hello" defaultValue="world" checked={true} defaultChecked />;`,
+      errors: [
+        { messageId: "noControlledAndUncontrolledTogether" },
+        { messageId: "noControlledAndUncontrolledTogether" },
+      ],
+    },
+    {
+      // Custom component following the same controlled/uncontrolled pattern
+      code: tsx`<MyInput value={val} defaultValue="fallback" />;`,
+      errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
+    },
+  ],
+  valid: [
+    // Controlled inputs
+    tsx`<input value="hello" />;`,
+    tsx`<input value={name} onChange={(e) => setName(e.target.value)} />;`,
+    tsx`<input type="checkbox" checked={isChecked} onChange={(e) => setIsChecked(e.target.checked)} />;`,
+    tsx`<textarea value="hello" onChange={(e) => setValue(e.target.value)} />;`,
+    tsx`<select value="a" onChange={(e) => setValue(e.target.value)} />;`,
+
+    // Uncontrolled inputs
+    tsx`<input defaultValue="world" />;`,
+    tsx`<input type="checkbox" defaultChecked />;`,
+    tsx`<input type="checkbox" defaultChecked={true} />;`,
+    tsx`<textarea defaultValue="world" />;`,
+    tsx`<select defaultValue="b" />;`,
+
+    // Unrelated props
+    tsx`<input type="text" placeholder="Enter value" />;`,
+    tsx`<input type="submit" value="Submit" />;`,
+    tsx`<input name="field" id="field" />;`,
+
+    // Spread attributes are ignored (can't statically determine contents)
+    tsx`<input {...props} defaultValue="world" />;`,
+    tsx`<input value="hello" {...rest} />;`,
+
+    // Sibling elements — each element is checked independently
+    tsx`
+      <div>
+        <input value="hello" />
+        <input defaultValue="world" />
+      </div>;
+    `,
+  ],
+});

--- a/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.ts
@@ -1,0 +1,73 @@
+import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
+import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
+import type { TSESTree } from "@typescript-eslint/types";
+
+import { createRule } from "../../utils";
+
+export const RULE_NAME = "unstable-rules-of-props";
+
+export const RULE_FEATURES = [
+  "EXP",
+] as const satisfies RuleFeature[];
+
+export type MessageID = "noControlledAndUncontrolledTogether";
+
+/**
+ * Pairs of [controlled prop, uncontrolled prop] that must not appear together
+ * on the same JSX element.
+ *
+ * - `value`   → controlled;   `defaultValue`   → uncontrolled
+ * - `checked` → controlled;   `defaultChecked` → uncontrolled
+ */
+const CONTROLLED_UNCONTROLLED_PAIRS = [
+  ["value", "defaultValue"],
+  ["checked", "defaultChecked"],
+] as const;
+
+export default createRule<[], MessageID>({
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Enforces the Rules of Props.",
+    },
+    messages: {
+      noControlledAndUncontrolledTogether:
+        "Prop `{{controlled}}` and `{{uncontrolled}}` should not be used together. Use either controlled or uncontrolled components, not both.",
+    },
+    schema: [],
+  },
+  name: RULE_NAME,
+  create,
+  defaultOptions: [],
+});
+
+export function create(context: RuleContext<MessageID, []>) {
+  return defineRuleListener({
+    JSXOpeningElement(node) {
+      const propMap = new Map<string, TSESTree.JSXAttribute>();
+
+      for (const attr of node.attributes) {
+        if (attr.type === AST.JSXSpreadAttribute) continue;
+        const { name } = attr.name;
+        if (typeof name !== "string") continue;
+        propMap.set(name, attr);
+      }
+
+      for (const [controlled, uncontrolled] of CONTROLLED_UNCONTROLLED_PAIRS) {
+        if (!propMap.has(controlled) || !propMap.has(uncontrolled)) continue;
+
+        // Report on the uncontrolled prop node since it is the one being
+        // superseded (and therefore misleading) when a controlled prop is
+        // present on the same element.
+        const uncontrolledAttr = propMap.get(uncontrolled);
+        if (uncontrolledAttr == null) continue;
+
+        context.report({
+          data: { controlled, uncontrolled },
+          messageId: "noControlledAndUncontrolledTogether",
+          node: uncontrolledAttr,
+        });
+      }
+    },
+  });
+}


### PR DESCRIPTION
- Move rule to unstable namespace with expanded scope for Props rules
- Detect mixing controlled and uncontrolled props (value/defaultValue, checked/defaultChecked)
- Add documentation, test cases, and rule implementation
- Register in plugin and disable in experimental config

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [x] Docs
- [x] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
