### PR TITLE
Fix additional `useState` names should only match patterns configuredin `additionalStateHooks`, closes #1600

### DIFF
--- a/packages/core/src/hook/hook-is.ts
+++ b/packages/core/src/hook/hook-is.ts
@@ -102,15 +102,16 @@ export function isUseStateLikeCall(
   if (node.type !== AST.CallExpression) {
     return false;
   }
-  return [/^use\w*State$/u, additionalStateHooks].some((regexp) => {
-    if (node.callee.type === AST.Identifier) {
-      return regexp.test(node.callee.name);
-    }
-    if (node.callee.type === AST.MemberExpression) {
-      return node.callee.property.type === AST.Identifier && regexp.test(node.callee.property.name);
-    }
-    return false;
-  });
+  switch (true) {
+    case node.callee.type === AST.Identifier:
+      return node.callee.name === "useState"
+        || additionalStateHooks.test(node.callee.name);
+    case node.callee.type === AST.MemberExpression
+      && node.callee.property.type === AST.Identifier:
+      return ast.getPropertyName(node.callee.property) === "useState"
+        || additionalStateHooks.test(node.callee.property.name);
+  }
+  return false;
 }
 
 // Utility functions for specific React hooks - each returns a function that checks if a node calls that specific hook

--- a/packages/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.spec.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import tsx from "dedent";
 
+import type { ESLintReactSettings } from "@eslint-react/shared";
 import { ruleTester } from "../../../../../../test";
 import rule, { RULE_NAME } from "./use-state";
 
@@ -11,6 +12,28 @@ ruleTester.run(RULE_NAME, rule, {
       code: tsx`
         function Component() {
           useState(0);
+
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "invalidAssignment" }],
+    },
+    {
+      code: tsx`
+        function Component() {
+          React.useState(0);
+
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "invalidAssignment" }],
+    },
+    {
+      code: tsx`
+        import React from "react";
+
+        function Component() {
+          React.useState(0);
 
           return <div />;
         }
@@ -265,6 +288,21 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    {
+      code: tsx`
+        function Component() {
+          const prev = usePreviousState(0);
+
+          return <div />;
+        }
+      `,
+      settings: {
+        "react-x": {
+          additionalStateHooks: "/^usePreviousState$/u",
+        },
+      },
+      errors: [{ messageId: "invalidAssignment" }],
+    },
   ],
   valid: [
     // --- Assignment / setter naming ---
@@ -393,5 +431,29 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    {
+      code: tsx`
+        function Component() {
+          usePreviousState(0);
+
+          return <div />;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+        const prev = usePreviousState(0);
+
+          return <div />;
+        }
+      `,
+    },
   ],
 });
+
+declare module "@typescript-eslint/utils/ts-eslint" {
+  export interface SharedConfigurationSettings {
+    ["react-x"]?: Partial<ESLintReactSettings>;
+  }
+}


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
