### PR TITLE
docs: standardize punctuation and phrasing in recipe docs

### DIFF
--- a/apps/website/content/docs/recipes/custom-rules-of-props.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-props.mdx
@@ -1,6 +1,6 @@
 ---
 title: custom-rules-of-props
-description: Custom rules for validating JSX props — duplicate props, mixing controlled/uncontrolled props, and explicit spread props.
+description: Custom rules for validating JSX props. Includes checks for duplicate props, mixing controlled and uncontrolled props, and explicit spread props.
 ---
 
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
@@ -9,9 +9,9 @@ import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 This recipe contains three custom rules for validating JSX props:
 
-1. **`noDuplicateProps`** — Reports when the same prop appears more than once on a JSX element.
-2. **`noExplicitSpreadProps`** — Reports when an object literal is spread onto a JSX element instead of writing each property as a separate prop. Includes auto-fix.
-3. **`noMixingControlledAndUncontrolledProps`** — Reports when both a controlled prop and its uncontrolled counterpart appear on the same element.
+1. **`noDuplicateProps`**: Reports duplicate props on a JSX element.
+2. **`noExplicitSpreadProps`**: Reports spreading object literals onto a JSX element instead of writing separate props. Includes auto-fix.
+3. **`noMixingControlledAndUncontrolledProps`**: Reports mixing a controlled prop and its uncontrolled counterpart on the same element.
 
 ## Rule Definitions
 
@@ -103,9 +103,9 @@ Copy the following into your project (e.g. `eslint.config.rules.ts`):
   </Tab>
 </Tabs>
 
-Reports when the same prop appears more than once on a JSX element. Only the last occurrence takes effect — earlier values are silently discarded. This is almost always a mistake, typically from copy-paste errors or merge conflict leftovers.
+Reports when a prop appears multiple times on a JSX element. Only the last occurrence takes effect, silently discarding earlier values. This is typically a copy-paste error or a merge conflict leftover.
 
-Spread attributes are intentionally ignored because overriding a spread prop with an explicit prop is a common and valid pattern.
+Spread attributes are ignored because overriding them with explicit props is a common and valid pattern.
 
 ### noExplicitSpreadProps
 
