### PR TITLE
  feat(eslint-plugin-react-x): add createdHere diagnostic to static-c…

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/static-components/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/lib.ts
@@ -3,12 +3,17 @@ import { type RuleContext } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { TSESLint } from "@typescript-eslint/utils";
 
+export interface DynamicComponentResult {
+  creationNode: TSESTree.Node | null;
+  isDynamic: boolean;
+}
+
 function resolveDynamicValue(
   context: RuleContext,
   node: TSESTree.Node,
   isInsideRender: (node: TSESTree.Node) => boolean,
   seen: Set<TSESLint.Scope.Variable>,
-): boolean {
+): TSESTree.Node | null {
   const expr = Extract.unwrap(node);
 
   switch (expr.type) {
@@ -17,18 +22,21 @@ function resolveDynamicValue(
     case AST.NewExpression:
     case AST.CallExpression:
     case AST.ClassExpression:
-      return true;
-    case AST.ConditionalExpression:
-      return resolveDynamicValue(context, expr.consequent, isInsideRender, seen)
-        || resolveDynamicValue(context, expr.alternate, isInsideRender, seen);
+      return expr;
+    case AST.ConditionalExpression: {
+      const consequent = resolveDynamicValue(context, expr.consequent, isInsideRender, seen);
+      if (consequent != null) return consequent;
+      return resolveDynamicValue(context, expr.alternate, isInsideRender, seen);
+    }
     case AST.Identifier:
     case AST.JSXIdentifier: {
       const resolved = findVariableForIdentifier(context, expr);
-      if (resolved == null) return false;
-      return isDynamicComponent(context, resolved, isInsideRender, seen);
+      if (resolved == null) return null;
+      const result = getDynamicComponentSource(context, resolved, isInsideRender, seen);
+      return result.creationNode;
     }
     default:
-      return false;
+      return null;
   }
 }
 
@@ -45,25 +53,32 @@ export function findVariableForIdentifier(
   return null;
 }
 
-export function isDynamicComponent(
+export function getDynamicComponentSource(
   context: RuleContext,
   variable: TSESLint.Scope.Variable,
   isInsideRender: (node: TSESTree.Node) => boolean,
   seen = new Set<TSESLint.Scope.Variable>(),
-): boolean {
-  if (seen.has(variable)) return false;
+): DynamicComponentResult {
+  if (seen.has(variable)) return { isDynamic: false, creationNode: null };
   seen.add(variable);
 
   for (const def of variable.defs) {
     const defNode = def.node;
     if (!isInsideRender(defNode)) continue;
 
-    if (defNode.type === AST.FunctionDeclaration) return true;
-    if (defNode.type === AST.ClassDeclaration) return true;
+    if (defNode.type === AST.FunctionDeclaration) {
+      return { isDynamic: true, creationNode: defNode };
+    }
+    if (defNode.type === AST.ClassDeclaration) {
+      return { isDynamic: true, creationNode: defNode };
+    }
 
     if (defNode.type === AST.VariableDeclarator) {
       if (defNode.init != null) {
-        if (resolveDynamicValue(context, defNode.init, isInsideRender, seen)) return true;
+        const source = resolveDynamicValue(context, defNode.init, isInsideRender, seen);
+        if (source != null) {
+          return { isDynamic: true, creationNode: source };
+        }
       }
 
       for (const ref of variable.references) {
@@ -73,11 +88,23 @@ export function isDynamicComponent(
           id.parent?.type === AST.AssignmentExpression
           && id.parent.left === id
         ) {
-          if (resolveDynamicValue(context, id.parent.right, isInsideRender, seen)) return true;
+          const source = resolveDynamicValue(context, id.parent.right, isInsideRender, seen);
+          if (source != null) {
+            return { isDynamic: true, creationNode: source };
+          }
         }
       }
     }
   }
 
-  return false;
+  return { isDynamic: false, creationNode: null };
+}
+
+export function isDynamicComponent(
+  context: RuleContext,
+  variable: TSESLint.Scope.Variable,
+  isInsideRender: (node: TSESTree.Node) => boolean,
+  seen = new Set<TSESLint.Scope.Variable>(),
+): boolean {
+  return getDynamicComponentSource(context, variable, isInsideRender, seen).isDynamic;
 }

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.ts
@@ -19,6 +19,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "ChildComponent" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "ChildComponent" },
           messageId: "default",
         },
       ],
