### PR TITLE
feat: add component-name rule to eslint-plugin-react-naming-convention

### DIFF
--- a/plugins/eslint-plugin-react-naming-convention/src/configs/recommended.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/configs/recommended.ts
@@ -5,6 +5,7 @@ import { plugin } from "../plugin";
 export const name = "react-naming-convention/recommended";
 
 export const rules = {
+  "react-naming-convention/component-name": "warn",
   "react-naming-convention/context-name": "warn",
   "react-naming-convention/id-name": "warn",
   "react-naming-convention/ref-name": "warn",

--- a/plugins/eslint-plugin-react-naming-convention/src/plugin.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/plugin.ts
@@ -2,6 +2,7 @@ import type { ESLint } from "eslint";
 
 import { name, version } from "../package.json";
 
+import componentName from "./rules/component-name/component-name";
 import contextName from "./rules/context-name/context-name";
 import idName from "./rules/id-name/id-name";
 import refName from "./rules/ref-name/ref-name";
@@ -12,6 +13,7 @@ export const plugin = {
     version,
   },
   rules: {
+    ["component-name"]: componentName,
     ["context-name"]: contextName,
     ["id-name"]: idName,
     ["ref-name"]: refName,

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.mdx
@@ -1,0 +1,95 @@
+---
+title: component-name
+description: Enforces the component name to be a valid PascalCase identifier.
+---
+
+**Full Name in `eslint-plugin-react-naming-convention`**
+
+```plain copy
+react-naming-convention/component-name
+```
+
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
+
+```plain copy
+@eslint-react/naming-convention-component-name
+```
+
+**Presets**
+
+`recommended`
+`recommended-typescript`
+`recommended-type-checked`
+`strict`
+`strict-typescript`
+`strict-type-checked`
+
+## Rule Details
+
+Enforces that any function containing or returning JSX is named using PascalCase. Functions prefixed with `use` (React hooks) and anonymous functions are exempt.
+
+## Common Violations
+
+### Invalid
+
+```tsx
+function myComponent() {
+  return <div />;
+}
+```
+
+```tsx
+const myComponent = () => <div />;
+```
+
+```tsx
+const myComponent = () => {
+  return <div />;
+};
+```
+
+```tsx
+const myComponent = () => <></>;
+```
+
+### Valid
+
+```tsx
+function MyComponent() {
+  return <div />;
+}
+```
+
+```tsx
+const MyComponent = () => <div />;
+```
+
+```tsx
+const MyComponent = () => {
+  return <div />;
+};
+```
+
+### Valid (hooks are exempt)
+
+```tsx
+const useMyHook = () => <div />;
+```
+
+### Valid (anonymous exports are exempt)
+
+```tsx
+export default function () {
+  return <div />;
+}
+```
+
+## Resources
+
+- [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.ts)
+- [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.spec.ts)
+
+## Further Reading
+
+- [React Docs: Your First Component](https://react.dev/learn/your-first-component)
+- [React Docs: Thinking in React](https://react.dev/learn/thinking-in-react)

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.spec.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.spec.ts
@@ -1,0 +1,117 @@
+import tsx from "dedent";
+
+import { ruleTester } from "../../../../../test";
+import rule, { RULE_NAME } from "./component-name";
+
+ruleTester.run(RULE_NAME, rule, {
+  invalid: [
+    {
+      code: tsx`
+        function myComponent() {
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+    {
+      code: tsx`
+        function mycomponent() {
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+    {
+      code: tsx`
+        const myComponent = () => <div />;
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+    {
+      code: tsx`
+        const myComponent = () => {
+          return <div />;
+        };
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+    {
+      code: tsx`
+        const myComponent = function () {
+          return <div />;
+        };
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+    {
+      code: tsx`
+        const myComponent = function myComponent() {
+          return <div />;
+        };
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+    {
+      code: tsx`
+        function myComponent() {
+          return (
+            <div>
+              <span />
+            </div>
+          );
+        }
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+    {
+      code: tsx`
+        const myComponent = () => <></>;
+      `,
+      errors: [{ messageId: "invalidComponentName" }],
+    },
+  ],
+  valid: [
+    tsx`
+      function MyComponent() {
+        return <div />;
+      }
+    `,
+    tsx`
+      const MyComponent = () => <div />;
+    `,
+    tsx`
+      const MyComponent = () => {
+        return <div />;
+      };
+    `,
+    tsx`
+      const MyComponent = function () {
+        return <div />;
+      };
+    `,
+    tsx`
+      const MyComponent = () => <></>;
+    `,
+    tsx`
+      const useMyHook = () => <div />;
+    `,
+    tsx`
+      function useMyHook() {
+        return <div />;
+      }
+    `,
+    tsx`
+      function helper() {
+        return "string";
+      }
+    `,
+    tsx`
+      const helper = () => 42;
+    `,
+    tsx`
+      export default function () {
+        return <div />;
+      }
+    `,
+  ],
+});

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/component-name/component-name.ts
@@ -1,0 +1,108 @@
+import * as core from "@eslint-react/core";
+import {
+  type RuleContext,
+  type RuleFeature,
+  merge,
+} from "@eslint-react/eslint";
+import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
+import type { TSESTree } from "@typescript-eslint/types";
+import { P, match } from "ts-pattern";
+
+import { createRule } from "../../utils";
+
+export const RULE_NAME = "component-name";
+
+export const RULE_FEATURES = [] as const satisfies RuleFeature[];
+
+export type MessageID = "invalidComponentName";
+
+type FunctionNode =
+  | TSESTree.ArrowFunctionExpression
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression;
+
+export default createRule<[], MessageID>({
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Enforces the component name to be a valid PascalCase identifier.",
+    },
+    messages: {
+      invalidComponentName: "Component '{{name}}' must be named in PascalCase.",
+    },
+    schema: [],
+  },
+  name: RULE_NAME,
+  create,
+  defaultOptions: [],
+});
+
+export function create(context: RuleContext<MessageID, []>) {
+  const jsxFunctions = new WeakSet<FunctionNode>();
+
+  function markEnclosingFunction(node: TSESTree.Node) {
+    let current: TSESTree.Node | undefined = node.parent;
+    while (current) {
+      if (
+        current.type === AST.FunctionDeclaration ||
+        current.type === AST.FunctionExpression ||
+        current.type === AST.ArrowFunctionExpression
+      ) {
+        jsxFunctions.add(current as FunctionNode);
+        return;
+      }
+      current = current.parent;
+    }
+  }
+
+  function checkFunction(node: FunctionNode) {
+    if (!jsxFunctions.has(node)) return;
+    const [id, name] = match(node)
+      .with(
+        {
+          type: AST.FunctionDeclaration,
+          id: { type: AST.Identifier, name: P.string },
+        },
+        (fn) => [fn.id, fn.id.name] as const,
+      )
+      .with(
+        {
+          parent: {
+            type: AST.VariableDeclarator,
+            id: { type: AST.Identifier, name: P.string },
+          },
+        },
+        (fn) => {
+          const parent = fn.parent as TSESTree.VariableDeclarator;
+          const varId = parent.id as TSESTree.Identifier;
+          return [varId, varId.name] as const;
+        },
+      )
+      .with(
+        {
+          type: AST.FunctionExpression,
+          id: { type: AST.Identifier, name: P.string },
+        },
+        (fn) => [fn.id, fn.id.name] as const,
+      )
+      .otherwise(() => [null, null] as const);
+
+    if (id == null || name == null) return;
+    if (name.startsWith("use")) return;
+    if (core.isFunctionComponentName(name)) return;
+    context.report({
+      data: { name },
+      messageId: "invalidComponentName",
+      node: id,
+    });
+  }
+
+  return merge({
+    JSXElement: markEnclosingFunction,
+    JSXFragment: markEnclosingFunction,
+    "ArrowFunctionExpression:exit": checkFunction,
+    "FunctionDeclaration:exit": checkFunction,
+    "FunctionExpression:exit": checkFunction,
+  });
+}


### PR DESCRIPTION
Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
Adds a new `react-naming-convention/component-name` rule that enforces PascalCase naming for any function that returns or contains JSX. Functions prefixed with `use` (React hooks) and anonymous functions are exempt.