@@ -114,7 +114,7 @@ Spread attributes are intentionally ignored because overriding a spread prop wit
     ```ts title="eslint.config.rules.ts"
     import type { RuleDefinition } from "@eslint-react/kit";
 
-    /** Disallow spreading object literals in JSX — write each property as a separate prop. */
+    /** Disallow spreading object literals in JSX. Write each property as a separate prop. */
     export function noExplicitSpreadProps(): RuleDefinition {
       return (context) => ({
         JSXSpreadAttribute(node) {
@@ -170,9 +170,9 @@ Spread attributes are intentionally ignored because overriding a spread prop wit
   </Tab>
 </Tabs>
 
-Reports when an object literal is spread directly onto a JSX element. The spread is unnecessary — each property of the object can be written as a separate JSX attribute instead. This improves readability and makes it easier to see which props an element receives at a glance.
+Reports when an object literal is spread directly onto a JSX element. This is unnecessary. Writing each property as a separate JSX attribute improves readability and makes props visible at a glance.
 
-Only plain object literals are flagged. Conditional expressions, variables, and other non-literal spreads are left untouched because they serve a legitimate purpose (e.g. conditionally applying a group of props).
+Only plain object literals are flagged. Conditional expressions, variables, and other non-literal spreads serve legitimate purposes and remain untouched.
 
 ### noMixingControlledAndUncontrolledProps
 
@@ -260,7 +260,7 @@ Only plain object literals are flagged. Conditional expressions, variables, and 
   </Tab>
 </Tabs>
 
-Reports when both a controlled prop and its uncontrolled counterpart appear on the same JSX element. Mixing both modes is a mistake — React will silently ignore the `default*` prop and may emit a console warning, leading to confusing bugs.
+Reports when both a controlled prop and its uncontrolled counterpart appear on the same JSX element. Mixing modes is a mistake. React will silently ignore the `default*` prop and might emit a console warning, leading to confusing bugs.
 
 Only well-known React prop pairs are checked:
 
@@ -300,4 +300,4 @@ export default [
 ## See Also
 
 - [`custom-rules-of-state`](./custom-rules-of-state)\
-  Custom rules for validating state usage — prefer updater function form in useState setters.
+  Custom rules for validating state usage. Prefer the updater function form in useState setters.

--- a/apps/website/content/docs/recipes/custom-rules-of-state.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-state.mdx
@@ -1,13 +1,13 @@
 ---
 title: custom-rules-of-state
-description: Custom rules for validating state usage — prefer updater function form in useState setters.
+description: Custom rules for validating state usage. Prefer the updater function form in useState setters.
 ---
 
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 ## Overview
 
-This rule reports when a `useState` setter is called with an expression that directly references the corresponding state variable. Using the callback (updater function) form ensures the update is always based on the latest state value, avoiding stale-state bugs in closures, event handlers, and timeouts.
+Reports when a `useState` setter is called with an expression that directly references the corresponding state variable. Using the callback (updater function) form ensures the update uses the latest state value, avoiding stale-state bugs in closures, event handlers, and timeouts.
 
 ## Rule Definition
 
@@ -72,7 +72,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
               const arg = node.arguments[0];
               if (arg == null) continue;
 
-              // Already using the callback form — OK.
+              // Already using the callback form.
               if (isFunction(arg)) continue;
 
               // Check if the argument contains a reference to the state variable.
@@ -125,7 +125,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
     function Counter() {
       const [count, setCount] = useState(0);
 
-      // ❌ Referencing `count` directly — stale state risk.
+      // ❌ Referencing `count` directly. Stale state risk.
       return (
         <button onClick={() => setCount(count + 1)}>
           {count}
@@ -155,7 +155,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
     function UserEditor() {
       const [user, setUser] = useState({ name: "John", age: 25 });
 
-      // ❌ Spreading state directly — stale state risk.
+      // ❌ Spreading state directly. Stale state risk.
       const updateAge = () => setUser({ ...user, age: 30 });
 
       return <button onClick={updateAge}>Update Age</button>;
@@ -168,7 +168,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
     function ItemList() {
       const [items, setItems] = useState(["a", "b"]);
 
-      // ❌ Calling a method on state directly — stale state risk.
+      // ❌ Calling a method on state directly. Stale state risk.
       const addItem = () => setItems([...items, "c"]);
 
       return <button onClick={addItem}>Add</button>;
@@ -183,7 +183,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
     function Counter() {
       const [count, setCount] = useState(0);
 
-      // ✅ Callback form — always gets the latest state.
+      // ✅ Callback form. Always gets the latest state.
       return (
         <button onClick={() => setCount((prev) => prev + 1)}>
           {count}
@@ -242,4 +242,4 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
 ## See Also
 
 - [`custom-rules-of-props`](./custom-rules-of-props)\
-  Custom rules for validating JSX props — duplicate props and mixing controlled/uncontrolled props.
+  Custom rules for validating JSX props. Includes checks for duplicate props and mixing controlled and uncontrolled props.

--- a/apps/website/content/docs/recipes/no-circular-effect.mdx
+++ b/apps/website/content/docs/recipes/no-circular-effect.mdx
@@ -1,17 +1,17 @@
 ---
 title: no-circular-effect
-description: Custom rule to detect circular dependencies between useEffect hooks — prevents infinite update loops caused by effects that set state they also depend on.
+description: Custom rule to detect circular dependencies between useEffect hooks. Prevents infinite update loops caused by effects that set state they also depend on.
 ---
 
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 
 <Callout type="warning">
-  In most cases, use the built-in [`set-state-in-effect`](/docs/rules/set-state-in-effect) rule instead — it's also part of [React's official lints](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect). Use this custom recipe only when you need to detect circular dependencies across multiple effects.
+  In most cases, use the built-in [`set-state-in-effect`](/docs/rules/set-state-in-effect) rule instead. It's also part of [React's official lints](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect). Use this custom recipe only when you need to detect circular dependencies across multiple effects.
 </Callout>
 
 ## Overview
 
-This rule detects when `useEffect`-like hooks form a cycle through state variables — e.g. an effect that depends on state A and sets state B, while another effect depends on state B and sets state A, creating an infinite update loop. It builds a directed graph of state dependencies across all effects in a component and reports any effect that participates in a cycle.
+This rule detects when `useEffect`-like hooks form a cycle through state variables. For example, if an effect depends on state A and sets state B, while another effect depends on state B and sets state A, it creates an infinite update loop. It builds a directed graph of state dependencies across all effects in a component and reports any effect that participates in a cycle.
 
 ## Rule Definition
 
@@ -188,7 +188,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
   <Tab value="Examples">
     #### Invalid
 
-    Circular effect with depth 1 — an effect depends on `items` and also sets `items`:
+    Circular effect with depth 1. An effect depends on `items` and also sets `items`:
 
     ```tsx
     import { useEffect, useState } from "react";
@@ -204,7 +204,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
     }
     ```
 
-    Circular effect with depth 2 — two effects form a cycle: one depends on `limit` and sets `items`, another depends on `items` and sets `limit`:
+    Circular effect with depth 2. Two effects form a cycle: one depends on `limit` and sets `items`, and another depends on `items` and sets `limit`:
 
     ```tsx
     import { useEffect, useState } from "react";
@@ -225,7 +225,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
     }
     ```
 
-    Circular effect with depth 3 — three effects form a cycle through `items → count → limit → items`:
+    Circular effect with depth 3. Three effects form a cycle through `items → count → limit → items`:
 
     ```tsx
     import { useEffect, useState } from "react";
@@ -262,7 +262,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
       const [count, setCount] = useState(0);
       const [label, setLabel] = useState("");
 
-      // ✅ Depends on `count`, sets `label` — no cycle.
+      // ✅ Depends on `count`, sets `label`. No cycle.
       useEffect(() => {
         setLabel(`Count is ${count}`);
       }, [count]);
@@ -279,7 +279,7 @@ Copy the following rule definition into your project (e.g. `eslint.config.rules.
     function ValidComponent2() {
       const [count, setCount] = useState(0);
 
-      // ✅ No dependency array — not a circular pattern.
+      // ✅ No dependency array. Not a circular pattern.
       useEffect(() => {
         setCount(0);
       });


### PR DESCRIPTION
Replace em-dashes with periods, tighten descriptions, and improve readability in custom-rules-of-props
and no-circular-effect recipes.

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