@@ -34,6 +38,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "ChildComponent" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "ChildComponent" },
           messageId: "default",
@@ -53,6 +61,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "Component" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "Component" },
           messageId: "default",
         },
       ],
@@ -68,6 +80,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "ChildComponent" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "ChildComponent" },
           messageId: "default",
@@ -89,6 +105,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "ChildComponent" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "ChildComponent" },
           messageId: "default",
         },
       ],
@@ -102,6 +122,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "ChildComponent" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "ChildComponent" },
           messageId: "default",
@@ -118,6 +142,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "ChildComponent" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "ChildComponent" },
           messageId: "default",
@@ -138,6 +166,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "Nested" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "Nested" },
           messageId: "default",
         },
       ],
@@ -155,6 +187,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "Component" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "Component" },
           messageId: "default",
         },
       ],
@@ -167,6 +203,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "Component" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "Component" },
           messageId: "default",
@@ -183,6 +223,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "Component" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "Component" },
           messageId: "default",
         },
       ],
@@ -195,6 +239,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "Component" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "Component" },
           messageId: "default",
@@ -216,6 +264,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "Component" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "Component" },
           messageId: "default",
         },
       ],
@@ -229,6 +281,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "B" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "B" },
           messageId: "default",
@@ -246,6 +302,10 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [
         {
           data: { name: "B" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "B" },
           messageId: "default",
         },
       ],
@@ -259,6 +319,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "B" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "B" },
           messageId: "default",
