### PR TITLE
feat(kit)!: remove files option from getConfig() and normalize file extensions

### DIFF
--- a/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
+++ b/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
@@ -183,7 +183,7 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   // Start with the eslint-plugin-react
   {
-    files: ["**/*.{js,mjs,cjs,jsx,mjsx,ts,mts,tsx,mtsx}"],
+    files: ["**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"],
     extends: [
       // Whatever config you had enabled with eslint-plugin-react
       pluginReact.configs.flat.recommended,
@@ -206,7 +206,7 @@ import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   {
-    files: ["**/*.{js,mjs,cjs,jsx,mjsx,ts,mts,tsx,mtsx}"],
+    files: ["**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"],
     extends: [
       eslintReact.configs["recommended-typescript"],
     ],

--- a/apps/website/content/docs/utilities/kit.mdx
+++ b/apps/website/content/docs/utilities/kit.mdx
@@ -110,7 +110,7 @@ function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
 ```ts
 interface Builder {
   use<F extends (...args: any[]) => RuleDefinition>(factory: F, ...args: Parameters<F>): Builder;
-  getConfig(options?: { files?: string[] }): Linter.Config;
+  getConfig(): Linter.Config;
   getPlugin(): ESLint.Plugin;
 }
 ```

--- a/examples/react-dom-with-custom-rules/eslint.config.ts
+++ b/examples/react-dom-with-custom-rules/eslint.config.ts
@@ -80,36 +80,39 @@ export default defineConfig(
       eslintPluginReactHooks.configs.flat["recommended-latest"] ?? [],
       eslintPluginReactRefresh.configs.recommended,
       eslintReact.configs["strict-type-checked"],
-      eslintReactKit()
-        .use(checkedRequiresOnchangeOrReadonly)
-        .use(componentHookFactories)
-        .use(forbidComponentProps, { forbidden: ["className", "style"] })
-        // .use(forbidDomProps, { forbidden: ["style", "className"] })
-        .use(forbidElements, {
-          forbidden: new Map(
-            [
-              ["button", "Use <Button> from '@/components/ui' instead."],
-              ["input", "Use <Input> from '@/components/ui' instead."],
-            ],
-          ),
-        })
-        .use(functionComponentDefinition)
-        .use(jsxBooleanValue)
-        .use(jsxFragments)
-        .use(jsxHandlerNames, { eventHandlerPrefix: "handle", eventHandlerPropPrefix: "on" })
-        .use(jsxMaxDepth, { max: 4 })
-        .use(jsxNoBind)
-        .use(jsxNoDuplicateProps)
-        // .use(jsxNoLiterals, { noStrings: false })
-        .use(jsxPascalCase)
-        .use(jsxPropsNoSpreadMulti)
-        .use(jsxPropsNoSpreading)
-        .use(maxComponentPerFile, { max: 100 })
-        .use(noAdjacentInlineElements)
-        .use(noMultiComp)
-        .use(noUnnecessaryUsePrefix)
-        .use(version, "19")
-        .getConfig({ files: TSCONFIG_APP.include }),
+      {
+        ...eslintReactKit()
+          .use(checkedRequiresOnchangeOrReadonly)
+          .use(componentHookFactories)
+          .use(forbidComponentProps, { forbidden: ["className", "style"] })
+          // .use(forbidDomProps, { forbidden: ["style", "className"] })
+          .use(forbidElements, {
+            forbidden: new Map(
+              [
+                ["button", "Use <Button> from '@/components/ui' instead."],
+                ["input", "Use <Input> from '@/components/ui' instead."],
+              ],
+            ),
+          })
+          .use(functionComponentDefinition)
+          .use(jsxBooleanValue)
+          .use(jsxFragments)
+          .use(jsxHandlerNames, { eventHandlerPrefix: "handle", eventHandlerPropPrefix: "on" })
+          .use(jsxMaxDepth, { max: 4 })
+          .use(jsxNoBind)
+          .use(jsxNoDuplicateProps)
+          // .use(jsxNoLiterals, { noStrings: false })
+          .use(jsxPascalCase)
+          .use(jsxPropsNoSpreadMulti)
+          .use(jsxPropsNoSpreading)
+          .use(maxComponentPerFile, { max: 100 })
+          .use(noAdjacentInlineElements)
+          .use(noMultiComp)
+          .use(noUnnecessaryUsePrefix)
+          .use(version, "19")
+          .getConfig(),
+        files: TSCONFIG_APP.include,
+      },
     ],
   },
 );

--- a/packages/utilities/kit/README.md
+++ b/packages/utilities/kit/README.md
@@ -123,7 +123,7 @@ function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
 ```ts
 interface Builder {
   use<F extends (...args: any[]) => RuleDefinition>(factory: F, ...args: Parameters<F>): Builder;
-  getConfig(options?: { files?: string[] }): Linter.Config;
+  getConfig(): Linter.Config;
   getPlugin(): ESLint.Plugin;
 }
 ```

--- a/packages/utilities/kit/docs/interfaces/Builder.md
+++ b/packages/utilities/kit/docs/interfaces/Builder.md
@@ -7,17 +7,8 @@
 ### getConfig()
 
 ```ts
-getConfig(options?: {
-  files?: string[];
-}): Config;
+getConfig(): Config;
 ```
-
-#### Parameters
-
-| Parameter | Type |
-| ------ | ------ |
-| `options?` | \{ `files?`: `string`[]; \} |
-| `options.files?` | `string`[] |
 
 #### Returns
 

--- a/packages/utilities/kit/src/index.ts
+++ b/packages/utilities/kit/src/index.ts
@@ -223,7 +223,7 @@ function makeRuleToolkit(context: RuleContext): RuleToolkit {
 export type RuleDefinition = (context: RuleContext, toolkit: RuleToolkit) => RuleListener;
 
 export interface Builder {
-  getConfig(options?: { files?: string[] }): Linter.Config;
+  getConfig(): Linter.Config;
   getPlugin(): ESLint.Plugin;
   use<F extends (...args: any[]) => RuleDefinition>(factory: F, ...args: Parameters<F>): Builder;
 }
@@ -232,9 +232,11 @@ export default function build(): Builder {
   const idGen = new IdGenerator();
   const rules: ESLint.Plugin["rules"] & {} = {};
   const builder: Builder = {
-    getConfig({ files = ["**/*.{js,mjs,cjs,jsx,mjsx,ts,mts,tsx,mtsx}"] } = {}): Linter.Config {
+    getConfig(): Linter.Config {
+      const name = pkg.name;
       return {
-        files,
+        name,
+        files: ["**/*.{js,jsx,cjs,mjs,ts,tsx,cts,mts}"],
         plugins: {
           [pkg.name]: builder.getPlugin(),
         },
@@ -245,8 +247,10 @@ export default function build(): Builder {
       };
     },
     getPlugin(): ESLint.Plugin {
+      const name = pkg.name;
+      const version = pkg.version;
       return {
-        meta: { name: pkg.name, version: pkg.version },
+        meta: { name, version },
         rules,
       };
     },


### PR DESCRIPTION
BREAKING CHANGE: `getConfig()` no longer accepts `{ files?: string[] }` options. Users should now specify files at the config array level instead.

Other changes:
- Added `cts` extension to default file patterns
- Removed `mjsx` and `mtsx` extensions
- Normalized extension order to: js,jsx,cjs,mjs,ts,tsx,cts,mts
- Added `name` field to returned config object
- Updated all documentation and examples accordingly

<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/Rel1cx/eslint-react/blob/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

<!-- Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers. -->

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

<!-- If yes, please describe the impact and migration path for existing applications in an attached issue. -->

- [x] Yes, and the changes were approved in issue #1243
- [ ] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
