### PR TITLE
refactor: improve `resolve` function with comprehensive definition ty…

### DIFF
--- a/packages/utilities/var/package.json
+++ b/packages/utilities/var/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@local/configs": "workspace:*",
+    "@typescript-eslint/typescript-estree": "canary",
     "tsdown": "^0.21.0-beta.2"
   },
   "peerDependencies": {

--- a/packages/utilities/var/src/resolve.ts
+++ b/packages/utilities/var/src/resolve.ts
@@ -1,19 +1,103 @@
+import * as ast from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/shared";
 import { DefinitionType } from "@typescript-eslint/scope-manager";
 import type { TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 
-export function resolve(context: RuleContext, node: TSESTree.Identifier, at = 0) {
-  const v = findVariable(context.sourceCode.getScope(node), node);
-  if (v == null) return null;
-  const def = v.defs.at(at);
+/**
+ * Resolves an identifier to the AST node that represents its value,
+ * suitable for use in ESLint rule analysis.
+ *
+ * The resolution follows these rules per definition type:
+ *
+ * | Definition type          | `def.node`                                   | Returns                            |
+ * |--------------------------|----------------------------------------------|------------------------------------|
+ * | `Variable`               | `VariableDeclarator`                         | `def.node.init` (or `null`)        |
+ * | `FunctionName`           | `FunctionDeclaration` / `FunctionExpression` | `def.node`                         |
+ * | `ClassName`              | `ClassDeclaration` / `ClassExpression`       | `def.node`                         |
+ * | `Parameter`              | containing function node                     | `def.node` (if a real function)    |
+ * | `TSEnumName`             | `TSEnumDeclaration`                          | `def.node`                         |
+ * | `TSEnumMember`           | `TSEnumMember`                               | `def.node.initializer` (or `null`) |
+ * | `ImportBinding`          | import specifier                             | `null`                             |
+ * | `CatchClause`            | `CatchClause`                                | `null`                             |
+ * | `TSModuleName`           | `TSModuleDeclaration`                        | `null`                             |
+ * | `Type`                   | type alias node                              | `null`                             |
+ * | `ImplicitGlobalVariable` | any node                                     | `null`                             |
+ *
+ * @param context The ESLint rule context used for scope lookup.
+ * @param node The identifier to resolve.
+ * @param at Which definition to use when multiple exist (default: `0`; pass `-1` for the last).
+ * @param localOnly When `true`, look up the variable only in the node's own scope (faster, but
+ *   will miss variables declared in an outer scope). When `false` (default), traverse the scope
+ *   chain upward via `findVariable` so that references to outer-scope bindings are resolved
+ *   correctly.
+ * @returns The resolved node, or `null` if the identifier cannot be resolved to a value node.
+ */
+export function resolve(
+  context: RuleContext,
+  node: TSESTree.Identifier,
+  at = 0,
+  localOnly = false,
+): TSESTree.Node | null {
+  const scope = context.sourceCode.getScope(node);
+  const variable = localOnly
+    ? scope.set.get(node.name)
+    : findVariable(scope, node);
+  if (variable == null) return null;
+  const def = variable.defs.at(at);
   if (def == null) return null;
-  switch (true) {
-    case def.type === DefinitionType.FunctionName:
-    case def.type === DefinitionType.ClassName:
+
+  switch (def.type) {
+    // Return function declaration/expression node itself
+    case DefinitionType.FunctionName:
       return def.node;
-    case "init" in def.node && def.node.init != null && !("declarations" in def.node.init):
-      return def.node.init;
+
+    // Return class declaration/expression node itself
+    case DefinitionType.ClassName:
+      return def.node;
+
+    // Return the initializer expression (if any)
+    case DefinitionType.Variable: {
+      const { init } = def.node;
+      if (init == null) return null;
+      // Guard against unexpected AST shapes that could cause infinite loops
+      if ("declarations" in init) return null;
+      return init;
+    }
+
+    // Return containing function node only for real functions (not type signatures)
+    case DefinitionType.Parameter:
+      return ast.isFunction(def.node) ? def.node : null;
+
+    // Return enum declaration for member inspection
+    case DefinitionType.TSEnumName:
+      return def.node;
+
+    // Return enum member's initializer, if present
+    case DefinitionType.TSEnumMember:
+      return def.node.initializer ?? null;
+
+    // Import bindings reference external values - not locally available
+    case DefinitionType.ImportBinding:
+      return null;
+
+    // Catch clause bindings hold dynamic error values - not statically determinable
+    case DefinitionType.CatchClause:
+      return null;
+
+    // Namespace/module names are structural, not value-producing
+    case DefinitionType.TSModuleName:
+      return null;
+
+    // Type aliases exist only in type system, no runtime value
+    case DefinitionType.Type:
+      return null;
+
+    // Implicit globals have no local initializer
+    case DefinitionType.ImplicitGlobalVariable:
+      return null;
+
+    default:
+      return null;
   }
-  return null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1103,6 +1103,9 @@ importers:
       '@local/configs':
         specifier: workspace:*
         version: link:../../../.pkgs/configs
+      '@typescript-eslint/typescript-estree':
+        specifier: canary
+        version: 8.56.2-alpha.1(typescript@5.9.3)
       tsdown:
         specifier: ^0.21.0-beta.2
         version: 0.21.0-beta.2(publint@0.3.17)(typescript@5.9.3)


### PR DESCRIPTION
…pe support

- Extend `resolve` in `@eslint-react/var` to handle all DefinitionType cases
- Add `localOnly` parameter for scope chain control
- Add comprehensive JSDoc with behavior table per definition type
- Migrate `set-state-in-effect` and `compute-object-type` to use shared resolve
- Remove duplicated local resolve implementations

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
