### PR TITLE
feat(eslint-plugin-react-x): implement noDuplicateProps check in unstable-rules-of-props, closes #1605

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.mdx
@@ -33,11 +33,60 @@ react-x/unstable-rules-of-props
 
 ## Rule Details
 
-This rule covers three concerns:
+This rule covers two concerns:
 
-1. Using conflicting prop combinations.
+1. No duplicate props on a JSX element.
+2. Using conflicting prop combinations (controlled and uncontrolled props together).
 
 ## Common Violations
+
+### Specifying the Same Prop More Than Once
+
+When the same prop appears multiple times on a JSX element, only the last occurrence takes effect. The earlier values are silently discarded, which is almost always a mistake — typically a copy-paste error or a merge conflict leftover.
+
+Spread props are ignored because it may be intentional to override a prop from the spread with an explicit prop.
+
+#### Invalid
+
+```tsx
+// ❌ 'id' is specified twice — only the last value takes effect.
+<div id="a" id="b" />;
+```
+
+```tsx
+// ❌ Duplicate props on a custom component.
+<MyComponent foo="a" foo="b" />;
+```
+
+```tsx
+// ❌ Duplicate boolean props.
+<input disabled disabled />;
+```
+
+```tsx
+// ❌ Duplicate event handlers.
+<div onClick={handleA} onClick={handleB} />;
+```
+
+#### Valid
+
+```tsx
+// ✅ All props are unique.
+<div id="a" className="b" />;
+```
+
+```tsx
+// ✅ Spread attributes are ignored.
+<div id="a" {...props} />;
+```
+
+```tsx
+// ✅ Same prop on different elements is fine.
+<div>
+  <span id="a" />
+  <span id="b" />
+</div>;
+```
 
 ### Using Controlled and Uncontrolled Props Together
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.spec.ts
@@ -5,6 +5,61 @@ import rule, { RULE_NAME } from "./unstable-rules-of-props";
 
 ruleTester.run(RULE_NAME, rule, {
   invalid: [
+    // ── noDuplicateProps ────────────────────────────────────────────────
+    {
+      code: tsx`<div id="a" id="b" />;`,
+      errors: [{ messageId: "noDuplicateProps" }],
+    },
+    {
+      code: tsx`<div id="a" className="x" id="b" />;`,
+      errors: [{ messageId: "noDuplicateProps" }],
+    },
+    {
+      // Triple duplicate – two reports (second and third occurrences)
+      code: tsx`<div id="a" id="b" id="c" />;`,
+      errors: [
+        { messageId: "noDuplicateProps" },
+        { messageId: "noDuplicateProps" },
+      ],
+    },
+    {
+      // Two different props each duplicated
+      code: tsx`<div id="a" className="x" id="b" className="y" />;`,
+      errors: [
+        { messageId: "noDuplicateProps" },
+        { messageId: "noDuplicateProps" },
+      ],
+    },
+    {
+      // Duplicate on a custom component
+      code: tsx`<MyComponent foo="a" foo="b" />;`,
+      errors: [{ messageId: "noDuplicateProps" }],
+    },
+    {
+      // Duplicate boolean props
+      code: tsx`<input disabled disabled />;`,
+      errors: [{ messageId: "noDuplicateProps" }],
+    },
+    {
+      // Duplicate expression props
+      code: tsx`<div onClick={handleA} onClick={handleB} />;`,
+      errors: [{ messageId: "noDuplicateProps" }],
+    },
+    {
+      // Duplicate namespaced props
+      code: tsx`<div on:click={handleA} on:click={handleB} />;`,
+      errors: [{ messageId: "noDuplicateProps" }],
+    },
+    {
+      // Duplicate prop combined with controlled/uncontrolled violation
+      code: tsx`<input value="a" value="b" defaultValue="c" />;`,
+      errors: [
+        { messageId: "noDuplicateProps" },
+        { messageId: "noControlledAndUncontrolledTogether" },
+      ],
+    },
+
+    // ── noControlledAndUncontrolledTogether ──────────────────────────────
     {
       code: tsx`<input value="hello" defaultValue="world" />;`,
       errors: [{ messageId: "noControlledAndUncontrolledTogether" }],
@@ -75,6 +130,26 @@ ruleTester.run(RULE_NAME, rule, {
     },
   ],
   valid: [
+    // ── noDuplicateProps (valid) ────────────────────────────────────────
+    // No duplicates — all unique props
+    tsx`<div id="a" className="b" />;`,
+    tsx`<MyComponent foo="a" bar="b" baz="c" />;`,
+
+    // Spread attributes are ignored — can't statically determine contents
+    tsx`<div id="a" {...props} />;`,
+
+    // Same prop name on different elements is fine
+    tsx`
+      <div>
+        <span id="a" />
+        <span id="b" />
+      </div>;
+    `,
+
+    // Namespaced props that are not duplicated
+    tsx`<div on:click={handleA} on:focus={handleB} />;`,
+
+    // ── noControlledAndUncontrolledTogether (valid) ──────────────────────
     // Controlled inputs
     tsx`<input value="hello" />;`,
     tsx`<input value={name} onChange={(e) => setName(e.target.value)} />;`,

--- a/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/unstable-rules-of-props/unstable-rules-of-props.ts
@@ -10,7 +10,9 @@ export const RULE_FEATURES = [
   "EXP",
 ] as const satisfies RuleFeature[];
 
-export type MessageID = "noControlledAndUncontrolledTogether";
+export type MessageID =
+  | "noDuplicateProps"
+  | "noControlledAndUncontrolledTogether";
 
 export default createRule<[], MessageID>({
   meta: {
@@ -19,6 +21,7 @@ export default createRule<[], MessageID>({
       description: "Enforces the Rules of Props.",
     },
     messages: {
+      noDuplicateProps: "Prop `{{prop}}` is specified more than once. Only the last one will take effect.",
       noControlledAndUncontrolledTogether:
         "Prop `{{controlled}}` and `{{uncontrolled}}` should not be used together. Use either controlled or uncontrolled components, not both.",
     },
@@ -36,6 +39,14 @@ function toControlledName(uncontrolledName: string): string | null {
   return head.toLowerCase() + tail;
 }
 
+function getPropName(attribute: TSESTree.JSXAttribute): string {
+  const { name: nameNode } = attribute;
+  if (nameNode.type === AST.JSXNamespacedName) {
+    return `${nameNode.namespace.name}:${nameNode.name.name}`;
+  }
+  return nameNode.name;
+}
+
 export function create(context: RuleContext<MessageID, []>) {
   return defineRuleListener({
     JSXOpeningElement(node: TSESTree.JSXOpeningElement) {
@@ -44,15 +55,25 @@ export function create(context: RuleContext<MessageID, []>) {
       for (const attribute of node.attributes) {
         if (attribute.type === AST.JSXSpreadAttribute) continue;
 
-        const { name: identifier } = attribute.name;
-        // Skip namespaced names.
-        if (typeof identifier !== "string") continue;
+        const propName = getPropName(attribute);
 
-        attributes.set(identifier, attribute);
+        // Report duplicate props.
+        if (attributes.has(propName)) {
+          context.report({
+            data: { prop: propName },
+            messageId: "noDuplicateProps",
+            node: attribute,
+          });
+        }
+
+        attributes.set(propName, attribute);
       }
 
       // Report when both controlled and uncontrolled forms coexist.
       for (const [propName, attrNode] of attributes) {
+        // Skip namespaced names for the controlled/uncontrolled check.
+        if (propName.includes(":")) continue;
+
         const controlledProp = toControlledName(propName);
         if (controlledProp == null) continue;
 


### PR DESCRIPTION
- Detect duplicate JSX attributes on the same element, including namespaced names
- Report on each repeated occurrence (second, third, etc.)
- Add getPropName helper to unify prop name extraction for both simple and namespaced attributes
- Add 9 invalid and 5 valid test cases for duplicate prop detection
- Update documentation with new "Specifying the Same Prop More Than Once" section

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
