### PR TITLE
Fix TS type expressions handling in rules, closes #1583

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
@@ -213,26 +213,17 @@ export function create(context: RuleContext<MessageID, []>) {
           node,
         });
       },
-
-      /**
-       * At the end of the program, filter collected violations to only those
-       * that appear inside a component or hook function, then report them.
-       * @param program The Program node of the entire file.
-       */
-      "Program:exit"(program) {
-        const components = cCollector.ctx.getAllComponents(program);
-        const hooks = hCollector.ctx.getAllHooks(program);
-        const componentAndHookFns = new Set([
-          ...components.map((c) => c.node),
-          ...hooks.map((h) => h.node),
-        ]);
+      "Program:exit"(node) {
+        const comps = cCollector.ctx.getAllComponents(node);
+        const hooks = hCollector.ctx.getAllHooks(node);
+        const funcs = [...comps, ...hooks];
 
         for (const { data, func, messageId, node } of violations) {
           // Walk up the function chain to find a component or hook boundary
           let current: ast.TSESTreeFunction | null = func;
           let insideComponentOrHook = false;
           while (current != null) {
-            if (componentAndHookFns.has(current)) {
+            if (funcs.some((f) => f.node === current)) {
               insideComponentOrHook = true;
               break;
             }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
@@ -73,9 +73,9 @@ export function create(context: RuleContext<MessageID, []>) {
         nExprs.push({ func, node });
       },
       "Program:exit"(node) {
-        const components = cCollector.ctx.getAllComponents(node);
+        const comps = cCollector.ctx.getAllComponents(node);
         const hooks = hCollector.ctx.getAllHooks(node);
-        const funcs = [...components, ...hooks];
+        const funcs = [...comps, ...hooks];
         for (const { func, node } of [...cExprs, ...nExprs]) {
           if (!funcs.some((f) => f.node === func)) continue;
           context.report({

--- a/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.spec.ts
@@ -541,6 +541,32 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "readDuringRender",
       }],
     },
+    // Write through TSNonNullExpression during render should report writeDuringRender
+    {
+      code: tsx`
+        function Component() {
+          const ref = useRef<number | null>(null);
+          ref.current! = 42;
+          return <div />;
+        }
+      `,
+      errors: [{
+        messageId: "writeDuringRender",
+      }],
+    },
+    // Write through TSAsExpression during render should report writeDuringRender
+    {
+      code: tsx`
+        function Component() {
+          const ref = useRef<number | null>(null);
+          (ref.current as number) = 42;
+          return <div />;
+        }
+      `,
+      errors: [{
+        messageId: "writeDuringRender",
+      }],
+    },
   ],
   valid: [
     // Initialize only once on first use with nullish coalescing assignment is valid pattern
@@ -1179,6 +1205,30 @@ ruleTester.run(RULE_NAME, rule, {
             return <div>{ref.current}</div>;
           }
           ref.current = computeExpensiveValue();
+          return <div />;
+        }
+      `,
+    },
+    // Write through TSNonNullExpression in event handler is valid
+    {
+      code: tsx`
+        function Component() {
+          const ref = useRef<HTMLElement>(null);
+          const handleClick = () => {
+            ref.current! = document.getElementById('foo')!;
+          };
+          return <button onClick={handleClick}>Click</button>;
+        }
+      `,
+    },
+    // Lazy init with TSNonNullExpression in null check
+    {
+      code: tsx`
+        function Component() {
+          const ref = useRef<ExpensiveThing | null>(null);
+          if ((ref.current as ExpensiveThing | null) === null) {
+            ref.current = createExpensiveThing();
+          }
           return <div />;
         }
       `,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
@@ -51,9 +51,11 @@ export function create(context: RuleContext<MessageID, []>) {
    * @returns true if the node is part of a null check test in an if statement
    */
   function isInNullCheckTest(node: TSESTree.MemberExpression): boolean {
-    const { parent } = node;
+    let parent: TSESTree.Node = node.parent;
+    while (ast.isTypeExpression(parent)) parent = parent.parent;
     if (!isMatching({ type: AST.BinaryExpression, operator: P.union("===", "==", "!==", "!=") }, parent)) return false;
-    const otherSide = parent.left === node ? parent.right : parent.left;
+    const isLeftSide = parent.left === node || ast.getUnderlyingExpression(parent.left) === node;
+    const otherSide = isLeftSide ? parent.right : parent.left;
     if (otherSide.type !== AST.Literal || otherSide.value != null) return false;
     return parent.parent.type === AST.IfStatement && parent.parent.test === parent;
   }
@@ -69,17 +71,15 @@ export function create(context: RuleContext<MessageID, []>) {
     const op = test.operator;
     if (op !== "===" && op !== "==" && op !== "!==" && op !== "!=") return false;
     const { left, right } = test;
-    const checkSides = (
-      a: TSESTree.Expression | TSESTree.PrivateIdentifier,
-      b: TSESTree.Expression | TSESTree.PrivateIdentifier,
-    ) =>
-      a.type === AST.MemberExpression
-      && a.object.type === AST.Identifier
-      && a.object.name === refName
-      && a.property.type === AST.Identifier
-      && a.property.name === "current"
-      && b.type === AST.Literal
-      && b.value == null;
+    const checkSides = (a: TSESTree.Node, b: TSESTree.Node) => {
+      a = ast.isTypeExpression(a) ? ast.getUnderlyingExpression(a) : a;
+      return a.type === AST.MemberExpression
+        && a.object.type === AST.Identifier
+        && a.object.name === refName
+        && b.type === AST.Literal
+        && b.value == null
+        && ast.getPropertyName(a.property) === "current";
+    };
     return checkSides(left, right) || checkSides(right, left);
   }
 
@@ -102,10 +102,24 @@ export function create(context: RuleContext<MessageID, []>) {
       MemberExpression(node: TSESTree.MemberExpression) {
         if (!ast.isIdentifier(node.property, "current")) return;
         refAccesses.push({
-          isWrite: match(node.parent)
-            .with({ type: AST.AssignmentExpression }, (p) => p.left === node)
-            .with({ type: AST.UpdateExpression }, (p) => p.argument === node)
-            .otherwise(() => false),
+          isWrite: (() => {
+            let parent: TSESTree.Node = node.parent;
+            while (ast.isTypeExpression(parent)) parent = parent.parent;
+            return match(parent)
+              .with(
+                {
+                  type: AST.AssignmentExpression,
+                },
+                (p) => p.left === node || ast.getUnderlyingExpression(p.left) === node,
+              )
+              .with(
+                {
+                  type: AST.UpdateExpression,
+                },
+                (p) => p.argument === node || ast.getUnderlyingExpression(p.argument) === node,
+              )
+              .otherwise(() => false);
+          })(),
           node,
         });
       },

--- a/packages/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
@@ -225,5 +225,13 @@ ruleTester.run(RULE_NAME, rule, {
         return <div onClick={handler} />;
       }
     `,
+    tsx`
+      function A() {
+        const x = useMemo(() => {
+            return 1 + 1;
+        }, []) as number;
+        return x;
+      }
+    `,
   ],
 });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
@@ -43,7 +43,8 @@ export function create(context: RuleContext<MessageID, []>) {
       // Check if the useMemo call result is assigned to a variable.
       // Valid: const x = useMemo(...)
       // Invalid: useMemo(...) — result discarded (side-effect usage)
-      const parent = node.parent;
+      let parent = node.parent;
+      while (ast.isTypeExpression(parent)) parent = parent.parent;
       const isAssigned = parent.type === AST.VariableDeclarator
         || parent.type === AST.AssignmentExpression
         || parent.type === AST.AssignmentPattern

--- a/packages/utilities/ast/src/property-name.ts
+++ b/packages/utilities/ast/src/property-name.ts
@@ -20,7 +20,7 @@ export function getPropertyName(node: TSESTree.Node): string | null {
     return String(node.value);
   }
   if (node.type === AST.TemplateLiteral && node.expressions.length === 0) {
-    return node.quasis[0]?.value.raw ?? null;
+    return node.quasis[0]?.value.cooked ?? node.quasis[0]?.value.raw ?? null;
   }
   return null;
 }


### PR DESCRIPTION
Unwrap TS type/non-null/as expressions when analyzing member expressions, assignments, and useMemo parents; improve null-check and write detection in refs rule; prefer cooked template literals for property names and add tests for TS assertions.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
