### PR TITLE
  feat(eslint-plugin-react-rsc): add directive position and quote checks to function-definition

### DIFF
--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.mdx
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.mdx
@@ -38,6 +38,10 @@ react-rsc/function-definition
 It includes the following checks:
 
 1. If a file has a top-level `'use server'` directive, exported functions must be async. Functions with their own `'use server'` directive must also be async.
+2. If a file has a top-level `'use client'` or `'use server'` directive, it must be placed at the very beginning of the file, before any imports or other code. Comments above the directive are allowed.
+3. If a function has a `'use server'` directive, it must be placed at the very beginning of the function body.
+4. `'use client'` and `'use server'` directives must be written with single or double quotes, not backticks.
+5. The `'use client'` directive must not be used inside a function body.
 
 ## Common Violations
 
@@ -119,6 +123,61 @@ export function Component() {
 }
 ```
 
+### Invalid
+
+```tsx
+import { useState } from 'react';
+
+'use client';
+```
+
+```tsx
+export function Component() {
+  const x = 1;
+
+  function serverFunction() {
+    'use server';
+    // ...
+  }
+}
+```
+
+```tsx
+`use client`;
+```
+
+```tsx
+export function Component() {
+  function serverFunction() {
+    'use client';
+    // ...
+  }
+}
+```
+
+### Valid
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+```
+
+```tsx
+export function Component() {
+  async function serverFunction() {
+    'use server';
+    // ...
+  }
+}
+```
+
+```tsx
+"use client";
+
+import { useState } from 'react';
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts)
@@ -126,4 +185,6 @@ export function Component() {
 
 ## Further Reading
 
+- [React Docs: `'use client'` Caveats](https://react.dev/reference/rsc/use-client#caveats)
+- [React Docs: `'use server'` Caveats](https://react.dev/reference/rsc/use-server#caveats)
 - [Next.js Docs: Invalid "use server" Value](https://nextjs.org/docs/messages/invalid-use-server-value).

--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.spec.ts
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.spec.ts
@@ -270,8 +270,124 @@ ruleTester.run(RULE_NAME, rule, {
         export { serverFunction };
       `,
     },
