### PR TITLE
refactor(eff): replace getOrElse/getOrElseUpdate to getOrInsert/getOrInsertComputed

### DIFF
--- a/.pkgs/eff/src/index.ts
+++ b/.pkgs/eff/src/index.ts
@@ -1216,20 +1216,21 @@ export function flow(
 // #region Map & Set
 
 /**
- * Retrieves a value from a Map or WeakMap if the key exists, or computes a new value if it doesn't.
+ * Retrieves a value from a Map or WeakMap if the key exists, or inserts and returns a default value if it doesn't.
  *
- * @param map - The Map or WeakMap to get from.
+ * @param map - The Map or WeakMap to get from or update.
  * @param key - The key to look up in the Map or WeakMap.
- * @param callback - The function to call to generate a new value if the key doesn't exist.
- * @returns The existing value for the key, or the computed fallback value.
+ * @param defaultValue - The value to insert and return if the key is not present.
+ * @returns The existing value for the key, or the inserted default value.
  */
-export function getOrElse<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, callback: () => V): V;
-export function getOrElse<K, V>(map: Map<K, V>, key: K, callback: () => V): V;
-export function getOrElse<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, callback: () => V): V {
+export function getOrInsert<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, defaultValue: V): V;
+export function getOrInsert<K, V>(map: Map<K, V>, key: K, defaultValue: V): V;
+export function getOrInsert<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, defaultValue: V): V {
   if (map.has(key)) {
     return map.get(key)!;
   }
-  return callback();
+  map.set(key, defaultValue);
+  return defaultValue;
 }
 
 /**
@@ -1237,33 +1238,18 @@ export function getOrElse<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, call
  *
  * @param map - The Map or WeakMap to get from or update.
  * @param key - The key to look up in the Map or WeakMap.
- * @param callback - The function to call to generate a new value if the key doesn't exist.
+ * @param callback - A function that returns the value to insert if the key is not present. Called with the key as argument.
  * @returns The existing value for the key, or the newly computed value.
  */
-export function getOrElseUpdate<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, callback: () => V): V;
-export function getOrElseUpdate<K, V>(map: Map<K, V>, key: K, callback: () => V): V;
-export function getOrElseUpdate<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, callback: () => V): V {
+export function getOrInsertComputed<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, callback: (key: K) => V): V;
+export function getOrInsertComputed<K, V>(map: Map<K, V>, key: K, callback: (key: K) => V): V;
+export function getOrInsertComputed<K extends WeakKey, V>(map: WeakMap<K, V>, key: K, callback: (key: K) => V): V {
   if (map.has(key)) {
     return map.get(key)!;
   }
-  const value = callback();
+  const value = callback(key);
   map.set(key, value);
   return value;
-}
-
-/**
- * Attempts to add a value to a Set, but only if it doesn't already exist.
- *
- * @param set - The Set to potentially add to.
- * @param value - The value to add if it doesn't already exist in the Set.
- * @returns `true` if the value was added, `false` if it already existed.
- */
-export function tryAddToSet<T>(set: Set<T>, value: T): boolean {
-  if (!set.has(value)) {
-    set.add(value);
-    return true;
-  }
-  return false;
 }
 
 // #endregion

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.ts
@@ -4,7 +4,7 @@ import { getElementFullType } from "@eslint-react/jsx";
 import type { RuleContext, RuleFeature } from "@eslint-react/shared";
 import { defineRuleListener, getSettingsFromContext } from "@eslint-react/shared";
 import { type ObjectType, computeObjectType } from "@eslint-react/var";
-import { getOrElseUpdate } from "@local/eff";
+import { getOrInsertComputed } from "@local/eff";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
 
