### PR TITLE
  feat(website,examples,ast): add Error Boundaries custom rule example

### DIFF
--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -522,44 +522,82 @@ eslintReactKit()
   .getConfig();
 ```
 
-### Multiple Collectors: No component/hook factories
+### Multiple Collectors: Error Boundaries
 
-Disallow defining components or hooks inside other functions (factory pattern).
+Validates usage of Error Boundaries instead of `try/catch` for errors in child components or the `use` hook.
+
+This is a simplified kit reimplementation of the built-in [`react-x/error-boundaries`](/docs/rules/error-boundaries) rule.
 
 ```ts twoslash
 import type { RuleFunction } from "@eslint-react/kit";
 import eslintReactKit, { merge } from "@eslint-react/kit";
 import type { TSESTree } from "@typescript-eslint/types";
 
-function findParent({ parent }: TSESTree.Node, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {
-  if (parent == null) return null;
-  if (test(parent)) return parent;
-  if (parent.type === "Program") return null;
-  return findParent(parent, test);
+function findParent(node: TSESTree.Node | null, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {
+  if (node == null) return null;
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current != null) {
+    if (test(current)) return current;
+    if (current.type === "Program") return null;
+    current = current.parent;
+  }
+  return null;
 }
 
-function isFunction({ type }: TSESTree.Node) {
-  return type === "FunctionDeclaration" || type === "FunctionExpression" || type === "ArrowFunctionExpression";
+function isJsxLike(node: TSESTree.Node | null): boolean {
+  if (node == null) return false;
+  return node.type === "JSXElement" || node.type === "JSXFragment";
 }
 
-function componentHookFactories(): RuleFunction {
-  return (context, { collect }) => {
+function errorBoundaries(): RuleFunction {
+  return (context, { collect, is }) => {
+    // Fast path: skip if `try` is not present in the file
+    if (!context.sourceCode.text.includes("try")) return {};
+
     const fc = collect.components(context);
     const hk = collect.hooks(context);
+
+    const reported = new Set<TSESTree.TryStatement>();
+    const useCalls = new Set<TSESTree.CallExpression>();
+
     return merge(
       fc.visitor,
       hk.visitor,
       {
+        CallExpression(node) {
+          if (!is.useCall(node)) return;
+          useCalls.add(node);
+        },
         "Program:exit"(program) {
           const comps = fc.query.all(program);
           const hooks = hk.query.all(program);
-          for (const { name, node, kind } of [...comps, ...hooks]) {
-            if (name == null) continue;
-            if (findParent(node, isFunction) == null) continue;
-            context.report({
-              node,
-              message: `Don't define ${kind} "${name}" inside a function. Move it to the module level.`,
-            });
+          const funcs = [...comps, ...hooks];
+
+          for (const call of useCalls) {
+            const stmt = findParent(call, (n) => n.type === "TryStatement");
+            const func = findParent(stmt, (n) => funcs.some((f) => f.node === n));
+            if (stmt != null && func != null && !reported.has(stmt)) {
+              context.report({
+                node: stmt,
+                message: "Use an Error Boundary instead of try/catch around the 'use' hook. The 'use' hook suspends the component, and its errors can only be caught by Error Boundaries.",
+              });
+              reported.add(stmt);
+            }
+          }
+
+          for (const { rets } of funcs) {
+            for (const ret of rets) {
+              if (ret == null) continue;
+              if (!isJsxLike(ret)) continue;
+              const stmt = findParent(ret, (n) => n.type === "TryStatement");
+              if (stmt != null && !reported.has(stmt)) {
+                context.report({
+                  node: stmt,
+                  message: "Use an Error Boundary to catch errors in child components. Try/catch can't catch errors during React's rendering process.",
+                });
+                reported.add(stmt);
+              }
+            }
           }
         },
       },
@@ -569,7 +607,7 @@ function componentHookFactories(): RuleFunction {
 
 // Usage
 eslintReactKit()
-  .use(componentHookFactories)
+  .use(errorBoundaries)
   .getConfig();
 ```
 

--- a/examples/react-dom-with-custom-rules/.config/errorBoundaries.ts
+++ b/examples/react-dom-with-custom-rules/.config/errorBoundaries.ts
@@ -1,0 +1,77 @@
+import { type RuleFunction, merge } from "@eslint-react/kit";
+import type { TSESTree } from "@typescript-eslint/types";
+
+function findParent(node: TSESTree.Node | null, test: (n: TSESTree.Node) => boolean): TSESTree.Node | null {
+  if (node == null) return null;
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current != null) {
+    if (test(current)) return current;
+    if (current.type === "Program") return null;
+    current = current.parent;
+  }
+  return null;
+}
+
+function isJsxLike(node: TSESTree.Node | null): boolean {
+  if (node == null) return false;
+  return node.type === "JSXElement" || node.type === "JSXFragment";
+}
+
+/** Validates usage of Error Boundaries instead of try/catch for errors in child components. */
+export function errorBoundaries(): RuleFunction {
+  return (context, { collect, is }) => {
+    // Fast path: skip if `try` is not present in the file
+    if (!context.sourceCode.text.includes("try")) return {};
+
+    const fc = collect.components(context);
+    const hk = collect.hooks(context);
+
+    const reported = new Set<TSESTree.TryStatement>();
+    const useCalls = new Set<TSESTree.CallExpression>();
+
+    return merge(
+      fc.visitor,
+      hk.visitor,
+      {
+        CallExpression(node) {
+          if (!is.useCall(node)) return;
+          useCalls.add(node);
+        },
+        "Program:exit"(program) {
+          const comps = fc.query.all(program);
+          const hooks = hk.query.all(program);
+          const funcs = [...comps, ...hooks];
+
+          for (const call of useCalls) {
+            const stmt = findParent(call, (n) => n.type === "TryStatement") as TSESTree.TryStatement | null;
+            const func = findParent(stmt, (n) => funcs.some((f) => f.node === n));
+            if (stmt != null && func != null && !reported.has(stmt)) {
+              context.report({
+                node: stmt,
+                message:
+                  "Use an Error Boundary instead of try/catch around the 'use' hook. The 'use' hook suspends the component, and its errors can only be caught by Error Boundaries.",
+              });
+              reported.add(stmt);
+            }
+          }
+
+          for (const { rets } of funcs) {
+            for (const ret of rets) {
+              if (ret == null) continue;
+              if (!isJsxLike(ret)) continue;
+              const stmt = findParent(ret, (n) => n.type === "TryStatement") as TSESTree.TryStatement | null;
+              if (stmt != null && !reported.has(stmt)) {
+                context.report({
+                  node: stmt,
+                  message:
+                    "Use an Error Boundary to catch errors in child components. Try/catch can't catch errors during React's rendering process.",
+                });
+                reported.add(stmt);
+              }
+            }
+          }
+        },
+      },
+    );
+  };
+}

--- a/examples/react-dom-with-custom-rules/.config/index.ts
+++ b/examples/react-dom-with-custom-rules/.config/index.ts
@@ -1,5 +1,6 @@
 export * from "./booleanPropNaming";
 export * from "./checkedRequiresOnchangeOrReadonly";
+export * from "./errorBoundaries";
 export * from "./forbidComponentProps";
 export * from "./forbidDomProps";
 export * from "./forbidElements";

--- a/examples/react-dom-with-custom-rules/eslint.config.ts
+++ b/examples/react-dom-with-custom-rules/eslint.config.ts
@@ -12,6 +12,7 @@ import TSCONFIG_NODE from "./tsconfig.node.json" with { type: "json" };
 import {
   booleanPropNaming,
   checkedRequiresOnchangeOrReadonly,
+  errorBoundaries,
   forbidComponentProps,
   forbidDomProps,
   forbidElements,
@@ -88,6 +89,7 @@ export default defineConfig(
         ...eslintReactKit()
           .use(booleanPropNaming)
           .use(checkedRequiresOnchangeOrReadonly)
+          .use(errorBoundaries)
           .use(forbidComponentProps, { forbidden: ["className", "style"] })
           .use(forbidDomProps, { forbidden: ["style", "className"] })
           .use(forbidElements, {

--- a/packages/ast/src/traverse.ts
+++ b/packages/ast/src/traverse.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
+import type { TSESTree } from "@typescript-eslint/types";
 
 type Predicate<T extends TSESTree.Node> = (node: TSESTree.Node) => node is T;
 type NodePredicate = (node: TSESTree.Node) => boolean;
@@ -6,11 +6,11 @@ export function findParent<T extends TSESTree.Node>(node: TSESTree.Node | null, 
 export function findParent(node: TSESTree.Node | null, test: NodePredicate): TSESTree.Node | null;
 export function findParent(node: TSESTree.Node | null, test: NodePredicate): TSESTree.Node | null {
   if (node == null) return null;
-  let parent = node.parent;
-  while (parent?.type !== AST.Program) {
-    if (parent == null) return null;
-    if (test(parent)) return parent;
-    parent = parent.parent;
+  let current = node.parent;
+  while (current != null) {
+    if (test(current)) return current;
+    if (current.type === "Program") return null;
+    current = current.parent;
   }
   return null;
 }


### PR DESCRIPTION
  - Replace the "No component/hook factories" kit docs example with a practical Error Boundaries custom rule demonstration
  - Add runnable `errorBoundaries` rule to `react-dom-with-custom-rules`
  - Refactor `findParent` in `ast/traverse` to use explicit null checks and remove `AST_NODE_TYPES` dependency

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
