### PR TITLE
fix(purity): treat new Date(arg) as pure, closes #1582

### DIFF
--- a/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.spec.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.spec.ts
@@ -1342,5 +1342,47 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    // -------------------------------------------------------------------------
+    // new Date(arg) with arguments is pure (deterministic)
+    // -------------------------------------------------------------------------
+    {
+      code: tsx`
+        function Component({ myDate }: { myDate: string }) {
+          return new Date(myDate) < new Date("2020-01-01") ? <span>one</span> : <span>two</span>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+          const date = new Date("2024-01-01");
+          return <div>{date.toISOString()}</div>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component({ timestamp }: { timestamp: number }) {
+          const date = new Date(timestamp);
+          return <div>{date.toISOString()}</div>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function useFormattedDate(input: string) {
+          const date = new Date(input);
+          return date.toLocaleDateString();
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component({ year, month, day }: { year: number; month: number; day: number }) {
+          const date = new Date(year, month, day);
+          return <div>{date.toISOString()}</div>;
+        }
+      `,
+    },
   ],
 });

--- a/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
@@ -78,6 +78,9 @@ export function create(context: RuleContext<MessageID, []>) {
         const expr = ast.getUnderlyingExpression(node.callee);
         if (expr.type !== AST.Identifier) return;
         if (!IMPURE_CTORS.has(expr.name)) return;
+        // `new Date(arg)` with arguments is pure (deterministic),
+        // only `new Date()` without arguments is impure (depends on current time).
+        if (expr.name === "Date" && node.arguments.length > 0) return;
         const func = ast.findParent(node, ast.isFunction);
         if (func == null) return;
         nEntries.push({ func, node });


### PR DESCRIPTION
`new Date(arg)` with arguments is deterministic (pure), only `new Date()` without arguments is impure (depends on current time).

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