@@ -275,6 +339,10 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
       errors: [
+        {
+          data: { name: "B" },
+          messageId: "createdHere",
+        },
         {
           data: { name: "B" },
           messageId: "default",

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.ts
@@ -4,13 +4,13 @@ import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint"
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import { createRule } from "../../utils";
-import { findVariableForIdentifier, isDynamicComponent } from "./lib";
+import { findVariableForIdentifier, getDynamicComponentSource } from "./lib";
 
 export const RULE_NAME = "static-components";
 
 export const RULE_FEATURES = ["EXP"] as const satisfies RuleFeature[];
 
-export type MessageID = "default";
+export type MessageID = "default" | "createdHere";
 
 export default createRule<[], MessageID>({
   meta: {
@@ -21,6 +21,9 @@ export default createRule<[], MessageID>({
     messages: {
       default:
         "Cannot create components during render. Components created during render will reset their state each time they are created. Declare components outside of render.",
+
+      // Subordinate error messages reported at the component creation site.
+      createdHere: "The component is created during render here.",
     },
     schema: [],
   },
@@ -82,13 +85,22 @@ export function create(context: RuleContext<MessageID, []>) {
           const enclosing = getEnclosingComponent(defNode);
           if (enclosing == null) continue;
 
-          if (!isDynamicComponent(context, variable, isInsideRender)) continue;
+          const result = getDynamicComponentSource(context, variable, isInsideRender);
+          if (!result.isDynamic) continue;
 
           context.report({
             data: { name },
             messageId: "default",
             node: jsxNode.name,
           });
+
+          if (result.creationNode != null) {
+            context.report({
+              data: { name },
+              messageId: "createdHere",
+              node: result.creationNode,
+            });
+          }
         }
       },
     },

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
@@ -567,6 +567,53 @@ ruleTester.run(RULE_NAME, rule, {
         return <div>{value}</div>;
       }
     `,
+    // useMemo as the right-hand side of a for...of loop
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ items }) {
+        const list = useMemo(() => items, [items]);
+        for (const item of list) {
+          console.log(item);
+        }
+        return <div />;
+      }
+    `,
+    // useMemo as the right-hand side of a for...in loop
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ obj }) {
+        const keys = useMemo(() => Object.keys(obj), [obj]);
+        for (const key of keys) {
+          console.log(key);
+        }
+        return <div />;
+      }
+    `,
+    // Inline useMemo as the right-hand side of a for...of/for...in loop.
+    // This usage pattern is uncommon in practice but is included for rule completeness.
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ items }) {
+        for (const item of useMemo(() => items, [items])) {
+          console.log(item);
+        }
+        return <div />;
+      }
+    `,
+    // This usage pattern is uncommon in practice but is included for rule completeness.
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ obj }) {
+        for (const key of useMemo(() => Object.keys(obj), [obj])) {
+          console.log(key);
+        }
+        return <div />;
+      }
+    `,
     // Rule 3 valid: Property mutation is not outer variable reassignment
     tsx`
       import { useMemo, useRef } from "react";

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
@@ -26,16 +26,16 @@ export default createRule<[], MessageID>({
       description: "Validates that 'useMemo' is called with a callback that returns a value.",
     },
     messages: {
-      mustReturnAValue:
-        "useMemo() callbacks must return a value. This useMemo() callback doesn't return a value. useMemo() is for computing and caching values, not for arbitrary side effects.",
-      noAsyncOrGeneratorFunctions:
-        "useMemo() callbacks may not be async or generator functions. useMemo() callbacks are called once and must synchronously return a value.",
       noParameters:
-        "useMemo() callbacks may not accept parameters. useMemo() callbacks are called by React to cache calculations across re-renders. They should not take parameters. Instead, directly reference the props, state, or local variables needed for the computation.",
+        "useMemo() callbacks may not accept parameters.\n\nuseMemo() callbacks are called by React to cache calculations across re-renders. They should not take parameters. Instead, directly reference the props, state, or local variables needed for the computation.",
+      noAsyncOrGeneratorFunctions:
+        "useMemo() callbacks may not be async or generator functions.\n\nuseMemo() callbacks are called once and must synchronously return a value.",
       noReassigningOuterVariables:
-        "useMemo() callbacks may not reassign variables declared outside of the callback. useMemo() callbacks must be pure functions and cannot reassign variables defined outside of the callback function.",
+        "useMemo() callbacks may not reassign variables declared outside of the callback.\n\nuseMemo() callbacks must be pure functions and cannot reassign variables defined outside of the callback function.",
+      mustReturnAValue:
+        "useMemo() callbacks must return a value.\n\nThis useMemo() callback doesn't return a value. useMemo() is for computing and caching values, not for arbitrary side effects.",
       resultMustBeUsed:
-        "useMemo() result is unused. This useMemo() value is unused. useMemo() is for computing and caching values, not for arbitrary side effects.",
+        "useMemo() result is unused.\n\nThis useMemo() value is unused. useMemo() is for computing and caching values, not for arbitrary side effects.",
     },
     schema: [],
   },
@@ -95,7 +95,9 @@ export function create(context: RuleContext<MessageID, []>) {
         || parent.type === AST.MemberExpression
         || parent.type === AST.TaggedTemplateExpression
         || parent.type === AST.ChainExpression
-        || parent.type === AST.ArrowFunctionExpression;
+        || parent.type === AST.ArrowFunctionExpression
+        || parent.type === AST.ForOfStatement
+        || parent.type === AST.ForInStatement;
 
       if (!isAssigned) {
         context.report({


### PR DESCRIPTION
…omponents and support for-of/for-in in use-memo

  - `static-components`: introduce `createdHere` message reported at the component creation site alongside the existing `default` error at the JSX usage site
  - `static-components`: refactor `isDynamicComponent` to `getDynamicComponentSource` to track the creation AST node
  - `use-memo`: allow `useMemo` as the right-hand side of `for...of` and `for...in` loops without triggering `resultMustBeUsed`
  - `use-memo`: improve error message readability by separating titles from descriptions with line breaks

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [x] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
