### PR TITLE
  refactor(scripts): improve consistency and maintainability of CLI tooling

### DIFF
--- a/scripts/generate-changelog.ts
+++ b/scripts/generate-changelog.ts
@@ -22,15 +22,19 @@ const CATEGORY_MAP = {
 const CATEGORY_ORDER = ["breaking", "feat", "fix", "perf", "docs"] as const;
 
 interface ParsedCommit {
-  category: string;
-  hash: string;
-  isBreaking: boolean;
-  message: string;
-  scope: string | undefined;
+  readonly category: string;
+  readonly hash: string;
+  readonly isBreaking: boolean;
+  readonly message: string;
+  readonly scope: string | undefined;
+}
+
+interface ParseResult {
+  readonly parsed: ParsedCommit[];
+  readonly skipped: string[];
 }
 
 function parseCommitLine(line: string): ParsedCommit | undefined {
-  // Format: "<hash> <type>(<scope>): <message>" or "<hash> <type>: <message>"
   // eslint-disable-next-line regexp/no-super-linear-backtracking
   const match = /^([a-f0-9]+)\s+(\w+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/u.exec(line.trim());
   if (match == null) return undefined;
@@ -92,12 +96,25 @@ function generateChangelogEntry(ver: string, grouped: Map<string, ParsedCommit[]
   return lines.join("\n");
 }
 
+function parseCommits(lines: string[]): ParseResult {
+  const parsed: ParsedCommit[] = [];
+  const skipped: string[] = [];
+  for (const line of lines) {
+    const commit = parseCommitLine(line);
+    if (commit != null) {
+      parsed.push(commit);
+    } else {
+      skipped.push(line);
+    }
+  }
+  return { parsed, skipped };
+}
+
 const getFromVersion = Effect.gen(function*() {
   const args = process.argv.slice(2);
   if (args[0] != null && args[0].length > 0) {
     return args[0].replace(/^v/, "");
   }
-  // Try to find the latest git tag
   const ce = yield* CommandExecutor.CommandExecutor;
   const tags = yield* ce.string(Command.make("git", "tag", "--sort=-v:refname", "--list", "v*")).pipe(
     Effect.map((s) => s.trim()),
@@ -126,39 +143,48 @@ const getCommitsSince = Effect.fnUntraced(
   },
 );
 
+const prependChangelogEntry = Effect.fnUntraced(
+  function*(entry: string) {
+    const fs = yield* FileSystem.FileSystem;
+    const existingChangelog = yield* fs.readFileString(CHANGELOG_PATH, "utf8").pipe(
+      Effect.catchAll(() => Effect.succeed("")),
+    );
+
+    const marker = "# Changelog";
+    const hasMarker = existingChangelog.startsWith(marker);
+    const newChangelog = hasMarker
+      ? `${marker}\n\n${entry}\n${existingChangelog.slice(marker.length + 1)}`
+      : `${marker}\n\n${entry}\n${existingChangelog}`;
+
+    yield* fs.writeFileString(CHANGELOG_PATH, newChangelog);
+    yield* Effect.log(ansis.bold.green(`Changelog entry prepended to ${CHANGELOG_PATH}.`));
+    yield* Effect.log(ansis.yellow("Please review and edit the generated entry before committing."));
+  },
+);
+
 const program = Effect.gen(function*() {
-  yield* Effect.log(ansis.bold("Generating changelog entry...\n"));
+  yield* Effect.log(ansis.bold("Generating changelog entry..."));
 
   const currentVersion = yield* version;
   yield* Effect.log(`Current version: ${ansis.bold(currentVersion)}`);
 
   const fromVersion = yield* getFromVersion;
-  yield* Effect.log(`Collecting commits since: ${ansis.bold(fromVersion)}\n`);
+  yield* Effect.log(`Collecting commits since: ${ansis.bold(fromVersion)}`);
 
   const commitLines = yield* getCommitsSince(fromVersion);
   if (commitLines.length === 0) {
     yield* Effect.logWarning(ansis.yellow("No commits found since the specified version."));
     return;
   }
-  yield* Effect.log(`Found ${ansis.bold(commitLines.length.toString())} commit(s).\n`);
+  yield* Effect.log(`Found ${ansis.bold(commitLines.length.toString())} commit(s).`);
 
-  const parsed: ParsedCommit[] = [];
-  const skipped: string[] = [];
-  for (const line of commitLines) {
-    const commit = parseCommitLine(line);
-    if (commit != null) {
-      parsed.push(commit);
-    } else {
-      skipped.push(line);
-    }
-  }
+  const { parsed, skipped } = parseCommits(commitLines);
 
   if (skipped.length > 0) {
     yield* Effect.log(ansis.yellow(`Skipped ${skipped.length} non-conventional commit(s):`));
     for (const line of skipped) {
       yield* Effect.log(ansis.dim(`  ${line}`));
     }
-    yield* Effect.log("");
   }
 
   if (parsed.length === 0) {
@@ -169,24 +195,10 @@ const program = Effect.gen(function*() {
   const grouped = groupCommits(parsed);
   const entry = generateChangelogEntry(currentVersion, grouped);
 
-  yield* Effect.log(ansis.bold("Generated changelog entry:\n"));
+  yield* Effect.log(ansis.bold("Generated changelog entry:"));
   yield* Effect.log(ansis.cyan(entry));
 
-  // Prepend to CHANGELOG.md
-  const fs = yield* FileSystem.FileSystem;
-  const existingChangelog = yield* fs.readFileString(CHANGELOG_PATH, "utf8").pipe(
-    Effect.catchAll(() => Effect.succeed("")),
-  );
-
-  const marker = "# Changelog";
-  const hasMarker = existingChangelog.startsWith(marker);
-  const newChangelog = hasMarker
-    ? `${marker}\n\n${entry}\n${existingChangelog.slice(marker.length + 1)}`
-    : `${marker}\n\n${entry}\n${existingChangelog}`;
-
-  yield* fs.writeFileString(CHANGELOG_PATH, newChangelog);
-  yield* Effect.log(ansis.bold.green(`\nChangelog entry prepended to ${CHANGELOG_PATH}.`));
-  yield* Effect.log(ansis.yellow("Please review and edit the generated entry before committing."));
+  yield* prependChangelogEntry(entry);
 });
 
 program.pipe(Effect.provide(NodeContext.layer), NodeRuntime.runMain);

--- a/scripts/rename-rule.ts
+++ b/scripts/rename-rule.ts
@@ -7,9 +7,7 @@ import * as Effect from "effect/Effect";
 
 import { glob } from "./lib/glob";
 
-// ─── CLI Arguments ────────────────────────────────────────────────────────────
-
-const VALID_PLUGINS = ["x", "dom", "jsx", "rsc", "web-api", "naming-convention", "debug"] as const;
+const VALID_PLUGINS = ["x", "jsx", "rsc", "dom", "web-api", "naming-convention", "debug"] as const;
 
 type PluginDomain = typeof VALID_PLUGINS[number];
 
@@ -38,8 +36,6 @@ function buildConfigKey(domain: PluginDomain, ruleName: string): string {
 function buildPluginPrefix(domain: PluginDomain): string {
   return `react-${domain}`;
 }
-
-// ─── Parse Arguments ──────────────────────────────────────────────────────────
 
 const parseArgs = Effect.gen(function*() {
   const args = process.argv.slice(2);
@@ -70,39 +66,33 @@ const parseArgs = Effect.gen(function*() {
   }
 
   return {
-    plugin: pluginArg as PluginDomain,
+    domain: pluginArg as PluginDomain,
     oldName,
     newName,
   };
 });
 
-// ─── Rename Source Files ──────────────────────────────────────────────────────
-
 const renameSourceFiles = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
-    const pluginDir = `plugins/eslint-plugin-react-${plugin}`;
+    const pluginDir = `plugins/eslint-plugin-react-${domain}`;
     const oldRuleDir = path.join(pluginDir, "src", "rules", oldName);
     const newRuleDir = path.join(pluginDir, "src", "rules", newName);
 
-    // Verify old rule directory exists
     const exists = yield* fs.exists(oldRuleDir);
     if (!exists) {
       return yield* Effect.fail(new Error(`Rule directory not found: ${oldRuleDir}`));
     }
 
-    // Verify new rule directory does NOT exist
     const newExists = yield* fs.exists(newRuleDir);
     if (newExists) {
       return yield* Effect.fail(new Error(`Target rule directory already exists: ${newRuleDir}`));
     }
 
-    // Create the new directory
     yield* fs.makeDirectory(newRuleDir, { recursive: true });
 
-    // Copy and rename each file
     const extensions = [".ts", ".spec.ts", ".mdx"];
     for (const ext of extensions) {
       const oldFile = path.join(oldRuleDir, `${oldName}${ext}`);
@@ -117,7 +107,6 @@ const renameSourceFiles = Effect.fnUntraced(
       }
     }
 
-    // Remove old directory
     yield* fs.remove(oldRuleDir, { recursive: true });
     yield* Effect.log(ansis.green(`  Removed old directory: ${oldRuleDir}`));
 
@@ -125,14 +114,12 @@ const renameSourceFiles = Effect.fnUntraced(
   },
 );
 
-// ─── Update Rule Implementation ──────────────────────────────────────────────
-
 const updateRuleImplementation = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
-    const pluginDir = `plugins/eslint-plugin-react-${plugin}`;
+    const pluginDir = `plugins/eslint-plugin-react-${domain}`;
     const ruleFile = path.join(pluginDir, "src", "rules", newName, `${newName}.ts`);
 
     const exists = yield* fs.exists(ruleFile);
@@ -142,8 +129,6 @@ const updateRuleImplementation = Effect.fnUntraced(
     }
 
     let content = yield* fs.readFileString(ruleFile, "utf8");
-
-    // Update RULE_NAME constant
     content = content.replace(
       `export const RULE_NAME = "${oldName}"`,
       `export const RULE_NAME = "${newName}"`,
@@ -154,14 +139,12 @@ const updateRuleImplementation = Effect.fnUntraced(
   },
 );
 
-// ─── Update Test File ─────────────────────────────────────────────────────────
-
 const updateTestFile = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
-    const pluginDir = `plugins/eslint-plugin-react-${plugin}`;
+    const pluginDir = `plugins/eslint-plugin-react-${domain}`;
     const specFile = path.join(pluginDir, "src", "rules", newName, `${newName}.spec.ts`);
 
     const exists = yield* fs.exists(specFile);
@@ -171,8 +154,6 @@ const updateTestFile = Effect.fnUntraced(
     }
 
     let content = yield* fs.readFileString(specFile, "utf8");
-
-    // Update import path
     content = content.replace(
       `from "./${oldName}"`,
       `from "./${newName}"`,
@@ -183,14 +164,12 @@ const updateTestFile = Effect.fnUntraced(
   },
 );
 
-// ─── Update Documentation ─────────────────────────────────────────────────────
-
 const updateDocumentation = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
-    const pluginDir = `plugins/eslint-plugin-react-${plugin}`;
+    const pluginDir = `plugins/eslint-plugin-react-${domain}`;
     const mdxFile = path.join(pluginDir, "src", "rules", newName, `${newName}.mdx`);
 
     const exists = yield* fs.exists(mdxFile);
@@ -199,31 +178,22 @@ const updateDocumentation = Effect.fnUntraced(
       return;
     }
 
-    const pluginPrefix = buildPluginPrefix(plugin);
-    const oldAggregatedKey = buildConfigKey(plugin, oldName);
-    const newAggregatedKey = buildConfigKey(plugin, newName);
+    const pluginPrefix = buildPluginPrefix(domain);
+    const oldAggregatedKey = buildConfigKey(domain, oldName);
+    const newAggregatedKey = buildConfigKey(domain, newName);
 
     let content = yield* fs.readFileString(mdxFile, "utf8");
 
-    // Update frontmatter title
     content = content.replace(`title: ${oldName}`, `title: ${newName}`);
-
-    // Update full name in eslint-plugin-react-* code block
     content = content.replace(`${pluginPrefix}/${oldName}`, `${pluginPrefix}/${newName}`);
-
-    // Update full name in @eslint-react/eslint-plugin code block
     content = content.replace(oldAggregatedKey, newAggregatedKey);
-
-    // Update Rule Source link
     content = content.replaceAll(
-      `eslint-plugin-react-${plugin}/src/rules/${oldName}/${oldName}.ts`,
-      `eslint-plugin-react-${plugin}/src/rules/${newName}/${newName}.ts`,
+      `eslint-plugin-react-${domain}/src/rules/${oldName}/${oldName}.ts`,
+      `eslint-plugin-react-${domain}/src/rules/${newName}/${newName}.ts`,
     );
-
-    // Update Test Source link
     content = content.replaceAll(
-      `eslint-plugin-react-${plugin}/src/rules/${oldName}/${oldName}.spec.ts`,
-      `eslint-plugin-react-${plugin}/src/rules/${newName}/${newName}.spec.ts`,
+      `eslint-plugin-react-${domain}/src/rules/${oldName}/${oldName}.spec.ts`,
+      `eslint-plugin-react-${domain}/src/rules/${newName}/${newName}.spec.ts`,
     );
 
     yield* fs.writeFileString(mdxFile, content);
@@ -231,14 +201,12 @@ const updateDocumentation = Effect.fnUntraced(
   },
 );
 
-// ─── Update Plugin Registration ───────────────────────────────────────────────
-
 const updatePluginRegistration = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
 
-    const pluginDir = `plugins/eslint-plugin-react-${plugin}`;
+    const pluginDir = `plugins/eslint-plugin-react-${domain}`;
     const pluginFile = path.join(pluginDir, "src", "plugin.ts");
 
     const exists = yield* fs.exists(pluginFile);
@@ -252,24 +220,18 @@ const updatePluginRegistration = Effect.fnUntraced(
 
     let content = yield* fs.readFileString(pluginFile, "utf8");
 
-    // Update import statement
     content = content.replace(
       `import ${oldCamel} from "./rules/${oldName}/${oldName}"`,
       `import ${newCamel} from "./rules/${newName}/${newName}"`,
     );
-
-    // Update rules map entry — handle both quoted key and computed key styles
-    // Style 1: "old-name": oldCamel,
     content = content.replace(
       `"${oldName}": ${oldCamel}`,
       `"${newName}": ${newCamel}`,
     );
-    // Style 2: ["old-name"]: oldCamel,
     content = content.replace(
       `["${oldName}"]: ${oldCamel}`,
       `["${newName}"]: ${newCamel}`,
     );
-    // Style 3: unquoted single-word key: oldCamel: oldCamel,
     if (!oldName.includes("-")) {
       content = content.replace(
         new RegExp(`(\\s)${oldName}: ${oldCamel}`, "u"),
@@ -282,14 +244,12 @@ const updatePluginRegistration = Effect.fnUntraced(
   },
 );
 
-// ─── Update Aggregated Plugin Configs ─────────────────────────────────────────
-
 const updateAggregatedConfigs = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
 
-    const oldConfigKey = buildConfigKey(plugin, oldName);
-    const newConfigKey = buildConfigKey(plugin, newName);
+    const oldConfigKey = buildConfigKey(domain, oldName);
+    const newConfigKey = buildConfigKey(domain, newName);
 
     const configGlob = ["plugins/eslint-plugin/src/configs/*.ts"];
     const configFiles = glob(configGlob);
@@ -314,17 +274,15 @@ const updateAggregatedConfigs = Effect.fnUntraced(
   },
 );
 
-// ─── Update Sub-Plugin Configs ────────────────────────────────────────────────
-
 const updateSubPluginConfigs = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
 
-    const pluginPrefix = buildPluginPrefix(plugin);
+    const pluginPrefix = buildPluginPrefix(domain);
     const oldSubKey = `${pluginPrefix}/${oldName}`;
     const newSubKey = `${pluginPrefix}/${newName}`;
 
-    const configGlob = [`plugins/eslint-plugin-react-${plugin}/src/configs/*.ts`];
+    const configGlob = [`plugins/eslint-plugin-react-${domain}/src/configs/*.ts`];
     const configFiles = glob(configGlob);
 
     let updatedCount = 0;
@@ -344,17 +302,15 @@ const updateSubPluginConfigs = Effect.fnUntraced(
   },
 );
 
-// ─── Update Rule Relations Table ──────────────────────────────────────────────
-
 const updateRuleRelationsTable = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string, newName: string) {
+  function*(domain: PluginDomain, oldName: string, newName: string) {
     const fs = yield* FileSystem.FileSystem;
     const relationsPath = "docs/rule-relations-table.md";
 
     const exists = yield* fs.exists(relationsPath);
     if (!exists) return;
 
-    const pluginPrefix = buildPluginPrefix(plugin);
+    const pluginPrefix = buildPluginPrefix(domain);
     const oldFullName = `${pluginPrefix}/${oldName}`;
     const newFullName = `${pluginPrefix}/${newName}`;
 
@@ -367,11 +323,9 @@ const updateRuleRelationsTable = Effect.fnUntraced(
   },
 );
 
-// ─── Verify No Leftover References ───────────────────────────────────────────
-
 const verifyNoLeftovers = Effect.fnUntraced(
-  function*(plugin: PluginDomain, oldName: string) {
-    const pluginDir = `plugins/eslint-plugin-react-${plugin}`;
+  function*(domain: PluginDomain, oldName: string) {
+    const pluginDir = `plugins/eslint-plugin-react-${domain}`;
     const aggregatedDir = "plugins/eslint-plugin";
 
     const allFiles = [
@@ -386,7 +340,6 @@ const verifyNoLeftovers = Effect.fnUntraced(
 
     for (const file of allFiles) {
       const content = yield* fs.readFileString(file, "utf8");
-      // Check for the old rule name in various forms
       if (
         content.includes(`"${oldName}"`)
         || content.includes(`/${oldName}/`)
@@ -401,49 +354,47 @@ const verifyNoLeftovers = Effect.fnUntraced(
   },
 );
 
-// ─── Main Program ─────────────────────────────────────────────────────────────
-
 const program = Effect.gen(function*() {
-  const { plugin, oldName, newName } = yield* parseArgs;
-  const pluginPrefix = buildPluginPrefix(plugin);
+  const { domain, oldName, newName } = yield* parseArgs;
+  const pluginPrefix = buildPluginPrefix(domain);
 
-  yield* Effect.log(ansis.bold(`Renaming rule: ${pluginPrefix}/${oldName} -> ${pluginPrefix}/${newName}\n`));
+  yield* Effect.log(ansis.bold(`Renaming rule: ${pluginPrefix}/${oldName} -> ${pluginPrefix}/${newName}`));
+  yield* Effect.log("");
 
-  // Step 1: Rename source files
   yield* Effect.log(ansis.bold("Step 1: Renaming source files..."));
-  yield* renameSourceFiles(plugin, oldName, newName);
+  yield* renameSourceFiles(domain, oldName, newName);
 
-  // Step 2: Update rule implementation
-  yield* Effect.log(ansis.bold("\nStep 2: Updating rule implementation..."));
-  yield* updateRuleImplementation(plugin, oldName, newName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 2: Updating rule implementation..."));
+  yield* updateRuleImplementation(domain, oldName, newName);
 
-  // Step 3: Update test file
-  yield* Effect.log(ansis.bold("\nStep 3: Updating test file..."));
-  yield* updateTestFile(plugin, oldName, newName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 3: Updating test file..."));
+  yield* updateTestFile(domain, oldName, newName);
 
-  // Step 4: Update documentation
-  yield* Effect.log(ansis.bold("\nStep 4: Updating documentation..."));
-  yield* updateDocumentation(plugin, oldName, newName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 4: Updating documentation..."));
+  yield* updateDocumentation(domain, oldName, newName);
 
-  // Step 5: Update plugin registration
-  yield* Effect.log(ansis.bold("\nStep 5: Updating plugin registration..."));
-  yield* updatePluginRegistration(plugin, oldName, newName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 5: Updating plugin registration..."));
+  yield* updatePluginRegistration(domain, oldName, newName);
 
-  // Step 6: Update aggregated plugin configs
-  yield* Effect.log(ansis.bold("\nStep 6: Updating aggregated plugin configs..."));
-  yield* updateAggregatedConfigs(plugin, oldName, newName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 6: Updating aggregated plugin configs..."));
+  yield* updateAggregatedConfigs(domain, oldName, newName);
 
-  // Step 7: Update sub-plugin configs
-  yield* Effect.log(ansis.bold("\nStep 7: Updating sub-plugin configs..."));
-  yield* updateSubPluginConfigs(plugin, oldName, newName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 7: Updating sub-plugin configs..."));
+  yield* updateSubPluginConfigs(domain, oldName, newName);
 
-  // Step 8: Update rule relations table
-  yield* Effect.log(ansis.bold("\nStep 8: Updating rule relations table..."));
-  yield* updateRuleRelationsTable(plugin, oldName, newName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 8: Updating rule relations table..."));
+  yield* updateRuleRelationsTable(domain, oldName, newName);
 
-  // Step 9: Verify no leftover references
-  yield* Effect.log(ansis.bold("\nStep 9: Checking for leftover references..."));
-  const leftovers = yield* verifyNoLeftovers(plugin, oldName);
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("Step 9: Checking for leftover references..."));
+  const leftovers = yield* verifyNoLeftovers(domain, oldName);
 
   if (leftovers.length > 0) {
     yield* Effect.logWarning(ansis.yellow(`  Found ${leftovers.length} file(s) with possible leftover references:`));
@@ -455,14 +406,14 @@ const program = Effect.gen(function*() {
     yield* Effect.log(ansis.green("  No leftover references found."));
   }
 
-  // Summary
+  yield* Effect.log("");
   yield* Effect.log(
-    ansis.bold.green(`\nRule renamed successfully: ${pluginPrefix}/${oldName} -> ${pluginPrefix}/${newName}`),
+    ansis.bold.green(`Rule renamed successfully: ${pluginPrefix}/${oldName} -> ${pluginPrefix}/${newName}`),
   );
-  yield* Effect.log(ansis.bold("\nRemaining manual steps:"));
+  yield* Effect.log(ansis.bold("Remaining manual steps:"));
   yield* Effect.log("  1. Update CHANGELOG.md with the rename entry");
   yield* Effect.log("  2. Run `pnpm run build` to verify the build");
-  yield* Effect.log("  3. Run `pnpm vitest run src/rules/${newName}/${newName}.spec.ts` to verify tests");
+  yield* Effect.log(`  3. Run \`pnpm vitest run src/rules/${newName}/${newName}.spec.ts\` to verify tests`);
   yield* Effect.log("  4. Run `pnpm run verify:rule-docs` to verify documentation");
 });
 

--- a/scripts/scaffold-rule.ts
+++ b/scripts/scaffold-rule.ts
@@ -5,29 +5,25 @@ import * as Path from "@effect/platform/Path";
 import ansis from "ansis";
 import * as Effect from "effect/Effect";
 
-const VALID_PLUGINS = ["x", "jsx", "dom", "rsc", "web-api", "naming-convention", "debug"] as const;
+const VALID_PLUGINS = ["x", "jsx", "rsc", "dom", "web-api", "naming-convention", "debug"] as const;
 
-type PluginName = typeof VALID_PLUGINS[number];
+type PluginDomain = typeof VALID_PLUGINS[number];
 
 function kebabToCamel(str: string): string {
   return str.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
 }
 
-function getPluginPackageName(plugin: PluginName): string {
-  return `eslint-plugin-react-${plugin}`;
+function buildPluginPrefix(domain: PluginDomain): string {
+  return `react-${domain}`;
 }
 
-function getPluginNpmName(plugin: PluginName): string {
-  return `eslint-plugin-react-${plugin}`;
+function buildConfigKey(domain: PluginDomain, ruleName: string): string {
+  if (domain === "x") return `@eslint-react/${ruleName}`;
+  return `@eslint-react/${domain}-${ruleName}`;
 }
 
-function getSubPluginPrefix(plugin: PluginName): string {
-  return `react-${plugin}`;
-}
-
-function getAggregatedRuleKey(plugin: PluginName, ruleName: string): string {
-  if (plugin === "x") return `@eslint-react/${ruleName}`;
-  return `@eslint-react/${plugin}-${ruleName}`;
+function buildPluginPackageName(domain: PluginDomain): string {
+  return `eslint-plugin-react-${domain}`;
 }
 
 function generateRuleTs(ruleName: string): string {
@@ -86,11 +82,10 @@ function generateRuleSpecTs(ruleName: string): string {
   ].join("\n");
 }
 
-function generateRuleMdx(plugin: PluginName, ruleName: string, description: string): string {
-  const subPluginPrefix = getSubPluginPrefix(plugin);
-  const aggregatedKey = getAggregatedRuleKey(plugin, ruleName);
-  const pluginNpmName = getPluginNpmName(plugin);
-  const pluginPkgName = getPluginPackageName(plugin);
+function generateRuleMdx(domain: PluginDomain, ruleName: string, description: string): string {
+  const pluginPrefix = buildPluginPrefix(domain);
+  const aggregatedKey = buildConfigKey(domain, ruleName);
+  const pluginPkgName = buildPluginPackageName(domain);
   const ruleSourceUrl =
     `https://github.com/Rel1cx/eslint-react/tree/main/plugins/${pluginPkgName}/src/rules/${ruleName}/${ruleName}.ts`;
   const testSourceUrl =
@@ -102,10 +97,10 @@ function generateRuleMdx(plugin: PluginName, ruleName: string, description: stri
     `description: ${description}`,
     `---`,
     ``,
-    `**Full Name in [\`${pluginNpmName}\`](https://npmx.dev/package/${pluginNpmName}/v/latest)**`,
+    `**Full Name in [\`${pluginPkgName}\`](https://npmx.dev/package/${pluginPkgName}/v/latest)**`,
     ``,
     "```plain copy",
-    `${subPluginPrefix}/${ruleName}`,
+    `${pluginPrefix}/${ruleName}`,
     "```",
     ``,
     `**Full Name in [\`@eslint-react/eslint-plugin\`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**`,
@@ -135,7 +130,6 @@ function generateRuleMdx(plugin: PluginName, ruleName: string, description: stri
 }
 
 function findImportInsertionIndex(lines: string[], importLine: string): number {
-  // Find the block of rule imports (lines starting with "import" and containing "./rules/")
   let lastRuleImportIndex = -1;
   for (let i = 0; i < lines.length; i++) {
     if (lines[i]!.startsWith("import ") && lines[i]!.includes("./rules/")) {
@@ -143,13 +137,11 @@ function findImportInsertionIndex(lines: string[], importLine: string): number {
     }
   }
   if (lastRuleImportIndex === -1) {
-    // Fallback: insert after the last import line
     for (let i = lines.length - 1; i >= 0; i--) {
       if (lines[i]!.startsWith("import ")) return i + 1;
     }
     return 0;
   }
-  // Find alphabetical insertion point within the rule import block
   let firstRuleImportIndex = lastRuleImportIndex;
   for (let i = lastRuleImportIndex; i >= 0; i--) {
     if (lines[i]!.startsWith("import ") && lines[i]!.includes("./rules/")) {
@@ -167,7 +159,6 @@ function findImportInsertionIndex(lines: string[], importLine: string): number {
 }
 
 function findRulesEntryInsertionIndex(lines: string[], entryKey: string): number {
-  // Find the "rules: {" line
   let rulesStartIndex = -1;
   let rulesEndIndex = -1;
   for (let i = 0; i < lines.length; i++) {
@@ -177,7 +168,6 @@ function findRulesEntryInsertionIndex(lines: string[], entryKey: string): number
     }
   }
   if (rulesStartIndex === -1) return -1;
-  // Find the closing brace of the rules object
   let depth = 0;
   for (let i = rulesStartIndex; i < lines.length; i++) {
     for (const ch of lines[i]!) {
@@ -190,11 +180,9 @@ function findRulesEntryInsertionIndex(lines: string[], entryKey: string): number
     }
   }
   if (rulesEndIndex === -1) return -1;
-  // Find alphabetical insertion point within the rules entries
   for (let i = rulesStartIndex + 1; i < rulesEndIndex; i++) {
     const line = lines[i]!.trim();
     if (line === "" || line.startsWith("//") || line.startsWith("/*")) continue;
-    // Extract the key from the line (handle both "key": and ["key"]: patterns)
     const keyMatch = /^(?:\[?")?([^"[\]]+)(?:"\]?)?:/u.exec(line);
     if (keyMatch?.[1] != null) {
       if (entryKey.localeCompare(keyMatch[1]) < 0) return i;
@@ -203,33 +191,7 @@ function findRulesEntryInsertionIndex(lines: string[], entryKey: string): number
   return rulesEndIndex;
 }
 
-const updatePluginTs = Effect.fnUntraced(
-  function*(pluginTsPath: string, ruleName: string) {
-    const fs = yield* FileSystem.FileSystem;
-    const content = yield* fs.readFileString(pluginTsPath, "utf8");
-    const lines = content.split("\n");
-
-    const camelName = kebabToCamel(ruleName);
-    const importLine = `import ${camelName} from "./rules/${ruleName}/${ruleName}";`;
-    const rulesEntry = `    "${ruleName}": ${camelName},`;
-
-    // Insert import
-    const importIndex = findImportInsertionIndex(lines, importLine);
-    lines.splice(importIndex, 0, importLine);
-
-    // Insert rules entry
-    const entryIndex = findRulesEntryInsertionIndex(lines, ruleName);
-    if (entryIndex === -1) {
-      return yield* Effect.fail(new Error(`Could not find rules object in ${pluginTsPath}`));
-    }
-    lines.splice(entryIndex, 0, rulesEntry);
-
-    yield* fs.writeFileString(pluginTsPath, lines.join("\n"));
-    yield* Effect.log(ansis.green(`  Updated ${pluginTsPath}`));
-  },
-);
-
-const program = Effect.gen(function*() {
+const parseArgs = Effect.gen(function*() {
   const args = process.argv.slice(2);
   if (args.length < 2) {
     yield* Effect.logError(
@@ -243,65 +205,95 @@ const program = Effect.gen(function*() {
     return yield* Effect.fail(new Error("Missing required arguments."));
   }
 
-  const [pluginArg, ruleName, ...descParts] = args;
+  const [pluginArg, ruleName, ...descParts] = args as [string, string, ...string[]];
   const description = descParts.join(" ") || "TODO: Add rule description.";
 
-  if (!VALID_PLUGINS.includes(pluginArg as PluginName)) {
+  if (!VALID_PLUGINS.includes(pluginArg as PluginDomain)) {
     return yield* Effect.fail(
       new Error(`Invalid plugin "${pluginArg}". Must be one of: ${VALID_PLUGINS.join(", ")}`),
     );
   }
-  const plugin = pluginArg as PluginName;
 
-  if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/u.test(ruleName!)) {
+  if (!/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/u.test(ruleName)) {
     return yield* Effect.fail(
       new Error(`Invalid rule name "${ruleName}". Must be kebab-case (e.g. no-foo-bar).`),
     );
   }
 
-  const fs = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
+  return { domain: pluginArg as PluginDomain, ruleName, description };
+});
 
-  const pluginPkgName = getPluginPackageName(plugin);
-  const pluginDir = path.join("plugins", pluginPkgName);
-  const rulesDir = path.join(pluginDir, "src", "rules", ruleName!);
-  const pluginTsPath = path.join(pluginDir, "src", "plugin.ts");
+const createRuleFiles = Effect.fnUntraced(
+  function*(domain: PluginDomain, ruleName: string, description: string) {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
 
-  // Check if rule directory already exists
-  const exists = yield* fs.exists(rulesDir);
-  if (exists) {
-    return yield* Effect.fail(new Error(`Rule directory already exists: ${rulesDir}`));
-  }
+    const pluginPkgName = buildPluginPackageName(domain);
+    const pluginDir = path.join("plugins", pluginPkgName);
+    const rulesDir = path.join(pluginDir, "src", "rules", ruleName);
 
-  yield* Effect.log(ansis.bold(`Scaffolding rule ${ansis.cyan(ruleName!)} in ${ansis.cyan(pluginPkgName)}...\n`));
+    const exists = yield* fs.exists(rulesDir);
+    if (exists) {
+      return yield* Effect.fail(new Error(`Rule directory already exists: ${rulesDir}`));
+    }
 
-  // Create rule directory
-  yield* fs.makeDirectory(rulesDir, { recursive: true });
-  yield* Effect.log(ansis.green(`  Created ${rulesDir}/`));
+    yield* fs.makeDirectory(rulesDir, { recursive: true });
+    yield* Effect.log(ansis.green(`  Created ${rulesDir}/`));
 
-  // Write rule implementation
-  const ruleTsPath = path.join(rulesDir, `${ruleName}.ts`);
-  yield* fs.writeFileString(ruleTsPath, generateRuleTs(ruleName!));
-  yield* Effect.log(ansis.green(`  Created ${ruleTsPath}`));
+    const ruleTsPath = path.join(rulesDir, `${ruleName}.ts`);
+    yield* fs.writeFileString(ruleTsPath, generateRuleTs(ruleName));
+    yield* Effect.log(ansis.green(`  Created ${ruleTsPath}`));
 
-  // Write rule test
-  const ruleSpecTsPath = path.join(rulesDir, `${ruleName}.spec.ts`);
-  yield* fs.writeFileString(ruleSpecTsPath, generateRuleSpecTs(ruleName!));
-  yield* Effect.log(ansis.green(`  Created ${ruleSpecTsPath}`));
+    const ruleSpecTsPath = path.join(rulesDir, `${ruleName}.spec.ts`);
+    yield* fs.writeFileString(ruleSpecTsPath, generateRuleSpecTs(ruleName));
+    yield* Effect.log(ansis.green(`  Created ${ruleSpecTsPath}`));
 
-  // Write rule documentation
-  const ruleMdxPath = path.join(rulesDir, `${ruleName}.mdx`);
-  yield* fs.writeFileString(ruleMdxPath, generateRuleMdx(plugin, ruleName!, description));
-  yield* Effect.log(ansis.green(`  Created ${ruleMdxPath}`));
+    const ruleMdxPath = path.join(rulesDir, `${ruleName}.mdx`);
+    yield* fs.writeFileString(ruleMdxPath, generateRuleMdx(domain, ruleName, description));
+    yield* Effect.log(ansis.green(`  Created ${ruleMdxPath}`));
 
-  // Update plugin.ts
-  yield* updatePluginTs(pluginTsPath, ruleName!);
+    return { pluginDir, pluginTsPath: path.join(pluginDir, "src", "plugin.ts"), rulesDir };
+  },
+);
 
-  yield* Effect.log(ansis.bold.green(`\nRule ${ruleName} scaffolded successfully!\n`));
+const updatePluginTs = Effect.fnUntraced(
+  function*(pluginTsPath: string, ruleName: string) {
+    const fs = yield* FileSystem.FileSystem;
+    const content = yield* fs.readFileString(pluginTsPath, "utf8");
+    const lines = content.split("\n");
+
+    const camelName = kebabToCamel(ruleName);
+    const importLine = `import ${camelName} from "./rules/${ruleName}/${ruleName}";`;
+    const rulesEntry = `    "${ruleName}": ${camelName},`;
+
+    const importIndex = findImportInsertionIndex(lines, importLine);
+    lines.splice(importIndex, 0, importLine);
+
+    const entryIndex = findRulesEntryInsertionIndex(lines, ruleName);
+    if (entryIndex === -1) {
+      return yield* Effect.fail(new Error(`Could not find rules object in ${pluginTsPath}`));
+    }
+    lines.splice(entryIndex, 0, rulesEntry);
+
+    yield* fs.writeFileString(pluginTsPath, lines.join("\n"));
+    yield* Effect.log(ansis.green(`  Updated ${pluginTsPath}`));
+  },
+);
+
+const program = Effect.gen(function*() {
+  const { domain, ruleName, description } = yield* parseArgs;
+  const pluginPkgName = buildPluginPackageName(domain);
+
+  yield* Effect.log(ansis.bold(`Scaffolding rule ${ansis.cyan(ruleName)} in ${ansis.cyan(pluginPkgName)}...`));
+
+  const { pluginTsPath } = yield* createRuleFiles(domain, ruleName, description);
+  yield* updatePluginTs(pluginTsPath, ruleName);
+
+  yield* Effect.log(ansis.bold.green(`Rule ${ruleName} scaffolded successfully!`));
   yield* Effect.log(ansis.bold("Next steps:"));
-  yield* Effect.log(`  1. Implement the rule logic in ${ansis.cyan(ruleTsPath)}`);
-  yield* Effect.log(`  2. Add test cases in ${ansis.cyan(ruleSpecTsPath)}`);
-  yield* Effect.log(`  3. Write documentation in ${ansis.cyan(ruleMdxPath)}`);
+  yield* Effect.log(`  1. Implement the rule logic in plugins/${pluginPkgName}/src/rules/${ruleName}/${ruleName}.ts`);
+  yield* Effect.log(`  2. Add test cases in plugins/${pluginPkgName}/src/rules/${ruleName}/${ruleName}.spec.ts`);
+  yield* Effect.log(`  3. Write documentation in plugins/${pluginPkgName}/src/rules/${ruleName}/${ruleName}.mdx`);
   yield* Effect.log(`  4. Add the rule to the appropriate preset configs if needed`);
   yield* Effect.log(`  5. Run ${ansis.cyan("pnpm run build")} and ${ansis.cyan("pnpm run test")} to verify`);
 });

--- a/scripts/verify-configs.ts
+++ b/scripts/verify-configs.ts
@@ -37,9 +37,9 @@ const DOMAIN_CONFIGS: Record<string, Record<string, unknown>> = {
 };
 
 interface RegisteredRule {
-  name: string;
-  configKey: string;
-  domain: string;
+  readonly name: string;
+  readonly configKey: string;
+  readonly domain: string;
 }
 
 function buildConfigKey(domain: string, ruleName: string): string {
@@ -60,7 +60,6 @@ const collectRegisteredRules = Effect.gen(function*() {
 
   for (const file of files) {
     const domain = /^plugins\/eslint-plugin-react-([^/]+)/u.exec(file)?.[1] ?? "";
-    // Skip debug plugin as it's not part of the aggregated plugin
     if (domain === "debug") continue;
     const mod = yield* Effect.tryPromise(() => import(`../${file}`));
     const ruleName = mod.RULE_NAME;
@@ -172,7 +171,6 @@ const verifyDomainConfigCompleteness = Effect.fnUntraced(
       const configKeys = Object.keys(configRules);
       const domainRuleKeys = new Set(domainRules.map((r) => r.configKey));
 
-      // Error: domain config contains a rule that doesn't belong to this domain
       for (const key of configKeys) {
         if (!domainRuleKeys.has(key)) {
           yield* Effect.logError(
@@ -186,7 +184,6 @@ const verifyDomainConfigCompleteness = Effect.fnUntraced(
         }
       }
 
-      // Info: registered rules not in the domain base config (expected for strict/all-only rules)
       const configKeySet = new Set(configKeys);
       const untrackedRules = domainRules.filter((r) => !configKeySet.has(r.configKey));
       if (untrackedRules.length > 0) {
@@ -207,16 +204,17 @@ const verifyDomainConfigCompleteness = Effect.fnUntraced(
 );
 
 const program = Effect.gen(function*() {
-  yield* Effect.log(ansis.bold("Verifying config consistency...\n"));
+  yield* Effect.log(ansis.bold("Verifying config consistency..."));
+  yield* Effect.log("");
 
   const rules = yield* collectRegisteredRules;
-  yield* Effect.log(`Found ${ansis.bold(rules.length.toString())} registered rules (excluding debug).\n`);
+  yield* Effect.log(`Found ${ansis.bold(rules.length.toString())} registered rules (excluding debug).`);
+  yield* Effect.log("");
 
-  // 1. All registered rules accounted for in configs
   const accountedErrors = yield* verifyAllRulesAccountedFor(rules);
 
-  // 2. Config keys reference valid rules
-  yield* Effect.log(ansis.bold("\n2. Checking config keys reference valid rules..."));
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("2. Checking config keys reference valid rules..."));
   const allKeyErrors = yield* verifyConfigKeysValid(rules, "all", allConfig.rules);
   const recommendedKeyErrors = yield* verifyConfigKeysValid(rules, "recommended", recommendedConfig.rules);
   const strictKeyErrors = yield* verifyConfigKeysValid(rules, "strict", strictConfig.rules);
@@ -231,12 +229,11 @@ const program = Effect.gen(function*() {
     disableTypeCheckedConfig.rules,
   );
 
-  // 3. Preset hierarchy
-  yield* Effect.log(ansis.bold("\n3. Checking preset hierarchy..."));
+  yield* Effect.log("");
+  yield* Effect.log(ansis.bold("3. Checking preset hierarchy..."));
   const recStrictErrors = yield* verifyHierarchy("recommended", recommendedConfig.rules, "strict", strictConfig.rules);
   const strictAllErrors = yield* verifyHierarchy("strict", strictConfig.rules, "all", allConfig.rules);
 
-  // 4. Domain config completeness
   yield* Effect.log("");
   const domainErrors = yield* verifyDomainConfigCompleteness(rules);
 
@@ -247,9 +244,11 @@ const program = Effect.gen(function*() {
     + domainErrors;
 
   if (totalErrors === 0) {
-    yield* Effect.log(ansis.bold.green("\nAll config consistency checks passed!"));
+    yield* Effect.log("");
+    yield* Effect.log(ansis.bold.green("All config consistency checks passed!"));
   } else {
-    yield* Effect.log(ansis.bold.red(`\nFound ${totalErrors} error(s).`));
+    yield* Effect.log("");
+    yield* Effect.log(ansis.bold.red(`Found ${totalErrors} error(s).`));
     return yield* Effect.fail(new Error(`Config verification failed with ${totalErrors} error(s).`));
   }
 });


### PR DESCRIPTION
- Add `readonly` modifiers to script interfaces (`ParsedCommit`, `ParseResult`, `RegisteredRule`)
- Extract helper functions (`parseCommits`, `prependChangelogEntry`, `parseArgs`, `createRuleFiles`) for better separation of concerns
- Unify parameter naming: `plugin` → `domain` across rename and scaffold scripts
- Normalize log output style (replace inline `\n` with explicit empty log calls)
- Remove redundant section and inline comments
- Fix template string interpolation for vitest path in `rename-rule.ts`
- Restore accidentally removed `eslint-disable-next-line` for backtracking regex
- Align `VALID_PLUGINS` order between `rename-rule.ts` and `scaffold-rule.ts`

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [x] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