@@ -68,7 +68,7 @@ export function create(context: RuleContext<MessageID, []>) {
         if (core.isHookCall(construction.node)) {
           return;
         }
-        getOrElseUpdate(constructions, enclosingFunction, () => []).push(construction);
+        getOrInsertComputed(constructions, enclosingFunction, () => []).push(construction);
       },
       "Program:exit"(program) {
         for (const { directives, node: component } of api.getAllComponents(program)) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
@@ -8,7 +8,7 @@ import {
   toRegExp,
 } from "@eslint-react/shared";
 import { computeObjectType } from "@eslint-react/var";
-import { getOrElseUpdate } from "@local/eff";
+import { getOrInsertComputed } from "@local/eff";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
@@ -90,7 +90,7 @@ export function create(context: RuleContext<MessageID, Options>, [options]: Opti
     [ast.SEL_OBJECT_DESTRUCTURING_VARIABLE_DECLARATOR](node: ast.ObjectDestructuringVariableDeclarator) {
       const enclosingFunction = ast.findParent(node, ast.isFunction);
       if (enclosingFunction == null) return;
-      getOrElseUpdate(declarators, enclosingFunction, () => []).push(node);
+      getOrInsertComputed(declarators, enclosingFunction, () => []).push(node);
     },
     "Program:exit"(program) {
       for (const { node: component } of api.getAllComponents(program)) {

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -3,7 +3,7 @@ import * as core from "@eslint-react/core";
 import { isUseRefCall } from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener, getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
-import { constVoid, getOrElseUpdate, not } from "@local/eff";
+import { constVoid, getOrInsertComputed, not } from "@local/eff";
 import type { Scope } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import type { TSESTree } from "@typescript-eslint/utils";
@@ -294,8 +294,8 @@ export function create(context: RuleContext<MessageID, []>) {
               }
               default: {
                 const init = ast.findParent(node, isHookDecl)?.init;
-                if (init == null) getOrElseUpdate(setStateCallsByFn, entry.node, () => []).push(node);
-                else getOrElseUpdate(setStateInHookCallbacks, init, () => []).push(node);
+                if (init == null) getOrInsertComputed(setStateCallsByFn, entry.node, () => []).push(node);
+                else getOrInsertComputed(setStateInHookCallbacks, init, () => []).push(node);
               }
             }
           })
@@ -330,7 +330,7 @@ export function create(context: RuleContext<MessageID, []>) {
             }
             const init = ast.findParent(parent, isHookDecl)?.init;
             if (init != null) {
-              getOrElseUpdate(setStateInEffectArg, init, () => []).push(node);
+              getOrInsertComputed(setStateInEffectArg, init, () => []).push(node);
             }
             break;
           }
@@ -344,14 +344,14 @@ export function create(context: RuleContext<MessageID, []>) {
             if (core.isUseCallbackCall(node.parent)) {
               const init = ast.findParent(node.parent, isHookDecl)?.init;
               if (init != null) {
-                getOrElseUpdate(setStateInEffectArg, init, () => []).push(node);
+                getOrInsertComputed(setStateInEffectArg, init, () => []).push(node);
               }
               break;
             }
             // const [state, setState] = useState();
             // useEffect(setState);
             if (isUseEffectCall(node.parent)) {
-              getOrElseUpdate(setStateInEffectSetup, node.parent, () => []).push(node);
+              getOrInsertComputed(setStateInEffectSetup, node.parent, () => []).push(node);
             }
           }
         }

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -1,6 +1,6 @@
 /* eslint-disable perfectionist/sort-interfaces */
 /* eslint-disable perfectionist/sort-objects */
-import { getOrElseUpdate, identity } from "@local/eff";
+import { getOrInsertComputed, identity } from "@local/eff";
 import type { ESLint, SharedConfigurationSettings } from "@typescript-eslint/utils/ts-eslint";
 
 import { P, match } from "ts-pattern";
@@ -135,7 +135,7 @@ const cache = new Map<unknown, ESLintReactSettingsNormalized>();
 
 export function getSettingsFromContext(context: RuleContext): ESLintReactSettingsNormalized {
   const settings = context.settings;
-  return getOrElseUpdate(
+  return getOrInsertComputed(
     cache,
     settings["react-x"],
     () => normalizeSettings(decodeSettings(settings["react-x"])),

--- a/packages/utilities/kit/docs/interfaces/Builder.md
+++ b/packages/utilities/kit/docs/interfaces/Builder.md
@@ -7,7 +7,7 @@
 ### getConfig()
 
 ```ts
-getConfig(args?: {
+getConfig(options?: {
   files?: string[];
 }): Config;
 ```
@@ -16,8 +16,8 @@ getConfig(args?: {
 
 | Parameter | Type |
 | ------ | ------ |
-| `args?` | \{ `files?`: `string`[]; \} |
-| `args.files?` | `string`[] |
+| `options?` | \{ `files?`: `string`[]; \} |
+| `options.files?` | `string`[] |
 
 #### Returns
 


### PR DESCRIPTION
- Replace getOrElse → getOrInsert for semantic clarity
- Replace getOrElseUpdate → getOrInsertComputed
- Update callback signature to receive key as argument
- Remove unused tryAddToSet utility
- Update all consumers in eslint-plugin-react-x and shared packages

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
