### PR TITLE
refactor: consolidate @typescript-eslint/types imports

### DIFF
--- a/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
+++ b/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
@@ -950,7 +950,7 @@ Disallow adjacent inline elements not separated by whitespace.
 
 ```ts
 import type { RuleFunction } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /** Disallow adjacent inline elements not separated by whitespace. */
 export function noAdjacentInlineElements(): RuleFunction {

--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -475,7 +475,7 @@ This is a simplified kit reimplementation of the built-in [`react-x/component-ho
 ```ts
 import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 function findParent({ parent }: TSESTree.Node, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {
   if (parent == null) return null;

--- a/apps/website/content/docs/recipes/component-hook-factories.mdx
+++ b/apps/website/content/docs/recipes/component-hook-factories.mdx
@@ -16,7 +16,7 @@ Copy the following into your project (e.g. `.config/componentHookFactories.ts`):
 ```ts title=".config/componentHookFactories.ts"
 import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /** Disallow defining components or hooks inside other functions (factory pattern). */
 export function componentHookFactories(): RuleFunction {

--- a/apps/website/content/docs/recipes/custom-rules-of-state.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-state.mdx
@@ -14,7 +14,7 @@ Copy the following code into your project (e.g. `.config/preferStateUpdaterFunct
 ```ts title=".config/preferStateUpdaterFunction.ts"
 import type { RuleFunction } from "@eslint-react/kit";
 import type { ScopeVariable } from "@typescript-eslint/scope-manager";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 
 /** Require the updater function form of useState setters when referencing the corresponding state variable. */

--- a/apps/website/content/docs/recipes/no-circular-effect.mdx
+++ b/apps/website/content/docs/recipes/no-circular-effect.mdx
@@ -17,7 +17,7 @@ Copy the following code into your project (e.g. `.config/noCircularEffect.ts`):
 
 ```ts title=".config/noCircularEffect.ts"
 import type { RuleFunction } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 import type { Scope } from "@typescript-eslint/utils/ts-eslint";
 

--- a/examples/react-dom-with-custom-rules/.config/componentHookFactories.ts
+++ b/examples/react-dom-with-custom-rules/.config/componentHookFactories.ts
@@ -1,6 +1,6 @@
 import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /** Disallow defining components or hooks inside other functions (factory pattern). */
 export function componentHookFactories(): RuleFunction {

--- a/examples/react-dom-with-custom-rules/.config/jsxFragments.ts
+++ b/examples/react-dom-with-custom-rules/.config/jsxFragments.ts
@@ -1,5 +1,5 @@
 import type { RuleFunction } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /** Options for {@link jsxFragments}. */
 export type JsxsFragmentsOptions = {

--- a/examples/react-dom-with-custom-rules/.config/noCircularEffect.ts
+++ b/examples/react-dom-with-custom-rules/.config/noCircularEffect.ts
@@ -1,5 +1,5 @@
 import type { RuleFunction } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 import type { Scope } from "@typescript-eslint/utils/ts-eslint";
 

--- a/examples/react-dom-with-custom-rules/tsconfig.node.json
+++ b/examples/react-dom-with-custom-rules/tsconfig.node.json
@@ -19,7 +19,7 @@
     "*.cts",
     "*.mts",
     "*.d.ts",
-    "rules/**/*.ts"
+    ".config/*.ts"
   ],
   "exclude": [
     "node_modules",

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.ts
@@ -2,7 +2,7 @@ import * as core from "@eslint-react/core";
 import type { RuleContext, RuleFeature } from "@eslint-react/shared";
 import { defineRuleListener, getSettingsFromContext } from "@eslint-react/shared";
 import type { Scope } from "@typescript-eslint/scope-manager";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/utils";
 
 import { createRule, stringify } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.ts
+++ b/packages/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.ts
@@ -1,7 +1,7 @@
 import { isUseRefCall } from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import type { Scope } from "@typescript-eslint/scope-manager";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/utils";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 

--- a/packages/plugins/eslint-plugin-react-jsx/src/utils/jsx.ts
+++ b/packages/plugins/eslint-plugin-react-jsx/src/utils/jsx.ts
@@ -1,7 +1,6 @@
 import * as ast from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/shared";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 // ---------------------------------------------------------------------------
 // Pure string utilities (no AST knowledge)

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.ts
@@ -1,8 +1,7 @@
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { findEnclosingAssignmentTarget } from "@eslint-react/var";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
 
 import { createRule } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.ts
+++ b/packages/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.ts
@@ -2,8 +2,7 @@ import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { findEnclosingAssignmentTarget } from "@eslint-react/var";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
 
 import { createRule } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
@@ -2,7 +2,7 @@ import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { isValueEqual, resolve } from "@eslint-react/var";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/utils";
 import { getStaticValue } from "@typescript-eslint/utils/ast-utils";
 import { P, isMatching, match } from "ts-pattern";

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.ts
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.ts
@@ -1,7 +1,7 @@
 import type * as ast from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { findEnclosingAssignmentTarget, isAssignmentTargetEqual } from "@eslint-react/var";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/utils";
 import { P, isMatching } from "ts-pattern";
 

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
@@ -2,7 +2,7 @@ import * as ast from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { findEnclosingAssignmentTarget, isAssignmentTargetEqual, resolve } from "@eslint-react/var";
 import { or } from "@local/eff";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/utils";
 import { P, isMatching, match } from "ts-pattern";
 

--- a/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.ts
+++ b/packages/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.ts
@@ -1,7 +1,7 @@
 import type * as ast from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { findEnclosingAssignmentTarget, isAssignmentTargetEqual } from "@eslint-react/var";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/utils";
 import { P, isMatching } from "ts-pattern";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
@@ -3,8 +3,7 @@ import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener, getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { DefinitionType } from "@typescript-eslint/scope-manager";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 
 import { createRule } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
@@ -2,8 +2,7 @@ import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { constFalse, constTrue } from "@local/eff";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { match } from "ts-pattern";
 
 import { createRule } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
@@ -1,8 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener, report } from "@eslint-react/shared";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
 import { isMatching } from "ts-pattern";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
@@ -1,8 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update/no-redundant-should-component-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-redundant-should-component-update/no-redundant-should-component-update.ts
@@ -1,8 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.ts
@@ -1,7 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.ts
@@ -1,7 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.ts
@@ -1,7 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
@@ -2,8 +2,7 @@ import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { constFalse, constTrue } from "@local/eff";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { match } from "ts-pattern";
 
 import { createRule } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.ts
@@ -2,8 +2,7 @@ import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import { constFalse, constTrue } from "@local/eff";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, isMatching, match } from "ts-pattern";
 
 import { createRule } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
@@ -7,8 +7,7 @@ import {
   type RuleFeature,
   defineRuleListener,
 } from "@eslint-react/shared";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
@@ -3,8 +3,7 @@ import * as core from "@eslint-react/core";
 import { isUseRefCall } from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
 import type { Scope } from "@typescript-eslint/scope-manager";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
 import { P, isMatching, match } from "ts-pattern";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -5,8 +5,7 @@ import { type RuleContext, type RuleFeature, defineRuleListener, getSettingsFrom
 import { resolve } from "@eslint-react/var";
 import { constVoid, getOrInsertComputed, not } from "@local/eff";
 import type { Scope } from "@typescript-eslint/scope-manager";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable, getStaticValue } from "@typescript-eslint/utils/ast-utils";
 import { match } from "ts-pattern";
 

--- a/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
@@ -3,8 +3,7 @@ import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener, getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { not } from "@local/eff";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable, getStaticValue } from "@typescript-eslint/utils/ast-utils";
 
 import { createRule } from "../../utils";

--- a/packages/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.ts
+++ b/packages/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.ts
@@ -1,8 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, defineRuleListener } from "@eslint-react/shared";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
 

--- a/packages/utilities/ast/src/node-equality.test.ts
+++ b/packages/utilities/ast/src/node-equality.test.ts
@@ -1,8 +1,7 @@
 /// <reference types="node" />
 
 import { parseForESLint } from "@typescript-eslint/parser";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import path from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/utilities/ast/src/node-selectors.ts
+++ b/packages/utilities/ast/src/node-selectors.ts
@@ -1,4 +1,4 @@
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /**
  * Represents an arrow function expression with an implicit return

--- a/packages/utilities/ast/src/node-types.ts
+++ b/packages/utilities/ast/src/node-types.ts
@@ -1,4 +1,4 @@
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /**
  * Represents function expressions and declarations in TSESTree

--- a/packages/utilities/jsx/src/find-attribute.ts
+++ b/packages/utilities/jsx/src/find-attribute.ts
@@ -2,8 +2,7 @@ import * as ast from "@eslint-react/ast";
 import type { TSESTreeJSXAttributeLike } from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { getAttributeName } from "./get-attribute-name";
 

--- a/packages/utilities/jsx/src/find-parent-attribute.ts
+++ b/packages/utilities/jsx/src/find-parent-attribute.ts
@@ -1,6 +1,5 @@
 import { findParent } from "@eslint-react/ast";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
  * Walk **up** the AST from `node` to find the nearest ancestor that is a

--- a/packages/utilities/jsx/src/get-children.ts
+++ b/packages/utilities/jsx/src/get-children.ts
@@ -1,6 +1,5 @@
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
  * Get the **meaningful** children of a JSX element or fragment.

--- a/packages/utilities/jsx/src/has-children.ts
+++ b/packages/utilities/jsx/src/has-children.ts
@@ -1,6 +1,5 @@
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
  * Check whether a JSX element (or fragment) has **meaningful** children —

--- a/packages/utilities/jsx/src/is-element.ts
+++ b/packages/utilities/jsx/src/is-element.ts
@@ -1,6 +1,5 @@
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { getElementFullType } from "./get-element-type";
 

--- a/packages/utilities/jsx/src/is-fragment-element.ts
+++ b/packages/utilities/jsx/src/is-fragment-element.ts
@@ -1,6 +1,5 @@
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { getElementFullType } from "./get-element-type";
 

--- a/packages/utilities/jsx/src/is-host-element.ts
+++ b/packages/utilities/jsx/src/is-host-element.ts
@@ -1,5 +1,4 @@
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
  * Check whether a node is a **host** (intrinsic / DOM) element.

--- a/packages/utilities/jsx/src/is-jsx-like.ts
+++ b/packages/utilities/jsx/src/is-jsx-like.ts
@@ -1,8 +1,7 @@
 import * as ast from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { DEFAULT_JSX_DETECTION_HINT, type JsxDetectionHint, JsxDetectionHint as Hint } from "./jsx-detection-hint";
 

--- a/packages/utilities/jsx/src/is-jsx-text.ts
+++ b/packages/utilities/jsx/src/is-jsx-text.ts
@@ -1,5 +1,4 @@
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
  * Check whether a node is a JSX text node.

--- a/packages/utilities/jsx/src/is-whitespace.ts
+++ b/packages/utilities/jsx/src/is-whitespace.ts
@@ -1,5 +1,4 @@
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
  * Check whether a JSX child node is **whitespace padding** that React would

--- a/packages/utilities/jsx/src/resolve-attribute-value.ts
+++ b/packages/utilities/jsx/src/resolve-attribute-value.ts
@@ -1,8 +1,7 @@
 import type { TSESTreeJSXAttributeLike } from "@eslint-react/ast";
 import * as ast from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/shared";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { getStaticValue } from "@typescript-eslint/utils/ast-utils";
 import { P, match } from "ts-pattern";
 

--- a/packages/utilities/kit/README.md
+++ b/packages/utilities/kit/README.md
@@ -501,7 +501,7 @@ This is a simplified kit reimplementation of the built-in [`react-x/component-ho
 ```ts
 import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 
 function componentHookFactories(): RuleFunction {
   function findParent({ parent }: TSESTree.Node, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {

--- a/packages/utilities/kit/src/index.ts
+++ b/packages/utilities/kit/src/index.ts
@@ -2,7 +2,7 @@ import type { TSESTreeFunction } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import type { ESLintReactSettingsNormalized, RuleFix, RuleFixer, RuleListener } from "@eslint-react/shared";
 import { IdGenerator, getSettingsFromContext } from "@eslint-react/shared";
-import type { TSESTree } from "@typescript-eslint/utils";
+import type { TSESTree } from "@typescript-eslint/types";
 import type { RuleContext } from "@typescript-eslint/utils/ts-eslint";
 import type { ESLint, Linter } from "eslint";
 import { kebabCase } from "string-ts";

--- a/packages/utilities/var/src/compute-object-type.test.ts
+++ b/packages/utilities/var/src/compute-object-type.test.ts
@@ -1,8 +1,7 @@
 /// <reference types="node" />
 
 import * as tsParser from "@typescript-eslint/parser";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import { Linter } from "eslint";
 import { describe, expect, it } from "vitest";

--- a/packages/utilities/var/src/find-enclosing-assignment-target.test.ts
+++ b/packages/utilities/var/src/find-enclosing-assignment-target.test.ts
@@ -1,8 +1,7 @@
 /// <reference types="node" />
 
 import { parseForESLint } from "@typescript-eslint/parser";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import path from "node:path";
 import { describe, expect, it } from "vitest";

--- a/packages/utilities/var/src/is-assignment-target-equal.test.ts
+++ b/packages/utilities/var/src/is-assignment-target-equal.test.ts
@@ -1,8 +1,7 @@
 /// <reference types="node" />
 
 import * as tsParser from "@typescript-eslint/parser";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import { Linter } from "eslint";
 import { describe, expect, it } from "vitest";

--- a/packages/utilities/var/src/is-value-equal.test.ts
+++ b/packages/utilities/var/src/is-value-equal.test.ts
@@ -1,8 +1,7 @@
 /// <reference types="node" />
 
 import * as tsParser from "@typescript-eslint/parser";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import { Linter } from "eslint";
 import { describe, expect, it } from "vitest";

--- a/packages/utilities/var/src/resolve.test.ts
+++ b/packages/utilities/var/src/resolve.test.ts
@@ -1,8 +1,7 @@
 /// <reference types="node" />
 
 import * as tsParser from "@typescript-eslint/parser";
-import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import { Linter } from "eslint";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
- Import TSESTree from @typescript-eslint/types instead of @typescript-eslint/utils
- Merge AST_NODE_TYPES and TSESTree imports into single lines
- Update corresponding docs and examples

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
