### PR TITLE
docs: fix additionalHooks regex examples, closes #1627

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps/exhaustive-deps.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps/exhaustive-deps.mdx
@@ -233,7 +233,7 @@ Custom effect hooks can also be configured via shared ESLint settings, which app
 {
   "settings": {
     "react-x": {
-      "additionalEffectHooks": "(useMyEffect|useCustomEffect)"
+      "additionalEffectHooks": "/^(useMyEffect|useCustomEffect)$/u"
     }
   }
 }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks/rules-of-hooks.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks/rules-of-hooks.mdx
@@ -226,7 +226,7 @@ Custom effect hooks can also be configured via shared ESLint settings, which app
 {
   "settings": {
     "react-x": {
-      "additionalEffectHooks": "(useMyEffect|useCustomEffect)"
+      "additionalEffectHooks": "/^(useMyEffect|useCustomEffect)$/u"
     }
   }
 }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.mdx
@@ -318,8 +318,8 @@ Custom state and effect hooks can also be configured via shared ESLint settings,
 {
   "settings": {
     "react-x": {
-      "additionalStateHooks": "(useMyState|useCustomState)",
-      "additionalEffectHooks": "(useMyEffect|useCustomEffect)"
+      "additionalStateHooks": "/^(useMyState|useCustomState)$/u",
+      "additionalEffectHooks": "/^(useMyEffect|useCustomEffect)$/u",
     }
   }
 }

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
@@ -73,7 +73,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
       settings: {
         "react-x": {
-          additionalStateHooks: "/^(useSta1|useSta2)$/",
+          additionalStateHooks: "/^(useSta1|useSta2)$/u",
         },
       },
     },

--- a/packages/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.mdx
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.mdx
@@ -210,7 +210,7 @@ Custom state hooks can also be configured via shared ESLint settings, which appl
 {
   "settings": {
     "react-x": {
-      "additionalStateHooks": "(useMyState|useCustomState)"
+      "additionalStateHooks": "/^(useMyState|useCustomState)$/u"
     }
   }
 }


### PR DESCRIPTION
Update all docs and test examples for `additionalStateHooks` and `additionalEffectHooks` settings to use the correct regex literal format with anchors and the `u` flag (e.g. `/^(useMyEffect|useCustomEffect)$/u`) instead of bare group patterns without delimiters.

Affected rules: exhaustive-deps, rules-of-hooks, set-state-in-effect, use-state. Also fix the test fixture in set-state-in-effect.spec.ts to match.

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [x] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
