### PR TITLE
refactor(kit): rename RuleDefinition to RuleFunction and deprecate old name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ export default defineConfig(
 
 - `react-jsx/no-children-prop`: Add suggestion-fix feature to move children from prop to element content.
 - `@eslint-react/eslint-plugin`: Unified plugin architecture refactored — configs now auto-inject the plugin, so users no longer need to manually register it separately.
-- `refactor(kit)`: Improve `Builder` and `RuleDefinition` implementation for better type inference and code organization.
+- `refactor(kit)`: Improve `Builder` and `RuleFunction` implementation for better type inference and code organization.
 - `refactor(kit)`: Replace `defineConfig` with chainable `.use().getConfig()` builder API, closes #1644.
 - `refactor(kit)`: Remove unused type parameter from `CollectorWithContext<T, E>` to `CollectorWithContext<T>`.
 - `refactor(kit)`: Rename parameter `args` to `options`.
@@ -390,7 +390,7 @@ If you still need these rules, you can enforce them using the new `@eslint-react
 
 ### 🪄 Improvements
 
-- `refactor(kit)`: Improve `Builder` and `RuleDefinition` implementation for better type inference and code organization.
+- `refactor(kit)`: Improve `Builder` and `RuleFunction` implementation for better type inference and code organization.
 - `docs(website)`: Improve `configure-project-rules` documentation with clearer examples and explanations.
 
 **Full Changelog**: https://github.com/Rel1cx/eslint-react/compare/v4.0.1-beta.0...v4.0.1-beta.1

--- a/apps/website/content/docs/changelog.md
+++ b/apps/website/content/docs/changelog.md
@@ -153,7 +153,7 @@ export default defineConfig(
 
 - `react-jsx/no-children-prop`: Add suggestion-fix feature to move children from prop to element content.
 - `@eslint-react/eslint-plugin`: Unified plugin architecture refactored — configs now auto-inject the plugin, so users no longer need to manually register it separately.
-- `refactor(kit)`: Improve `Builder` and `RuleDefinition` implementation for better type inference and code organization.
+- `refactor(kit)`: Improve `Builder` and `RuleFunction` implementation for better type inference and code organization.
 - `refactor(kit)`: Replace `defineConfig` with chainable `.use().getConfig()` builder API, closes #1644.
 - `refactor(kit)`: Remove unused type parameter from `CollectorWithContext<T, E>` to `CollectorWithContext<T>`.
 - `refactor(kit)`: Rename parameter `args` to `options`.
@@ -392,7 +392,7 @@ If you still need these rules, you can enforce them using the new `@eslint-react
 
 ### 🪄 Improvements
 
-- `refactor(kit)`: Improve `Builder` and `RuleDefinition` implementation for better type inference and code organization.
+- `refactor(kit)`: Improve `Builder` and `RuleFunction` implementation for better type inference and code organization.
 - `docs(website)`: Improve `configure-project-rules` documentation with clearer examples and explanations.
 
 **Full Changelog**: https://github.com/Rel1cx/eslint-react/compare/v4.0.1-beta.0...v4.0.1-beta.1

--- a/apps/website/content/docs/configuration/configure-project-rules.mdx
+++ b/apps/website/content/docs/configuration/configure-project-rules.mdx
@@ -22,12 +22,12 @@ Define custom rules directly in your `eslint.config.ts`:
 import eslintJs from "@eslint/js";
 import eslintReact from "@eslint-react/eslint-plugin";
 import eslintReactKit, { merge } from "@eslint-react/kit";
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 /** Enforce function declarations for function components. */
-function functionComponentDefinition(): RuleDefinition {
+function functionComponentDefinition(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
     return merge(

--- a/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
+++ b/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
@@ -290,10 +290,10 @@ export default defineConfig([
 Require `onChange` or `readOnly` when using `checked` on `<input>`.
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Require `onChange` or `readOnly` when using `checked` on `<input>`. */
-export function checkedRequiresOnchangeOrReadonly(): RuleDefinition {
+export function checkedRequiresOnchangeOrReadonly(): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const name = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -321,7 +321,7 @@ export function checkedRequiresOnchangeOrReadonly(): RuleDefinition {
 Forbid certain props on React components (not DOM elements). Only reports on PascalCase elements.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link forbidComponentProps}. */
 export type ForbidComponentPropsOptions = {
@@ -330,7 +330,7 @@ export type ForbidComponentPropsOptions = {
 };
 
 /** Forbid certain props on React components (not DOM elements). */
-export function forbidComponentProps({ forbidden }: ForbidComponentPropsOptions): RuleDefinition {
+export function forbidComponentProps({ forbidden }: ForbidComponentPropsOptions): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const propName = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -354,7 +354,7 @@ export function forbidComponentProps({ forbidden }: ForbidComponentPropsOptions)
 Forbid certain props on DOM elements (not React components). Only reports on lowercase DOM element names.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link forbidDomProps}. */
 export type ForbidDomPropsOptions = {
@@ -363,7 +363,7 @@ export type ForbidDomPropsOptions = {
 };
 
 /** Forbid certain props on DOM elements (not React components). */
-export function forbidDomProps({ forbidden }: ForbidDomPropsOptions): RuleDefinition {
+export function forbidDomProps({ forbidden }: ForbidDomPropsOptions): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const propName = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -387,7 +387,7 @@ export function forbidDomProps({ forbidden }: ForbidDomPropsOptions): RuleDefini
 Forbid specific JSX elements. Customize the `forbidden` map with your project's requirements.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link forbidElements}. */
 export type ForbidElementsOptions = {
@@ -396,7 +396,7 @@ export type ForbidElementsOptions = {
 };
 
 /** Forbid specific JSX elements. */
-export function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
+export function forbidElements({ forbidden }: ForbidElementsOptions): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const name = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -413,11 +413,11 @@ export function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefini
 Enforce arrow function definitions for function components.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
 /** Enforce arrow function definitions for function components. */
-export function functionComponentDefinition(): RuleDefinition {
+export function functionComponentDefinition(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
     return merge(
@@ -477,10 +477,10 @@ export function functionComponentDefinition(): RuleDefinition {
 Enforce shorthand for boolean JSX attributes (e.g. prefer `<C disabled />` over `<C disabled={true} />`).
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Enforce shorthand for boolean JSX attributes. */
-export function jsxBooleanValue(): RuleDefinition {
+export function jsxBooleanValue(): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const { value } = node;
@@ -501,7 +501,7 @@ export function jsxBooleanValue(): RuleDefinition {
 Enforce shorthand syntax for React fragments. Reports when `<React.Fragment>` is used instead of `<>...</>`. Allows standard form when `key` prop is present.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxFragments}. */
 export type JsxsFragmentsOptions = {
@@ -510,7 +510,7 @@ export type JsxsFragmentsOptions = {
 };
 
 /** Enforce shorthand or standard form for React fragments. */
-export function jsxFragments({ mode = "syntax" }: JsxsFragmentsOptions = {}): RuleDefinition {
+export function jsxFragments({ mode = "syntax" }: JsxsFragmentsOptions = {}): RuleFunction {
   return (context) => {
     function reportSyntaxPreferred(node: TSESTree.JSXOpeningElement, pattern: "React.Fragment" | "Fragment") {
       const hasAttributes = node.attributes.length > 0;
@@ -571,7 +571,7 @@ export function jsxFragments({ mode = "syntax" }: JsxsFragmentsOptions = {}): Ru
 Enforce naming convention for JSX event handler props and the functions they reference.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxHandlerNames}. */
 export type JsxHandlerNamesOptions = {
@@ -588,7 +588,7 @@ export function jsxHandlerNames({
   eventHandlerPrefix = "handle",
   eventHandlerPropPrefix = "on",
   checkInlineFunction = false,
-}: JsxHandlerNamesOptions = {}): RuleDefinition {
+}: JsxHandlerNamesOptions = {}): RuleFunction {
   const EVENT_HANDLER_REGEX = new RegExp(`^${eventHandlerPropPrefix}[A-Z]`);
   const HANDLER_FUNC_REGEX = new RegExp(`^${eventHandlerPrefix}[A-Z]`);
 
@@ -640,7 +640,7 @@ export function jsxHandlerNames({
 Enforce a maximum depth for JSX elements.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxMaxDepth}. */
 export type JsxMaxDepthOptions = {
@@ -649,7 +649,7 @@ export type JsxMaxDepthOptions = {
 };
 
 /** Enforce JSX maximum depth. */
-export function jsxMaxDepth({ max }: JsxMaxDepthOptions): RuleDefinition {
+export function jsxMaxDepth({ max }: JsxMaxDepthOptions): RuleFunction {
   return (context) => ({
     JSXElement(node) {
       let depth = 0;
@@ -677,10 +677,10 @@ export function jsxMaxDepth({ max }: JsxMaxDepthOptions): RuleDefinition {
 Prevent arrow functions, function expressions, and `.bind()` in JSX props.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Prevent inline functions and `.bind()` in JSX props. */
-export function jsxNoBind(): RuleDefinition {
+export function jsxNoBind(): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const value = node.value;
@@ -707,7 +707,7 @@ export function jsxNoBind(): RuleDefinition {
 Disallow duplicate properties in JSX elements.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxNoDuplicateProps}. */
 export type JsxNoDuplicatePropsOptions = {
@@ -716,7 +716,7 @@ export type JsxNoDuplicatePropsOptions = {
 };
 
 /** Disallow duplicate properties in JSX. */
-export function jsxNoDuplicateProps({ ignoreCase = false }: JsxNoDuplicatePropsOptions = {}): RuleDefinition {
+export function jsxNoDuplicateProps({ ignoreCase = false }: JsxNoDuplicatePropsOptions = {}): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const seen = new Map<string, string>();
@@ -743,7 +743,7 @@ export function jsxNoDuplicateProps({ ignoreCase = false }: JsxNoDuplicatePropsO
 Disallow usage of string literals in JSX. By default requires wrapping strings in JSX expressions `{'TEXT'}`.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxNoLiterals}. */
 export type JsxNoLiteralsOptions = {
@@ -758,7 +758,7 @@ export type JsxNoLiteralsOptions = {
 /** Disallow usage of string literals in JSX. */
 export function jsxNoLiterals(
   { noStrings = false, allowedStrings = [], ignoreProps = true }: JsxNoLiteralsOptions = {},
-): RuleDefinition {
+): RuleFunction {
   const allowedSet = new Set(allowedStrings);
   return (context) => ({
     Literal(node) {
@@ -820,7 +820,7 @@ export function jsxNoLiterals(
 Enforce PascalCase for user-defined JSX components. DOM elements like `<div>` are ignored.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxPascalCase}. */
 export type JsxPascalCaseOptions = {
@@ -833,7 +833,7 @@ export type JsxPascalCaseOptions = {
 /** Enforce PascalCase for user-defined JSX components. */
 export function jsxPascalCase(
   { allowAllCaps = false, allowLeadingUnderscore = false }: JsxPascalCaseOptions = {},
-): RuleDefinition {
+): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const name = node.name;
@@ -886,10 +886,10 @@ export function jsxPascalCase(
 Disallow spreading the same expression multiple times in a JSX element.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Disallow JSX prop spreading the same identifier multiple times. */
-export function jsxPropsNoSpreadMulti(): RuleDefinition {
+export function jsxPropsNoSpreadMulti(): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const seen = new Set<string>();
@@ -922,10 +922,10 @@ export function jsxPropsNoSpreadMulti(): RuleDefinition {
 Disallow JSX props spreading.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Disallow JSX props spreading. */
-export function jsxPropsNoSpreading(): RuleDefinition {
+export function jsxPropsNoSpreading(): RuleFunction {
   return (context) => ({
     JSXSpreadAttribute(node) {
       context.report({
@@ -942,11 +942,11 @@ export function jsxPropsNoSpreading(): RuleDefinition {
 Disallow adjacent inline elements not separated by whitespace.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 
 /** Disallow adjacent inline elements not separated by whitespace. */
-export function noAdjacentInlineElements(): RuleDefinition {
+export function noAdjacentInlineElements(): RuleFunction {
   /** Set of inline HTML elements. */
   const INLINE_ELEMENTS = new Set([
     "a",
@@ -1015,11 +1015,11 @@ export function noAdjacentInlineElements(): RuleDefinition {
 Prevent defining more than one component per file.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
 /** Prevent defining more than one component per file. */
-export function noMultiComp(): RuleDefinition {
+export function noMultiComp(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
     return merge(visitor, {

--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -25,13 +25,13 @@ npm install --save-dev @eslint-react/kit
 ```ts title="eslint.config.ts"
 import eslintReact from "@eslint-react/eslint-plugin";
 import eslintReactKit, { merge } from "@eslint-react/kit";
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import eslintJs from "@eslint/js";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 /** Enforce function declarations for function components. */
-function functionComponentDefinition(): RuleDefinition {
+function functionComponentDefinition(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
     return merge(
@@ -80,27 +80,27 @@ eslintReactKit(): Builder
 
 Creates a `Builder` instance for registering custom rules via the chainable `.use()` API.
 
-### `RuleDefinition`
+### `RuleFunction`
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
-type RuleDefinition = (ctx: RuleContext, kit: RuleToolkit) => RuleListener;
+type RuleFunction = (ctx: RuleContext, kit: RuleToolkit) => RuleListener;
 ```
 
 A rule definition is a function that receives the ESLint rule context and the structured `Kit` toolkit, and returns a `RuleListener` (AST visitor object).
 
-Rules are defined as **named functions** that return a `RuleDefinition`. The function name is automatically converted to kebab-case and used as the rule name under the `@eslint-react/kit` plugin namespace.
+Rules are defined as **named functions** that return a `RuleFunction`. The function name is automatically converted to kebab-case and used as the rule name under the `@eslint-react/kit` plugin namespace.
 
 ```ts
 // Function name `noForwardRef` → rule name `no-forward-ref`
 // Registered as `@eslint-react/kit/no-forward-ref`
-function noForwardRef(): RuleDefinition {
+function noForwardRef(): RuleFunction {
   return (context, { is }) => ({ ... });
 }
 
 // Functions that accept options work the same way
-function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
+function forbidElements({ forbidden }: ForbidElementsOptions): RuleFunction {
   return (context) => ({ ... });
 }
 ```
@@ -109,7 +109,7 @@ function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
 
 ```ts
 interface Builder {
-  use<F extends (...args: any[]) => RuleDefinition>(factory: F, ...args: Parameters<F>): Builder;
+  use<F extends (...args: any[]) => RuleFunction>(factory: F, ...args: Parameters<F>): Builder;
   getConfig(): Linter.Config;
   getPlugin(): ESLint.Plugin;
 }
@@ -175,7 +175,7 @@ This is essential for combining a collector's `visitor` with your own inspection
 
 ## Kit — the toolkit object
 
-The second argument passed to the `RuleDefinition` function is a structured `Kit` object:
+The second argument passed to the `RuleFunction` function is a structured `Kit` object:
 
 ```
 kit
@@ -352,9 +352,9 @@ Exposes the normalized `react-x` settings from the ESLint shared configuration (
 **Usage:**
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
-function version(major = "19"): RuleDefinition {
+function version(major = "19"): RuleFunction {
   return (context, { settings }) => ({
     Program(program) {
       if (!settings.version.startsWith(`${major}.`)) {
@@ -375,9 +375,9 @@ function version(major = "19"): RuleDefinition {
 This is a simplified kit reimplementation of the built-in [`react-x/no-forwardRef`](/docs/rules/no-forward-ref) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
-function noForwardRef(): RuleDefinition {
+function noForwardRef(): RuleFunction {
   return (context, { is }) => ({
     CallExpression(node) {
       if (is.forwardRefCall(node)) {
@@ -398,10 +398,10 @@ eslintReactKit()
 This is a simplified kit reimplementation of the built-in [`react-x/prefer-destructuring-assignment`](/docs/rules/prefer-destructuring-assignment) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
-function destructureComponentProps(): RuleDefinition {
+function destructureComponentProps(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
 
@@ -439,10 +439,10 @@ eslintReactKit()
 This is a simplified kit reimplementation of the built-in [`react-x/no-unnecessary-use-prefix`](/docs/rules/no-unnecessary-use-prefix) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
-function noUnnecessaryUsePrefix(): RuleDefinition {
+function noUnnecessaryUsePrefix(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.hooks(context);
 
@@ -473,7 +473,7 @@ Disallow defining components or hooks inside other functions (factory pattern).
 This is a simplified kit reimplementation of the built-in [`react-x/component-hook-factories`](/docs/rules/component-hook-factories) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 
@@ -488,7 +488,7 @@ function isFunction({ type }: TSESTree.Node) {
   return type === "FunctionDeclaration" || type === "FunctionExpression" || type === "ArrowFunctionExpression";
 }
 
-function componentHookFactories(): RuleDefinition {
+function componentHookFactories(): RuleFunction {
   return (context, { collect }) => {
     const fc = collect.components(context);
     const hk = collect.hooks(context);
@@ -525,7 +525,7 @@ eslintReactKit()
 
 ```ts title="eslint.config.ts"
 import eslintReactKit from "@eslint-react/kit";
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 // Spread the config into a new object to add or override properties like `files`:
 export default [
@@ -550,7 +550,7 @@ Use `getPlugin()` when you want full control over the plugin namespace and rule 
 
 ```ts title="eslint.config.ts"
 import eslintReactKit from "@eslint-react/kit";
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 const kit = eslintReactKit()
   .use(noForwardRef)

--- a/apps/website/content/docs/recipes/component-hook-factories.mdx
+++ b/apps/website/content/docs/recipes/component-hook-factories.mdx
@@ -9,17 +9,17 @@ This recipe contains a custom rule that disallows defining components or hooks i
 
 Defining components or hooks inside other functions creates new instances on every call. React treats each as a completely different component, destroying and recreating the entire component tree, losing all state, and causing performance problems.
 
-## Rule Definition
+## Rule Factory
 
 Copy the following into your project (e.g. `eslint.config.rules.ts`):
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 
 /** Disallow defining components or hooks inside other functions (factory pattern). */
-export function componentHookFactories(): RuleDefinition {
+export function componentHookFactories(): RuleFunction {
   function findParent(
     { parent }: TSESTree.Node,
     test: (n: TSESTree.Node) => boolean,

--- a/apps/website/content/docs/recipes/custom-rules-of-props.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-props.mdx
@@ -11,17 +11,17 @@ This recipe contains three custom rules for validating JSX props:
 2. **`noExplicitSpreadProps`**: Reports spreading object literals onto a JSX element instead of writing separate props. Includes auto-fix.
 3. **`noMixingControlledAndUncontrolledProps`**: Reports mixing a controlled prop and its uncontrolled counterpart on the same element.
 
-## Rule Definitions
+## Rule Factories
 
 Copy the following into your project (e.g. `eslint.config.rules.ts`):
 
 ### noDuplicateProps
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Disallow duplicate props on JSX elements. */
-export function noDuplicateProps(): RuleDefinition {
+export function noDuplicateProps(): RuleFunction {
   return (context) => {
     function getPropName(
       attribute: { name: { type: string; namespace?: { name: string }; name: string | { name: string } } },
@@ -104,10 +104,10 @@ Spread attributes are ignored because overriding them with explicit props is a c
 ### noExplicitSpreadProps
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 /** Disallow spreading object literals in JSX. Write each property as a separate prop. */
-export function noExplicitSpreadProps(): RuleDefinition {
+export function noExplicitSpreadProps(): RuleFunction {
   return (context) => ({
     JSXSpreadAttribute(node) {
       if (node.argument.type === "ObjectExpression") {
@@ -167,7 +167,7 @@ Only plain object literals are flagged. Conditional expressions, variables, and 
 ### noMixingControlledAndUncontrolledProps
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 const CONTROLLED_PAIRS: [controlled: string, uncontrolled: string][] = [
   ["value", "defaultValue"],
@@ -175,7 +175,7 @@ const CONTROLLED_PAIRS: [controlled: string, uncontrolled: string][] = [
 ];
 
 /** Disallow using controlled and uncontrolled props on the same element. */
-export function noMixingControlledAndUncontrolledProps(): RuleDefinition {
+export function noMixingControlledAndUncontrolledProps(): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const props = new Set<string>();

--- a/apps/website/content/docs/recipes/custom-rules-of-state.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-state.mdx
@@ -7,18 +7,18 @@ description: Validates state usage. Prefer the updater function form in useState
 
 Reports when a `useState` setter is called with an expression that directly references the corresponding state variable. Using the callback (updater function) form ensures the update uses the latest state value, avoiding stale-state bugs in closures, event handlers, and timeouts.
 
-## Rule Definition
+## Rule Factory
 
 Copy the following rule definition into your project (e.g. `eslint.config.rules.ts`):
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import type { ScopeVariable } from "@typescript-eslint/scope-manager";
 import type { TSESTree } from "@typescript-eslint/utils";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 
 /** Require the updater function form of useState setters when referencing the corresponding state variable. */
-export function preferStateUpdaterFunction(): RuleDefinition {
+export function preferStateUpdaterFunction(): RuleFunction {
   function isFunction({ type }: TSESTree.Node) {
     return type === "FunctionDeclaration" || type === "FunctionExpression" || type === "ArrowFunctionExpression";
   }

--- a/apps/website/content/docs/recipes/function-component-definition.mdx
+++ b/apps/website/content/docs/recipes/function-component-definition.mdx
@@ -7,16 +7,16 @@ description: Enforces arrow function style for function component definitions.
 
 This rule enforces that function components are defined with arrow functions instead of function declarations or function expressions. It provides an auto-fix suggestion that converts non-arrow function components to arrow function syntax.
 
-## Rule Definition
+## Rule Factory
 
 Copy the following rule definition into your project (e.g. `eslint.config.rules.ts`):
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
 /** Enforce arrow function style for function component definitions. */
-export function functionComponentDefinition(): RuleDefinition {
+export function functionComponentDefinition(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context, {
       hint: hint.component.Default & ~hint.component.DoNotIncludeFunctionDefinedAsObjectMethod,

--- a/apps/website/content/docs/recipes/no-circular-effect.mdx
+++ b/apps/website/content/docs/recipes/no-circular-effect.mdx
@@ -11,18 +11,18 @@ description: Detects circular dependencies between useEffect hooks. Prevents inf
 
 This rule detects when `useEffect`-like hooks form a cycle through state variables. For example, if an effect depends on state A and sets state B, while another effect depends on state B and sets state A, it creates an infinite update loop. It builds a directed graph of state dependencies across all effects in a component and reports any effect that participates in a cycle.
 
-## Rule Definition
+## Rule Factory
 
 Copy the following rule definition into your project (e.g. `eslint.config.rules.ts`):
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 import type { Scope } from "@typescript-eslint/utils/ts-eslint";
 
 /** Detect circular dependencies between useEffect hooks via useState setters. */
-export function noCircularEffect(): RuleDefinition {
+export function noCircularEffect(): RuleFunction {
   return (context, { is, settings }) => {
     const { additionalStateHooks, additionalEffectHooks } = settings;
 

--- a/apps/website/content/docs/recipes/overview.md
+++ b/apps/website/content/docs/recipes/overview.md
@@ -24,15 +24,15 @@ npm install --save-dev @eslint-react/kit
 
 Each recipe page provides:
 
-1. **Rule Definition** — A self-contained function you copy into your project (e.g. into an `eslint.config.rules.ts` file).
+1. **Rule Factory** — A self-contained function you copy into your project (e.g. into an `eslint.config.rules.ts` file).
 2. **Usage** — How to wire it up in your `eslint.config.ts` using `eslintReactKit().use(...)`.
 
 Here's the general pattern:
 
 ```ts title="eslint.config.rules.ts"
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
-function noForwardRef(): RuleDefinition {
+function noForwardRef(): RuleFunction {
   return (context, { is }) => ({
     CallExpression(node) {
       if (is.forwardRefCall(node)) {

--- a/examples/react-dom-with-custom-rules/eslint.config.rules.ts
+++ b/examples/react-dom-with-custom-rules/eslint.config.rules.ts
@@ -1,11 +1,11 @@
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 import type { Scope } from "@typescript-eslint/utils/ts-eslint";
 
 /** Require `onChange` or `readOnly` when using `checked` on `<input>`. */
-export function checkedRequiresOnchangeOrReadonly(): RuleDefinition {
+export function checkedRequiresOnchangeOrReadonly(): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const name = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -28,7 +28,7 @@ export function checkedRequiresOnchangeOrReadonly(): RuleDefinition {
 }
 
 /** Disallow defining components or hooks inside other functions (factory pattern). */
-export function componentHookFactories(): RuleDefinition {
+export function componentHookFactories(): RuleFunction {
   function findParent({ parent }: TSESTree.Node, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {
     if (parent == null) return null;
     if (test(parent)) return parent;
@@ -71,7 +71,7 @@ export type ForbidComponentPropsOptions = {
 };
 
 /** Forbid certain props on React components (not DOM elements). */
-export function forbidComponentProps({ forbidden }: ForbidComponentPropsOptions): RuleDefinition {
+export function forbidComponentProps({ forbidden }: ForbidComponentPropsOptions): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const propName = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -96,7 +96,7 @@ export type ForbidDomPropsOptions = {
 };
 
 /** Forbid certain props on DOM elements (not React components). */
-export function forbidDomProps({ forbidden }: ForbidDomPropsOptions): RuleDefinition {
+export function forbidDomProps({ forbidden }: ForbidDomPropsOptions): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const propName = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -121,7 +121,7 @@ export type ForbidElementsOptions = {
 };
 
 /** Forbid specific JSX elements. */
-export function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
+export function forbidElements({ forbidden }: ForbidElementsOptions): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const name = node.name.type === "JSXIdentifier" ? node.name.name : null;
@@ -133,7 +133,7 @@ export function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefini
 }
 
 /** Enforce arrow function definitions for function components. */
-export function functionComponentDefinition(): RuleDefinition {
+export function functionComponentDefinition(): RuleFunction {
   return (context, { collect, hint }) => {
     const { query, visitor } = collect.components(context, {
       hint: hint.component.Default & ~hint.component.DoNotIncludeFunctionDefinedAsObjectMethod,
@@ -190,7 +190,7 @@ export function functionComponentDefinition(): RuleDefinition {
 }
 
 /** Enforce shorthand for boolean JSX attributes. */
-export function jsxBooleanValue(): RuleDefinition {
+export function jsxBooleanValue(): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const { value } = node;
@@ -212,7 +212,7 @@ export type JsxsFragmentsOptions = {
 };
 
 /** Enforce shorthand or standard form for React fragments. */
-export function jsxFragments({ mode = "syntax" }: JsxsFragmentsOptions = {}): RuleDefinition {
+export function jsxFragments({ mode = "syntax" }: JsxsFragmentsOptions = {}): RuleFunction {
   return (context) => {
     function reportSyntaxPreferred(node: TSESTree.JSXOpeningElement, pattern: "React.Fragment" | "Fragment") {
       const hasAttributes = node.attributes.length > 0;
@@ -282,7 +282,7 @@ export function jsxHandlerNames({
   eventHandlerPrefix = "handle",
   eventHandlerPropPrefix = "on",
   checkInlineFunction = false,
-}: JsxHandlerNamesOptions = {}): RuleDefinition {
+}: JsxHandlerNamesOptions = {}): RuleFunction {
   const EVENT_HANDLER_REGEX = new RegExp(`^${eventHandlerPropPrefix}[A-Z]`);
   const HANDLER_FUNC_REGEX = new RegExp(`^${eventHandlerPrefix}[A-Z]`);
 
@@ -335,7 +335,7 @@ export type JsxMaxDepthOptions = {
 };
 
 /** Enforce JSX maximum depth. */
-export function jsxMaxDepth({ max }: JsxMaxDepthOptions): RuleDefinition {
+export function jsxMaxDepth({ max }: JsxMaxDepthOptions): RuleFunction {
   return (context) => ({
     JSXElement(node) {
       let depth = 0;
@@ -358,7 +358,7 @@ export function jsxMaxDepth({ max }: JsxMaxDepthOptions): RuleDefinition {
 }
 
 /** Prevent inline functions and `.bind()` in JSX props. */
-export function jsxNoBind(): RuleDefinition {
+export function jsxNoBind(): RuleFunction {
   return (context) => ({
     JSXAttribute(node) {
       const value = node.value;
@@ -386,7 +386,7 @@ export type JsxNoDuplicatePropsOptions = {
 };
 
 /** Disallow duplicate properties in JSX. */
-export function jsxNoDuplicateProps({ ignoreCase = false }: JsxNoDuplicatePropsOptions = {}): RuleDefinition {
+export function jsxNoDuplicateProps({ ignoreCase = false }: JsxNoDuplicatePropsOptions = {}): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const seen = new Map<string, string>();
@@ -420,7 +420,7 @@ export type JsxNoLiteralsOptions = {
 /** Disallow usage of string literals in JSX. */
 export function jsxNoLiterals(
   { noStrings = false, allowedStrings = [], ignoreProps = true }: JsxNoLiteralsOptions = {},
-): RuleDefinition {
+): RuleFunction {
   const allowedSet = new Set(allowedStrings);
   return (context) => ({
     Literal(node) {
@@ -487,7 +487,7 @@ export type JsxPascalCaseOptions = {
 /** Enforce PascalCase for user-defined JSX components. */
 export function jsxPascalCase(
   { allowAllCaps = false, allowLeadingUnderscore = false }: JsxPascalCaseOptions = {},
-): RuleDefinition {
+): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const name = node.name;
@@ -535,7 +535,7 @@ export function jsxPascalCase(
 }
 
 /** Disallow JSX prop spreading the same identifier multiple times. */
-export function jsxPropsNoSpreadMulti(): RuleDefinition {
+export function jsxPropsNoSpreadMulti(): RuleFunction {
   return (context) => ({
     JSXOpeningElement(node) {
       const seen = new Set<string>();
@@ -563,7 +563,7 @@ export function jsxPropsNoSpreadMulti(): RuleDefinition {
 }
 
 /** Disallow JSX props spreading. */
-export function jsxPropsNoSpreading(): RuleDefinition {
+export function jsxPropsNoSpreading(): RuleFunction {
   return (context) => ({
     JSXSpreadAttribute(node) {
       context.report({
@@ -581,7 +581,7 @@ export type MaxComponentPerFileOptions = {
 };
 
 /** Prevent defining more than one component per file. */
-export function maxComponentPerFile({ max }: MaxComponentPerFileOptions): RuleDefinition {
+export function maxComponentPerFile({ max }: MaxComponentPerFileOptions): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
     return merge(visitor, {
@@ -601,7 +601,7 @@ export function maxComponentPerFile({ max }: MaxComponentPerFileOptions): RuleDe
 }
 
 /** Disallow adjacent inline elements not separated by whitespace. */
-export function noAdjacentInlineElements(): RuleDefinition {
+export function noAdjacentInlineElements(): RuleFunction {
   /** Set of inline HTML elements. */
   const INLINE_ELEMENTS = new Set([
     "a",
@@ -665,7 +665,7 @@ export function noAdjacentInlineElements(): RuleDefinition {
 }
 
 /** Prevent defining more than one component per file. */
-export function noMultiComp(): RuleDefinition {
+export function noMultiComp(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
     return merge(visitor, {
@@ -683,7 +683,7 @@ export function noMultiComp(): RuleDefinition {
 }
 
 /** Warn on custom hooks that don't call other hooks. */
-export function noUnnecessaryUsePrefix(): RuleDefinition {
+export function noUnnecessaryUsePrefix(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.hooks(context);
 
@@ -704,7 +704,7 @@ export function noUnnecessaryUsePrefix(): RuleDefinition {
 }
 
 /** Require the project to use a specific React version. */
-export function version(major = "19"): RuleDefinition {
+export function version(major = "19"): RuleFunction {
   return (context, { settings }) => ({
     Program(program) {
       if (!settings.version.startsWith(`${major}.`)) {
@@ -718,7 +718,7 @@ export function version(major = "19"): RuleDefinition {
 }
 
 /** Detect circular dependencies between useEffect hooks via useState setters. */
-export function noCircularEffect(): RuleDefinition {
+export function noCircularEffect(): RuleFunction {
   return (context, { is, settings }) => {
     // Map: setter Scope.Variable → state Scope.Variable
     const setterToState = new Map<Scope.Variable, Scope.Variable>();

--- a/packages/utilities/kit/README.md
+++ b/packages/utilities/kit/README.md
@@ -8,7 +8,7 @@ ESLint React's toolkit for building custom React rules with JavasSript functions
 - [Quick Start](#quick-start)
 - [API Reference](#api-reference)
   - [`eslintReactKit` (default export)](#eslintreactkit-default-export)
-  - [`RuleDefinition`](#ruledefinition)
+  - [`RuleFunction`](#rulefunction)
   - [`Builder`](#builder)
     - [`getConfig`](#getconfig)
     - [`getPlugin`](#getplugin)
@@ -39,13 +39,13 @@ npm install --save-dev @eslint-react/kit
 ```ts
 import eslintReact from "@eslint-react/eslint-plugin";
 import eslintReactKit, { merge } from "@eslint-react/kit";
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import eslintJs from "@eslint/js";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 /** Enforce function declarations for function components. */
-function functionComponentDefinition(): RuleDefinition {
+function functionComponentDefinition(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
     return merge(
@@ -94,27 +94,27 @@ eslintReactKit(): Builder
 
 Creates a `Builder` instance for registering custom rules via the chainable `.use()` API.
 
-### `RuleDefinition`
+### `RuleFunction`
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
-type RuleDefinition = (ctx: RuleContext, kit: RuleToolkit) => RuleListener;
+type RuleFunction = (ctx: RuleContext, kit: RuleToolkit) => RuleListener;
 ```
 
 A rule definition is a function that receives the ESLint rule context and the structured `Kit` toolkit, and returns a `RuleListener` (AST visitor object).
 
-Rules are defined as **named functions** that return a `RuleDefinition`. The function name is automatically converted to kebab-case and used as the rule name under the `@eslint-react/kit` plugin namespace.
+Rules are defined as **named functions** that return a `RuleFunction`. The function name is automatically converted to kebab-case and used as the rule name under the `@eslint-react/kit` plugin namespace.
 
 ```ts
 // Function name `noForwardRef` → rule name `no-forward-ref`
 // Registered as `@eslint-react/kit/no-forward-ref`
-function noForwardRef(): RuleDefinition {
+function noForwardRef(): RuleFunction {
   return (context, { is }) => ({ ... });
 }
 
 // Functions that accept options work the same way
-function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
+function forbidElements({ forbidden }: ForbidElementsOptions): RuleFunction {
   return (context) => ({ ... });
 }
 ```
@@ -123,7 +123,7 @@ function forbidElements({ forbidden }: ForbidElementsOptions): RuleDefinition {
 
 ```ts
 interface Builder {
-  use<F extends (...args: any[]) => RuleDefinition>(factory: F, ...args: Parameters<F>): Builder;
+  use<F extends (...args: any[]) => RuleFunction>(factory: F, ...args: Parameters<F>): Builder;
   getConfig(): Linter.Config;
   getPlugin(): ESLint.Plugin;
 }
@@ -189,7 +189,7 @@ This is essential for combining a collector's `visitor` with your own inspection
 
 ### Kit — the toolkit object
 
-The second argument passed to the `RuleDefinition` function is a structured `Kit` object:
+The second argument passed to the `RuleFunction` function is a structured `Kit` object:
 
 ```
 kit
@@ -376,9 +376,9 @@ Exposes the normalized `react-x` settings from the ESLint shared configuration (
 **Usage:**
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
-function version(major = "19"): RuleDefinition {
+function version(major = "19"): RuleFunction {
   return (context, { settings }) => ({
     Program(program) {
       if (!settings.version.startsWith(`${major}.`)) {
@@ -401,9 +401,9 @@ function version(major = "19"): RuleDefinition {
 This is a simplified kit reimplementation of the built-in [`react-x/no-forwardRef`](https://beta.eslint-react.xyz/docs/rules/no-forward-ref) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
-function noForwardRef(): RuleDefinition {
+function noForwardRef(): RuleFunction {
   return (context, { is }) => ({
     CallExpression(node) {
       if (is.forwardRefCall(node)) {
@@ -424,10 +424,10 @@ eslintReactKit()
 This is a simplified kit reimplementation of the built-in [`react-x/prefer-destructuring-assignment`](https://beta.eslint-react.xyz/docs/rules/prefer-destructuring-assignment) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
-function destructureComponentProps(): RuleDefinition {
+function destructureComponentProps(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.components(context);
 
@@ -465,10 +465,10 @@ eslintReactKit()
 This is a simplified kit reimplementation of the built-in [`react-x/no-unnecessary-use-prefix`](https://beta.eslint-react.xyz/docs/rules/no-unnecessary-use-prefix) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
-function noUnnecessaryUsePrefix(): RuleDefinition {
+function noUnnecessaryUsePrefix(): RuleFunction {
   return (context, { collect }) => {
     const { query, visitor } = collect.hooks(context);
 
@@ -499,11 +499,11 @@ Disallow defining components or hooks inside other functions (factory pattern).
 This is a simplified kit reimplementation of the built-in [`react-x/component-hook-factories`](https://beta.eslint-react.xyz/docs/rules/component-hook-factories) rule.
 
 ```ts
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/utils";
 
-function componentHookFactories(): RuleDefinition {
+function componentHookFactories(): RuleFunction {
   function findParent({ parent }: TSESTree.Node, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {
     if (parent == null) return null;
     if (test(parent)) return parent;
@@ -550,7 +550,7 @@ eslintReactKit()
 
 ```ts
 import eslintReactKit from "@eslint-react/kit";
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 // Spread the config into a new object to add or override properties like `files`:
 export default [
@@ -575,7 +575,7 @@ Use `getPlugin()` when you want full control over the plugin namespace and rule 
 
 ```ts
 import eslintReactKit from "@eslint-react/kit";
-import type { RuleDefinition } from "@eslint-react/kit";
+import type { RuleFunction } from "@eslint-react/kit";
 
 const kit = eslintReactKit()
   .use(noForwardRef);

--- a/packages/utilities/kit/docs/README.md
+++ b/packages/utilities/kit/docs/README.md
@@ -2,24 +2,25 @@
 
 ## Interfaces
 
-| Interface | Description |
-| ------ | ------ |
-| [Builder](interfaces/Builder.md) | - |
-| [Collector](interfaces/Collector.md) | - |
-| [CollectorWithContext](interfaces/CollectorWithContext.md) | - |
-| [RuleFix](interfaces/RuleFix.md) | - |
-| [RuleFixer](interfaces/RuleFixer.md) | - |
+| Interface                                                  | Description |
+| ---------------------------------------------------------- | ----------- |
+| [Builder](interfaces/Builder.md)                           | -           |
+| [Collector](interfaces/Collector.md)                       | -           |
+| [CollectorWithContext](interfaces/CollectorWithContext.md) | -           |
+| [RuleFix](interfaces/RuleFix.md)                           | -           |
+| [RuleFixer](interfaces/RuleFixer.md)                       | -           |
 
 ## Type Aliases
 
-| Type Alias | Description |
-| ------ | ------ |
-| [RuleDefinition](type-aliases/RuleDefinition.md) | - |
-| [RuleListener](type-aliases/RuleListener.md) | - |
+| Type Alias                                       | Description |
+| ------------------------------------------------ | ----------- |
+| [~~RuleFunction~~](type-aliases/RuleFunction.md) | -           |
+| [RuleFunction](type-aliases/RuleFunction.md)     | -           |
+| [RuleListener](type-aliases/RuleListener.md)     | -           |
 
 ## Functions
 
-| Function | Description |
-| ------ | ------ |
-| [default](functions/default.md) | - |
-| [merge](functions/merge.md) | Defines a rule listener by merging multiple visitor objects |
+| Function                        | Description                                                 |
+| ------------------------------- | ----------------------------------------------------------- |
+| [default](functions/default.md) | -                                                           |
+| [merge](functions/merge.md)     | Defines a rule listener by merging multiple visitor objects |

--- a/packages/utilities/kit/docs/interfaces/Builder.md
+++ b/packages/utilities/kit/docs/interfaces/Builder.md
@@ -38,7 +38,7 @@ use<F>(factory: F, ...args: Parameters<F>): Builder;
 
 | Type Parameter |
 | ------ |
-| `F` *extends* (...`args`: `any`[]) => [`RuleDefinition`](../type-aliases/RuleDefinition.md) |
+| `F` *extends* (...`args`: `any`[]) => [`RuleFunction`](../type-aliases/RuleFunction.md) |
 
 #### Parameters
 

--- a/packages/utilities/kit/docs/type-aliases/RuleDefinition.md
+++ b/packages/utilities/kit/docs/type-aliases/RuleDefinition.md
@@ -1,18 +1,11 @@
-[@eslint-react/kit](../README.md) / RuleDefinition
+[@eslint-react/kit](../README.md) / RuleFunction
 
-# Type Alias: RuleDefinition
+# ~~Type Alias: RuleFunction~~
 
 ```ts
-type RuleDefinition = (context: RuleContext, toolkit: RuleToolkit) => RuleListener;
+type RuleFunction = RuleFunction;
 ```
 
-## Parameters
+## Deprecated
 
-| Parameter | Type |
-| ------ | ------ |
-| `context` | `RuleContext` |
-| `toolkit` | `RuleToolkit` |
-
-## Returns
-
-[`RuleListener`](RuleListener.md)
+Use `RuleFunction` instead.

--- a/packages/utilities/kit/docs/type-aliases/RuleFunction.md
+++ b/packages/utilities/kit/docs/type-aliases/RuleFunction.md
@@ -1,0 +1,18 @@
+[@eslint-react/kit](../README.md) / RuleFunction
+
+# Type Alias: RuleFunction
+
+```ts
+type RuleFunction = (context: RuleContext, toolkit: RuleToolkit) => RuleListener;
+```
+
+## Parameters
+
+| Parameter | Type |
+| ------ | ------ |
+| `context` | `RuleContext` |
+| `toolkit` | `RuleToolkit` |
+
+## Returns
+
+[`RuleListener`](RuleListener.md)

--- a/packages/utilities/kit/src/index.ts
+++ b/packages/utilities/kit/src/index.ts
@@ -220,12 +220,17 @@ function makeRuleToolkit(context: RuleContext): RuleToolkit {
   };
 }
 
-export type RuleDefinition = (context: RuleContext, toolkit: RuleToolkit) => RuleListener;
+export type RuleFunction = (context: RuleContext, toolkit: RuleToolkit) => RuleListener;
+
+/**
+ * @deprecated Use `RuleFunction` instead.
+ */
+export type RuleDefinition = RuleFunction;
 
 export interface Builder {
   getConfig(): Linter.Config;
   getPlugin(): ESLint.Plugin;
-  use<F extends (...args: any[]) => RuleDefinition>(factory: F, ...args: Parameters<F>): Builder;
+  use<F extends (...args: any[]) => RuleFunction>(factory: F, ...args: Parameters<F>): Builder;
 }
 
 export default function build(): Builder {
@@ -254,7 +259,7 @@ export default function build(): Builder {
         rules,
       };
     },
-    use(make: (...args: any[]) => RuleDefinition, ...args: any[]): Builder {
+    use(make: (...args: any[]) => RuleFunction, ...args: any[]): Builder {
       const name = kebabCase(make.name === "" ? idGen.next() : make.name);
       Reflect.set(rules, name, {
         meta: {


### PR DESCRIPTION
- Introduce `RuleFunction` as the new primary type name
- Keep `RuleDefinition` as a deprecated alias for backwards compatibility
- Update all docs, examples, and changelog references to use `RuleFunction`

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
