### PR TITLE
  docs(website): enable twoslash type-checking for code examples

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -2,14 +2,9 @@ import { baseUrl } from "#/lib/metadata";
 import { RootProvider } from "fumadocs-ui/provider/next";
 import { Metadata } from "next";
 import { ViewTransitions } from "next-view-transitions";
-import { Inter } from "next/font/google";
 
 import "#/app/app.css";
 import "#/app/app.override.css";
-
-const inter = Inter({
-  subsets: ["latin"],
-});
 
 const themeOptions = {
   enabled: true,
@@ -30,7 +25,7 @@ export const metadata: Metadata = {
 export default function Layout({ children }: LayoutProps<"/">) {
   return (
     <ViewTransitions>
-      <html className={inter.className} lang="en" suppressHydrationWarning>
+      <html lang="en" suppressHydrationWarning>
         <meta content="#fff" name="msapplication-TileColor" />
         <meta content="en" httpEquiv="Content-Language" />
         <meta content="ESLint React" name="apple-mobile-web-app-title" />

--- a/apps/website/content/docs/configuration/configure-project-rules.mdx
+++ b/apps/website/content/docs/configuration/configure-project-rules.mdx
@@ -18,7 +18,7 @@ npm install --save-dev @eslint-react/kit
 
 Define custom rules directly in your `eslint.config.ts`:
 
-```ts copy filename="eslint.config.ts"
+```ts twoslash copy filename="eslint.config.ts"
 import eslintJs from "@eslint/js";
 import eslintReact from "@eslint-react/eslint-plugin";
 import eslintReactKit, { merge } from "@eslint-react/kit";

--- a/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
+++ b/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
@@ -226,7 +226,7 @@ npm install --save-dev @eslint-react/kit
 
 Below are drop-in rule definitions for the most commonly needed rules. Register them via the `.use()` chain in your config:
 
-```ts title="eslint.config.ts"
+```ts twoslash title="eslint.config.ts"
 import eslintReact from "@eslint-react/eslint-plugin";
 import eslintReactKit from "@eslint-react/kit";
 import { defineConfig } from "eslint/config";
@@ -248,7 +248,7 @@ import {
   jsxPropsNoSpreading,
   noAdjacentInlineElements,
   noMultiComp,
-} from "./.config";
+} from "@examples/react-dom-with-custom-rules";
 
 export default defineConfig([
   {
@@ -288,7 +288,7 @@ export default defineConfig([
 
 Require `onChange` or `readOnly` when using `checked` on `<input>`.
 
-```ts title=".config/checkedRequiresOnchangeOrReadonly.ts"
+```ts twoslash title=".config/checkedRequiresOnchangeOrReadonly.ts"
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Require `onChange` or `readOnly` when using `checked` on `<input>`. */
@@ -319,7 +319,7 @@ export function checkedRequiresOnchangeOrReadonly(): RuleFunction {
 
 Forbid certain props on React components (not DOM elements). Only reports on PascalCase elements.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link forbidComponentProps}. */
@@ -353,7 +353,7 @@ export function forbidComponentProps(options: ForbidComponentPropsOptions): Rule
 
 Forbid certain props on DOM elements (not React components). Only reports on lowercase DOM element names.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link forbidDomProps}. */
@@ -387,7 +387,7 @@ export function forbidDomProps(options: ForbidDomPropsOptions): RuleFunction {
 
 Forbid specific JSX elements. Customize the `forbidden` map with your project's requirements.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link forbidElements}. */
@@ -414,7 +414,7 @@ export function forbidElements(options: ForbidElementsOptions): RuleFunction {
 
 Enforce arrow function definitions for function components.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 
@@ -480,7 +480,7 @@ export function functionComponentDefinition(): RuleFunction {
 
 Enforce shorthand for boolean JSX attributes (e.g. prefer `<C disabled />` over `<C disabled={true} />`).
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Enforce shorthand for boolean JSX attributes. */
@@ -504,8 +504,9 @@ export function jsxBooleanValue(): RuleFunction {
 
 Enforce shorthand syntax for React fragments. Reports when `<React.Fragment>` is used instead of `<>...</>`. Allows standard form when `key` prop is present.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
+import type { TSESTree } from "@typescript-eslint/types";
 
 /** Options for {@link jsxFragments}. */
 export type JsxsFragmentsOptions = {
@@ -575,7 +576,7 @@ export function jsxFragments(options: JsxsFragmentsOptions = {}): RuleFunction {
 
 Enforce naming convention for JSX event handler props and the functions they reference.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxHandlerNames}. */
@@ -645,7 +646,7 @@ export function jsxHandlerNames(options: JsxHandlerNamesOptions = {}): RuleFunct
 
 Enforce a maximum depth for JSX elements.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxMaxDepth}. */
@@ -683,7 +684,7 @@ export function jsxMaxDepth(options: JsxMaxDepthOptions): RuleFunction {
 
 Prevent arrow functions, function expressions, and `.bind()` in JSX props.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Prevent inline functions and `.bind()` in JSX props. */
@@ -713,7 +714,7 @@ export function jsxNoBind(): RuleFunction {
 
 Disallow duplicate properties in JSX elements.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxNoDuplicateProps}. */
@@ -750,7 +751,7 @@ export function jsxNoDuplicateProps(options: JsxNoDuplicatePropsOptions = {}): R
 
 Disallow usage of string literals in JSX. By default requires wrapping strings in JSX expressions `{'TEXT'}`.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxNoLiterals}. */
@@ -826,7 +827,7 @@ export function jsxNoLiterals(options: JsxNoLiteralsOptions = {}): RuleFunction 
 
 Enforce PascalCase for user-defined JSX components. DOM elements like `<div>` are ignored.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Options for {@link jsxPascalCase}. */
@@ -891,7 +892,7 @@ export function jsxPascalCase(options: JsxPascalCaseOptions = {}): RuleFunction 
 
 Disallow spreading the same expression multiple times in a JSX element.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Disallow JSX prop spreading the same identifier multiple times. */
@@ -927,7 +928,7 @@ export function jsxPropsNoSpreadMulti(): RuleFunction {
 
 Disallow JSX props spreading.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 /** Disallow JSX props spreading. */
@@ -947,7 +948,7 @@ export function jsxPropsNoSpreading(): RuleFunction {
 
 Disallow adjacent inline elements not separated by whitespace.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 
@@ -1020,7 +1021,7 @@ export function noAdjacentInlineElements(): RuleFunction {
 
 Prevent defining more than one component per file.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 import { merge } from "@eslint-react/kit";
 

--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -22,7 +22,7 @@ npm install --save-dev @eslint-react/kit
 
 ## Quick Start
 
-```ts title="eslint.config.ts"
+```ts twoslash title="eslint.config.ts"
 import eslintReact from "@eslint-react/eslint-plugin";
 import eslintReactKit, { merge } from "@eslint-react/kit";
 import type { RuleFunction } from "@eslint-react/kit";
@@ -351,7 +351,7 @@ Exposes the normalized `react-x` settings from the ESLint shared configuration (
 
 **Usage:**
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 
 function version(major = "19"): RuleFunction {
@@ -374,8 +374,9 @@ function version(major = "19"): RuleFunction {
 
 This is a simplified kit reimplementation of the built-in [`react-x/no-forwardRef`](/docs/rules/no-forward-ref) rule.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
+import eslintReactKit, { merge } from "@eslint-react/kit";
 
 function noForwardRef(): RuleFunction {
   return (context, { is }) => ({
@@ -397,9 +398,9 @@ eslintReactKit()
 
 This is a simplified kit reimplementation of the built-in [`react-x/prefer-destructuring-assignment`](/docs/rules/prefer-destructuring-assignment) rule.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
-import { merge } from "@eslint-react/kit";
+import eslintReactKit, { merge } from "@eslint-react/kit";
 
 function destructureComponentProps(): RuleFunction {
   return (context, { collect }) => {
@@ -438,9 +439,9 @@ eslintReactKit()
 
 This is a simplified kit reimplementation of the built-in [`react-x/no-unnecessary-use-prefix`](/docs/rules/no-unnecessary-use-prefix) rule.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
-import { merge } from "@eslint-react/kit";
+import eslintReactKit, { merge } from "@eslint-react/kit";
 
 function noUnnecessaryUsePrefix(): RuleFunction {
   return (context, { collect }) => {
@@ -472,9 +473,9 @@ eslintReactKit()
 Disallow defining components or hooks inside other functions (factory pattern).
 This is a simplified kit reimplementation of the built-in [`react-x/component-hook-factories`](/docs/rules/component-hook-factories) rule.
 
-```ts
+```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
-import { merge } from "@eslint-react/kit";
+import eslintReactKit, { merge } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 
 function findParent({ parent }: TSESTree.Node, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {
@@ -523,9 +524,32 @@ eslintReactKit()
 
 `getConfig()` returns a plain config object. You can spread it into a new object to override or supplement its properties — for example, to scope the config to specific files or add extra settings alongside your kit rules.
 
-```ts title="eslint.config.ts"
+```ts twoslash title="eslint.config.ts"
 import eslintReactKit from "@eslint-react/kit";
 import type { RuleFunction } from "@eslint-react/kit";
+
+function noForwardRef(): RuleFunction {
+  return (context, { is }) => ({
+    CallExpression(node) {
+      if (is.forwardRefCall(node)) {
+        context.report({ node, message: "forwardRef is deprecated in React 19. Pass ref as a prop instead." });
+      }
+    },
+  });
+}
+
+function version(major = "19"): RuleFunction {
+  return (context, { settings }) => ({
+    Program(program) {
+      if (!settings.version.startsWith(`${major}.`)) {
+        context.report({
+          node: program,
+          message: `This project requires React ${major}, but detected version ${settings.version}.`,
+        });
+      }
+    },
+  });
+}
 
 // Spread the config into a new object to add or override properties like `files`:
 export default [
@@ -548,9 +572,32 @@ This pattern is especially useful when composing kit configs alongside other ESL
 
 Use `getPlugin()` when you want full control over the plugin namespace and rule severities instead of the all-in-one `getConfig()`.
 
-```ts title="eslint.config.ts"
+```ts twoslash title="eslint.config.ts"
 import eslintReactKit from "@eslint-react/kit";
 import type { RuleFunction } from "@eslint-react/kit";
+
+function noForwardRef(): RuleFunction {
+  return (context, { is }) => ({
+    CallExpression(node) {
+      if (is.forwardRefCall(node)) {
+        context.report({ node, message: "forwardRef is deprecated in React 19. Pass ref as a prop instead." });
+      }
+    },
+  });
+}
+
+function version(major = "19"): RuleFunction {
+  return (context, { settings }) => ({
+    Program(program) {
+      if (!settings.version.startsWith(`${major}.`)) {
+        context.report({
+          node: program,
+          message: `This project requires React ${major}, but detected version ${settings.version}.`,
+        });
+      }
+    },
+  });
+}
 
 const kit = eslintReactKit()
   .use(noForwardRef)

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,9 +12,11 @@
   },
   "dependencies": {
     "@eslint-react/kit": "workspace:*",
+    "@examples/react-dom-with-custom-rules": "workspace:*",
     "@local/configs": "workspace:*",
     "@local/eff": "workspace:*",
     "@takumi-rs/image-response": "^0.73.1",
+    "@typescript-eslint/types": "^8.58.2",
     "bsky-react-post": "^0.1.7",
     "clsx": "^2.1.1",
     "effect": "^3.21.0",

--- a/examples/react-dom-with-custom-rules/package.json
+++ b/examples/react-dom-with-custom-rules/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./.config/index.ts",
+      "import": "./.config/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc && vite build",
     "dev": "vite",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,9 @@ importers:
       '@eslint-react/kit':
         specifier: workspace:*
         version: link:../../packages/utilities/kit
+      '@examples/react-dom-with-custom-rules':
+        specifier: workspace:*
+        version: link:../../examples/react-dom-with-custom-rules
       '@local/configs':
         specifier: workspace:*
         version: link:../../.pkgs/configs
@@ -239,6 +242,9 @@ importers:
       '@takumi-rs/image-response':
         specifier: ^0.73.1
         version: 0.73.1
+      '@typescript-eslint/types':
+        specifier: ^8.58.2
+        version: 8.58.2
       bsky-react-post:
         specifier: ^0.1.7
         version: 0.1.7(react@19.2.4)(swr@2.4.1(react@19.2.4))


### PR DESCRIPTION
  - Add `twoslash` annotations to TypeScript code blocks across docs
  - Fix missing imports and undefined variables in kit examples to satisfy twoslash
  - Replace relative `./.config` imports with `@examples/react-dom-with-custom-rules`
  - Add `exports` field to `examples/react-dom-with-custom-rules/package.json`
  - Add `@examples/react-dom-with-custom-rules` and `@typescript-eslint/types` dependencies to `apps/website`
  - Remove unused `Inter` font from website layout

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
