### PR TITLE
fix: traverse type expressions in component id, init path, and wrappe…

### DIFF
--- a/packages/core/docs/variables/ComponentDetectionHint.md
+++ b/packages/core/docs/variables/ComponentDetectionHint.md
@@ -4,6 +4,7 @@
 
 ```ts
 ComponentDetectionHint: {
+  DoNotIncludeFunctionDefinedAsArbitraryCallExpressionCallback: bigint;
   DoNotIncludeFunctionDefinedAsArrayFlatMapCallback: bigint;
   DoNotIncludeFunctionDefinedAsArrayMapCallback: bigint;
   DoNotIncludeFunctionDefinedInArrayExpression: bigint;
@@ -32,6 +33,7 @@ Hints for component collector
 
 | Name | Type | Default value |
 | ------ | ------ | ------ |
+| <a id="property-donotincludefunctiondefinedasarbitrarycallexpressioncallback"></a> `DoNotIncludeFunctionDefinedAsArbitraryCallExpressionCallback` | `bigint` | - |
 | <a id="property-donotincludefunctiondefinedasarrayflatmapcallback"></a> `DoNotIncludeFunctionDefinedAsArrayFlatMapCallback` | `bigint` | - |
 | <a id="property-donotincludefunctiondefinedasarraymapcallback"></a> `DoNotIncludeFunctionDefinedAsArrayMapCallback` | `bigint` | - |
 | <a id="property-donotincludefunctiondefinedinarrayexpression"></a> `DoNotIncludeFunctionDefinedInArrayExpression` | `bigint` | - |

--- a/packages/core/src/component/component-detection.ts
+++ b/packages/core/src/component/component-detection.ts
@@ -5,7 +5,6 @@ import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { isCreateElementCall } from "../api";
 import { JsxDetectionHint } from "../jsx";
 import { isRenderMethodCallback } from "./component-detection-legacy";
-import { getFunctionComponentId } from "./component-id";
 import { isFunctionWithLooseComponentName } from "./component-name";
 import { isComponentWrapperCallLoose } from "./component-wrapper";
 
@@ -68,48 +67,52 @@ export function isComponentDefinition(context: RuleContext, node: ast.TSESTreeFu
       return false;
   }
 
-  // 3. Apply contextual exclusions via hints
+  // 3. Traverse up to find the non-type expression parent
+  let parent = node.parent;
+  while (ast.isTypeExpression(parent)) parent = parent.parent;
+
+  // 4. Apply contextual exclusions via hints
   switch (true) {
     case ast.isOneOf([AST.ArrowFunctionExpression, AST.FunctionExpression])(node)
-      && node.parent.type === AST.Property
-      && node.parent.parent.type === AST.ObjectExpression:
+      && parent.type === AST.Property
+      && parent.parent.type === AST.ObjectExpression:
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedOnObjectMethod) return false;
       break;
     case ast.isOneOf([AST.ArrowFunctionExpression, AST.FunctionExpression])(node)
-      && node.parent.type === AST.MethodDefinition:
+      && parent.type === AST.MethodDefinition:
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedOnClassMethod) return false;
       break;
     case ast.isOneOf([AST.ArrowFunctionExpression, AST.FunctionExpression])(node)
-      && node.parent.type === AST.Property:
+      && parent.type === AST.Property:
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedOnClassProperty) return false;
       break;
-    case node.parent.type === AST.ArrayPattern:
+    case parent.type === AST.ArrayPattern:
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedInArrayPattern) return false;
       break;
-    case node.parent.type === AST.ArrayExpression:
+    case parent.type === AST.ArrayExpression:
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedInArrayExpression) return false;
       break;
-    case node.parent.type === AST.CallExpression
-      && node.parent.callee.type === AST.MemberExpression
-      && node.parent.callee.property.type === AST.Identifier
-      && node.parent.callee.property.name === "map":
+    case parent.type === AST.CallExpression
+      && parent.callee.type === AST.MemberExpression
+      && parent.callee.property.type === AST.Identifier
+      && parent.callee.property.name === "map":
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedAsArrayMapCallback) return false;
       break;
-    case node.parent.type === AST.CallExpression
-      && node.parent.callee.type === AST.MemberExpression
-      && node.parent.callee.property.type === AST.Identifier
-      && node.parent.callee.property.name === "flatMap":
+    case parent.type === AST.CallExpression
+      && parent.callee.type === AST.MemberExpression
+      && parent.callee.property.type === AST.Identifier
+      && parent.callee.property.name === "flatMap":
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedAsArrayFlatMapCallback) return false;
       break;
-    case getFunctionComponentId(context, node) == null
-      && node.parent.type === AST.CallExpression
-      && !isComponentWrapperCallLoose(context, node.parent)
-      && !isCreateElementCall(context, node.parent):
+    case parent.type === AST.CallExpression
+      && ast.getFunctionId(node) == null
+      && !isComponentWrapperCallLoose(context, parent)
+      && !isCreateElementCall(context, parent):
       if (hint & ComponentDetectionHint.DoNotIncludeFunctionDefinedAsArbitraryCallExpressionCallback) return false;
       break;
   }
 
-  // 4. Exclude inline JSX callbacks (event handlers, render props)
+  // 5. Exclude inline JSX callbacks (event handlers, render props)
   const significantParent = ast.findParentNode(
     node,
     ast.isOneOf([

--- a/packages/core/src/component/component-id.ts
+++ b/packages/core/src/component/component-id.ts
@@ -18,7 +18,9 @@ export function getFunctionComponentId(
   if (functionId != null) {
     return functionId;
   }
-  const { parent } = node;
+  // Traverse up through type expressions (as, satisfies, !, etc.)
+  let parent = node.parent;
+  while (ast.isTypeExpression(parent)) parent = parent.parent;
   // Get function component identifier from `const Component = memo(() => {});`
   if (
     parent.type === AST.CallExpression

--- a/packages/core/src/component/component-wrapper.ts
+++ b/packages/core/src/component/component-wrapper.ts
@@ -36,7 +36,8 @@ export function isComponentWrapperCallLoose(context: RuleContext, node: TSESTree
  */
 export function isComponentWrapperCallback(context: RuleContext, node: TSESTree.Node) {
   if (!ast.isFunction(node)) return false;
-  const parent = node.parent;
+  let parent = node.parent;
+  while (ast.isTypeExpression(parent)) parent = parent.parent;
   if (parent.type !== AST.CallExpression) return false;
   return isComponentWrapperCall(context, parent);
 }
@@ -49,7 +50,8 @@ export function isComponentWrapperCallback(context: RuleContext, node: TSESTree.
  */
 export function isComponentWrapperCallbackLoose(context: RuleContext, node: TSESTree.Node) {
   if (!ast.isFunction(node)) return false;
-  const parent = node.parent;
+  let parent = node.parent;
+  while (ast.isTypeExpression(parent)) parent = parent.parent;
   if (parent.type !== AST.CallExpression) return false;
   return isComponentWrapperCallLoose(context, parent);
 }

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.spec.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.spec.ts
@@ -1767,6 +1767,173 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    // --------------------------------------------------------------------------
+    // Tests for type expression parent traversal (component-detection.ts L70-72)
+    // `while (ast.isTypeExpression(parent)) parent = parent.parent;`
+    // Ensures that TSAsExpression, TSSatisfiesExpression, TSNonNullExpression,
+    // TSTypeAssertion, and TSInstantiationExpression are traversed through
+    // so that contextual exclusion hints in step 4 still apply correctly.
+    // --------------------------------------------------------------------------
+    {
+      // Function component assigned via `as` type assertion
+      code: tsx`
+        const App = (() => {
+          return <div />;
+        }) as React.FC;
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 0,
+            memo: false,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      // Function component assigned via `satisfies`
+      code: tsx`
+        const App = (() => {
+          return <div />;
+        }) satisfies React.FC;
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 0,
+            memo: false,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      // Function component assigned via `as ... satisfies ...` chained
+      code: tsx`
+        const App = (() => {
+          return <div />;
+        }) as React.FC satisfies React.FC;
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 0,
+            memo: false,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      // Function component with TSNonNullExpression then `as`
+      code: tsx`
+        const App = (() => {
+          return <div />;
+        })! as React.FC;
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 0,
+            memo: false,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      // Function component inside React.memo wrapped in `as`
+      code: tsx`
+        const App = React.memo((() => {
+          return <div />;
+        }) as React.FC);
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 0,
+            memo: true,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      // Function component inside React.memo wrapped in `satisfies`
+      code: tsx`
+        const App = React.memo((() => {
+          return <div />;
+        }) satisfies React.FC);
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 0,
+            memo: true,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      // Function component inside React.memo wrapped in TSNonNullExpression + `as` + `satisfies`
+      code: tsx`
+        const App = React.memo((() => {
+          return <div />;
+        })! as React.FC satisfies React.FC);
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: false,
+            hookCalls: 0,
+            memo: true,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      // Function component inside React.forwardRef wrapped in `as`
+      code: tsx`
+        const App = React.forwardRef((() => {
+          return <div />;
+        }) as React.FC);
+      `,
+      errors: [{
+        data: {
+          json: stringify({
+            name: "App",
+            displayName: "none",
+            forwardRef: true,
+            hookCalls: 0,
+            memo: false,
+          }),
+        },
+        messageId: "default",
+      }],
+    },
   ],
   valid: [
     tsx`
@@ -1813,5 +1980,28 @@ ruleTester.run(RULE_NAME, rule, {
         return null;
       }) as ActionFUnction satisfies ActionFUnction;
     `,
+    // --------------------------------------------------------------------------
+    // Tests for type expression parent traversal (component-detection.ts L70-72)
+    // Ensures contextual exclusions correctly apply through type expression wrappers
+    // --------------------------------------------------------------------------
+    // Anonymous function in arbitrary call expression wrapped in `as` — excluded by
+    // DoNotIncludeFunctionDefinedAsArbitraryCallExpressionCallback
+    "someFunction((() => null) as any)",
+    "someFunction((() => null) satisfies any)",
+    "someFunction((() => null)! as any satisfies any)",
+    // Anonymous function in .map() wrapped in type expressions — excluded by
+    // DoNotIncludeFunctionDefinedAsArrayMapCallback
+    "items.map((() => <div />) as any)",
+    "items.map((() => <div />) satisfies any)",
+    "items.map((() => <div />)! as any)",
+    // Anonymous function in .flatMap() wrapped in type expressions — excluded by
+    // DoNotIncludeFunctionDefinedAsArrayFlatMapCallback
+    "items.flatMap((() => <div />) as any)",
+    "items.flatMap((() => <div />) satisfies any)",
+    // Anonymous function in array expression wrapped in type expressions — excluded by
+    // DoNotIncludeFunctionDefinedInArrayExpression
+    "[(() => <div />) as any]",
+    "[(() => <div />) satisfies any]",
+    "[(() => <div />)! as any satisfies any]",
   ],
 });

--- a/packages/utilities/ast/src/function-init-path.ts
+++ b/packages/utilities/ast/src/function-init-path.ts
@@ -1,6 +1,7 @@
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
+import { isTypeExpression } from "./node-is";
 import type { TSESTreeFunction } from "./node-types";
 
 /**
@@ -86,7 +87,9 @@ export function getFunctionInitPath(node: TSESTreeFunction): null | FunctionInit
     return [node] as const;
   }
 
-  const { parent } = node;
+  // Traverse up through type expressions (as, satisfies, !, etc.) to find the semantic parent
+  let parent: TSESTree.Node = node.parent;
+  while (isTypeExpression(parent)) parent = parent.parent;
 
   // Match against various component patterns
   switch (true) {


### PR DESCRIPTION
…r detection

`getFunctionComponentId`, `getFunctionInitPath`, `isComponentWrapperCallback`, and `isComponentWrapperCallbackLoose` now skip through TSAsExpression, TSSatisfiesExpression, TSNonNullExpression, etc. when resolving the semantic parent, consistent with the existing traversal in `isComponentDefinition`. This fixes detection of memo/forwardRef flags and component names for patterns like `React.memo((() => <div />) as React.FC)`.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