+    {
+      code: tsx`
+        import React from 'react';
+        'use client';
+      `,
+      errors: [{ messageId: "fileDirectivePosition" }],
+    },
+    {
+      code: tsx`
+        import React from 'react';
+        'use server';
+      `,
+      errors: [{ messageId: "fileDirectivePosition" }],
+    },
+    {
+      code: tsx`
+        const x = 1;
+        'use client';
+      `,
+      errors: [{ messageId: "fileDirectivePosition" }],
+    },
+    {
+      code: tsx`
+        \`use client\`;
+      `,
+      errors: [{ messageId: "fileDirectiveQuote" }],
+    },
+    {
+      code: tsx`
+        \`use server\`;
+      `,
+      errors: [{ messageId: "fileDirectiveQuote" }],
+    },
+    {
+      code: tsx`
+        export function Component() {
+          async function serverFunction() {
+            const x = 1;
+            'use server';
+            return 42;
+          }
+
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "localDirectivePosition" }],
+    },
+    {
+      code: tsx`
+        export function Component() {
+          async function serverFunction() {
+            \`use server\`;
+            return 42;
+          }
+
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "localDirectiveQuote" }],
+    },
+    {
+      code: tsx`
+        export function Component() {
+          function serverFunction() {
+            'use client';
+            return 42;
+          }
+
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "localDirectiveUnexpected" }],
+    },
+    {
+      code: tsx`
+        export function Component() {
+          function serverFunction() {
+            \`use client\`;
+            return 42;
+          }
+
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "localDirectiveQuote" }],
+    },
+    {
+      code: tsx`
+        export const x = 1;
+        'use server';
+      `,
+      errors: [{ messageId: "fileDirectivePosition" }],
+    },
+    {
+      code: tsx`
+        export function Component() {
+          async function serverFunction() {
+            return 42;
+            'use server';
+          }
+
+          return <div />;
+        }
+      `,
+      errors: [{ messageId: "localDirectivePosition" }],
+    },
   ],
   valid: [
+    tsx`
+      "use strict";
+      'use client';
+    `,
+    tsx`
+      'use client';
+      export function clientFunction() {
+        return 42;
+      }
+    `,
     tsx`
       'use server';
       export async function serverFunction() {
@@ -325,6 +441,64 @@ ruleTester.run(RULE_NAME, rule, {
       export function Component() {
         const serverFunction = async () => {
           'use server';
+          return 42;
+        }
+
+        return <div />;
+      }
+    `,
+    tsx`
+      'use client';
+      import { useState } from 'react';
+    `,
+    tsx`
+      // comment
+      'use client';
+    `,
+    tsx`
+      /* comment */
+      'use server';
+      export async function serverFunction() {
+        return 42;
+      }
+    `,
+    tsx`
+      export function Component() {
+        async function serverFunction() {
+          'use strict';
+          'use server';
+          return 42;
+        }
+
+        return <div />;
+      }
+    `,
+    tsx`
+      "use client";
+      import { useState } from 'react';
+    `,
+    tsx`
+      "use server";
+      export async function serverFunction() {
+        return 42;
+      }
+    `,
+    tsx`
+      export function Component() {
+        async function serverFunction() {
+          "use server";
+          return 42;
+        }
+
+        return <div />;
+      }
+    `,
+    tsx`
+      \`use \${"client"}\`;
+    `,
+    tsx`
+      export function Component() {
+        async function serverFunction() {
           return 42;
         }
 

--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
@@ -14,7 +14,14 @@ import { createRule } from "../../utils";
 
 export const RULE_NAME = "function-definition";
 
-export type MessageID = "file" | "local";
+export type MessageID =
+  | "file"
+  | "fileDirectivePosition"
+  | "fileDirectiveQuote"
+  | "local"
+  | "localDirectivePosition"
+  | "localDirectiveQuote"
+  | "localDirectiveUnexpected";
 
 export const RULE_FEATURES = [
   "FIX",
@@ -31,7 +38,14 @@ export default createRule<[], MessageID>({
     messages: {
       file:
         "Functions exported from files with `use server` directive are React Server Functions and therefore must be async.",
+      fileDirectivePosition:
+        "The '{{name}}' directive must be at the very beginning of the file, before any imports or other code.",
+      fileDirectiveQuote: "The '{{name}}' directive must be written with single or double quotes, not backticks.",
       local: "Functions with `use server` directive are React Server Functions and therefore must be async.",
+      localDirectivePosition: "The '{{name}}' directive must be at the very beginning of the function body.",
+      localDirectiveQuote: "The '{{name}}' directive must be written with single or double quotes, not backticks.",
+      localDirectiveUnexpected:
+        "The '{{name}}' directive can only be used at the top of a file, not inside a function body.",
     },
     schema: [],
   },
@@ -41,8 +55,11 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  // Fast path: skip if `use server` is not present in the entire file for performance
-  if (!context.sourceCode.text.includes("use server")) return {};
+  const hasUseServer = context.sourceCode.text.includes("use server");
+  const hasUseClient = context.sourceCode.text.includes("use client");
+
+  // Fast path: skip if neither `use server` nor `use client` is present
+  if (!hasUseServer && !hasUseClient) return {};
 
   const hasFileLevelUseServerDirective = context.sourceCode.ast.body.some(Check.isDirective("use server"));
 
@@ -103,9 +120,96 @@ export function create(context: RuleContext<MessageID, []>) {
     reportNonAsyncFunction(unwrapped, "file");
   }
 
+  /**
+   * Check file-level directives for correct position and quote style.
+   * Well-formed directives at the beginning of the file will have a `directive` property.
+   * If they appear after other code, the parser will not set `directive`.
+   */
+  function checkFileLevelDirectives() {
+    for (const node of context.sourceCode.ast.body) {
+      if (node.type !== AST.ExpressionStatement) continue;
+
+      if (Check.isLiteral("string")(node.expression)) {
+        const value = node.expression.value;
+        if ((value === "use server" || value === "use client") && node.directive == null) {
+          context.report({
+            data: { name: value },
+            messageId: "fileDirectivePosition",
+            node,
+          });
+        }
+        continue;
+      }
+
+      if (
+        node.expression.type === AST.TemplateLiteral
+        && node.expression.quasis.length === 1
+        && node.expression.expressions.length === 0
+      ) {
+        const value = node.expression.quasis[0]?.value.cooked;
+        if (value === "use server" || value === "use client") {
+          context.report({
+            data: { name: value },
+            messageId: "fileDirectiveQuote",
+            node,
+          });
+        }
+      }
+    }
+  }
+
+  /**
+   * Check function-level directives for correct position and quote style.
+   * @param node The function node to check
+   */
+  function checkFunctionDirectives(
+    node: TSESTree.FunctionDeclaration | TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression,
+  ) {
+    if (node.body.type !== AST.BlockStatement) return;
+
+    for (const stmt of node.body.body) {
+      if (stmt.type !== AST.ExpressionStatement) continue;
+
+      if (Check.isLiteral("string")(stmt.expression)) {
+        const value = stmt.expression.value;
+        if (value === "use server" && stmt.directive == null) {
+          context.report({
+            data: { name: value },
+            messageId: "localDirectivePosition",
+            node: stmt,
+          });
+        }
+        if (value === "use client") {
+          context.report({
+            data: { name: value },
+            messageId: "localDirectiveUnexpected",
+            node: stmt,
+          });
+        }
+        continue;
+      }
+
+      if (
+        stmt.expression.type === AST.TemplateLiteral
+        && stmt.expression.quasis.length === 1
+        && stmt.expression.expressions.length === 0
+      ) {
+        const value = stmt.expression.quasis[0]?.value.cooked;
+        if (value === "use server" || value === "use client") {
+          context.report({
+            data: { name: value },
+            messageId: "localDirectiveQuote",
+            node: stmt,
+          });
+        }
+      }
+    }
+  }
+
   return merge(
     {
       ArrowFunctionExpression(node) {
+        checkFunctionDirectives(node);
         checkLocalServerFunction(node);
       },
       ExportDefaultDeclaration(node) {
@@ -151,10 +255,15 @@ export function create(context: RuleContext<MessageID, []>) {
         }
       },
       FunctionDeclaration(node) {
+        checkFunctionDirectives(node);
         checkLocalServerFunction(node);
       },
       FunctionExpression(node) {
+        checkFunctionDirectives(node);
         checkLocalServerFunction(node);
+      },
+      Program() {
+        checkFileLevelDirectives();
       },
     },
   );


### PR DESCRIPTION
- Check file-level 'use client' and 'use server' are at the beginning
- Check function-level 'use server' is at the beginning of the body
- Disallow backticks for both directives
- Disallow 'use client' inside function bodies
- Update docs with React official caveats references

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [x] Docs
- [x] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
