### PR TITLE
feat(plugins/eslint-plugin-react-x): improve set-state-in-effect vali…

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/lib.ts
@@ -1,3 +1,4 @@
+import { Check } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import type { RuleContext } from "@eslint-react/eslint";
 import type { Scope } from "@typescript-eslint/scope-manager";
@@ -165,7 +166,58 @@ export function isInitializedFromRef(context: RuleContext, name: string, initial
       case init.type === AST.CallExpression
         && core.isUseRefCall(context, init):
         return true;
+      // const { foo } = ref.current.getBoundingClientRect();
+      case init.type === AST.CallExpression:
+        return getNestedIdentifiers(init).some((id) =>
+          isInitializedFromRef(context, id.name, context.sourceCode.getScope(id))
+        );
     }
   }
   return false;
+}
+
+/**
+ * Check if a setState call is inside a conditional block whose test expression
+ * is derived from a ref value (e.g. `if (prevRef.current !== value) setState(...)`).
+ * @param context The ESLint rule context
+ * @param node The AST node to check
+ * @returns `true` if the node is inside a ref-gated conditional block
+ */
+export function isRefGatedContext(
+  context: RuleContext,
+  node: TSESTree.Node,
+): boolean {
+  let current: TSESTree.Node | undefined = node.parent;
+  while (current != null) {
+    if (Check.isFunction(current)) break;
+    if (current.type === AST.IfStatement) {
+      if (isRefInExpression(context, current.test)) return true;
+    }
+    if (current.type === AST.ConditionalExpression) {
+      if (isRefInExpression(context, current.test)) return true;
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+function isRefInExpression(context: RuleContext, node: TSESTree.Node): boolean {
+  return getNestedIdentifiers(node).some((id) =>
+    isInitializedFromRef(context, id.name, context.sourceCode.getScope(id))
+  );
+}
+
+/**
+ * Get the actual CallExpression node from a setState call reference.
+ * When the node is an Identifier that is the callee of a CallExpression,
+ * returns the parent CallExpression; otherwise returns the node itself.
+ * @param node The setState call node (CallExpression or Identifier)
+ * @returns The actual CallExpression node
+ */
+export function getSetStateCallExpression(
+  node: TSESTree.CallExpression | TSESTree.Identifier,
+): TSESTree.CallExpression | TSESTree.Identifier {
+  return node.type === AST.Identifier && node.parent?.type === AST.CallExpression
+    ? node.parent
+    : node;
 }

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.diff.md
@@ -1,0 +1,136 @@
+# set-state-in-effect IMPL vs. SPEC Report
+
+**IMPL**: `set-state-in-effect.ts` + `lib.ts` (ESLint rule)\
+**SPEC**: `46-validateNoSetStateInEffects.md` (React Compiler `ValidateNoSetStateInEffects`)
+
+---
+
+## 1. Underlying Mechanism
+
+The SPEC operates on the React Compiler's HIR (High-level IR), analyzing instructions (`LoadLocal`, `StoreLocal`, `FunctionExpression`, `CallExpression`, etc.) within each basic block. It builds a `setStateFunctions` map that propagates through variable assignments and function expressions, and uses `createControlDominators` to identify ref-controlled blocks.
+
+The IMPL operates on the ESLint AST. It uses a function-entry stack (`functionEntries`) to track whether code is inside an effect setup function, a deferred context (async / `.then`), or an immediate callback. It detects `setState` calls by resolving identifiers to their `useState`-like definitions via `resolve`, and tracks transitive calls through WeakMaps (`setStateCallsByFn`, `setStateInHookCallbacks`, `setStateInEffectArg`).
+
+**Verdict**: The SPEC uses compiler-level instruction propagation and control-dominator analysis. The IMPL uses syntactic function nesting and static resolution.
+
+---
+
+## 2. Effect Hook Coverage
+
+| Hook Category        | SPEC                                      | IMPL                                          |
+| -------------------- | ----------------------------------------- | --------------------------------------------- |
+| `useEffect`          | Detected (`isUseEffectHookType`)          | Detected (`isUseEffectLikeCall`)              |
+| `useLayoutEffect`    | Detected (`isUseLayoutEffectHookType`)    | Detected (`/^use\w*Effect$/u`)                |
+| `useInsertionEffect` | Detected (`isUseInsertionEffectHookType`) | Detected (`/^use\w*Effect$/u`)                |
+| Custom effect hooks  | Not mentioned                             | Supported via `additionalEffectHooks` setting |
+
+**Verdict**: Both cover the three built-in effect hooks. The IMPL adds configurability for custom effect hooks.
+
+---
+
+## 3. setState Source Detection & Propagation
+
+| Pattern                                                             | SPEC                                              | IMPL                                                                      |
+| ------------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------- |
+| Direct destructuring `const [_, setX] = useState()`                 | Detected via `isSetStateType`                     | Detected via `isIdFromUseStateCall`                                       |
+| Array index `data[1]()`                                             | Detected                                          | Detected via `getStaticValue`                                             |
+| Method call `data.at(1)()`                                          | Detected                                          | Detected via `getStaticValue`                                             |
+| Aliased variable `const aliased = setX; aliased()`                  | Detected via `LoadLocal`/`StoreLocal` propagation | **Not detected** — `resolve` does not follow aliases through reassignment |
+| Prop named `setXxx` with `@enableTreatSetIdentifiersAsStateSetters` | Detected                                          | **Not detected** — no equivalent feature flag                             |
+| Wrapped in `useCallback`/`useMemo` passed to effect                 | Detected via HIR flow                             | Detected via `setStateInHookCallbacks` / `setStateInEffectArg`            |
+
+**Verdict**: The SPEC has more comprehensive propagation through HIR variable instructions. The IMPL relies on direct definition tracing and explicit hook-callback tracking.
+
+---
+
+## 4. Transitive Detection
+
+The SPEC recursively analyzes `FunctionExpression` lowered functions via `getSetStateCall`. If a function expression references a setState and calls it synchronously, the function itself is tracked as a setState-calling function, enabling transitive reporting through arbitrary call depth.
+
+The IMPL records setState calls per-function in `setStateCallsByFn`, and at `Program:exit` resolves callee identifiers to their definitions. It supports transitive detection for direct function declarations, arrow functions, and hook-wrapped callbacks (`useCallback` / `useMemo`).
+
+**Verdict**: Both support transitive detection. The SPEC's HIR-based propagation is more robust for aliases and complex assignment chains.
+
+---
+
+## 5. useEffectEvent Handling
+
+The SPEC explicitly checks `isUseEffectEventType` during instruction traversal. If a `useEffectEvent` call's callback argument is tracked as calling setState, the return value of the `useEffectEvent` call itself is added to `setStateFunctions`, so that calling the effect event inside an effect is flagged.
+
+The IMPL does **not** explicitly recognize `useEffectEvent`. However, because `isHookDecl` treats any call to a hook-named function (including `useEffectEvent`) as a hook declaration, `setState` calls inside the callback are recorded into `setStateInHookCallbacks`. When the effect event is later called inside an effect, `getSetStateCalls` resolves the callee back to the `useEffectEvent` call and reports the inner setState calls.
+
+**Verdict**: Functionally equivalent for the common case, but the IMPL's support is emergent rather than explicit.
+
+---
+
+## 6. Deferred / Callback setState
+
+The SPEC naturally allows setState in callbacks because those calls reside in separate function blocks that are not the effect's setup block. Only synchronous calls within the effect setup block itself are flagged.
+
+The IMPL classifies functions by `getFunctionKind`:
+
+- `deferred` — async functions or `.then` callbacks → setState allowed
+- `setup` — the effect's callback → setState reported (unless exempted)
+- `immediate` — IIFEs or arrow functions called synchronously → tracked and reported if inside setup
+
+**Limitation**: The IMPL cannot distinguish `setTimeout(() => setState(), 10)` (deferred) from an immediately-invoked function that calls setState. Both are treated as "immediate" callbacks inside the setup function, so the setState is reported. The SPEC handles this correctly via block-level analysis.
+
+**Verdict**: The SPEC's block-level analysis is more precise for deferred callbacks. The IMPL conservatively reports setState in any synchronous callback defined inside the effect, which may produce false positives for `setTimeout` / `addEventListener` patterns that are not yet assigned to an external listener.
+
+---
+
+## 7. Ref-Derived setState Exception
+
+The SPEC supports `enableAllowSetStateFromRefsInEffects`. When enabled:
+
+- Builds a `refDerivedValues` set by propagating ref values through HIR instructions (including phi nodes and mutation effects)
+- Uses `createControlDominators` to determine if a block is controlled by a ref-derived condition
+- Allows setState if either the argument is in `refDerivedValues` or the block is ref-controlled
+
+The IMPL supports ref-derived exceptions through:
+
+- `isArgumentUsingRefValue` — checks if the setState argument directly or indirectly contains a ref value (`ref.current`, `useRef()`, or variables initialized from ref)
+- `isRefGatedContext` — checks if the setState call is inside an `IfStatement` or `ConditionalExpression` whose test expression contains a ref value
+
+**Verdict**: The SPEC's HIR-based propagation is more complete (e.g., it tracks ref values through phi nodes and mutations). The IMPL's AST-based checks are a pragmatic approximation that covers the majority of real-world patterns but may miss complex ref-value propagation chains.
+
+---
+
+## 8. Namespace Import Support
+
+The SPEC previously had a bug (#35419) where `React.useEffect(...)` was not detected because it checked `MethodCall.receiver` instead of `property`. This was fixed in 7.1.0.
+
+The IMPL checks `MemberExpression.property` from the start via `isUseEffectLikeCall` / `isUseStateLikeCall`, so `React.useEffect` and `React.useState` have always been correctly recognized.
+
+**Verdict**: Both now handle namespace imports correctly. The IMPL did not have the original bug.
+
+---
+
+## 9. Error Reporting
+
+| Aspect                      | SPEC                                                                                                                                               | IMPL                                                                                      |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Primary message             | "Calling setState synchronously within an effect can trigger cascading renders"                                                                    | "Do not call the 'set' function '{{name}}' of 'useState' synchronously in an effect..."   |
+| Verbose mode                | Supported (`enableVerboseNoSetStateInEffect`) with detailed guidance for non-local derived data, derived event patterns, and force-update patterns | **Not supported** — single message only                                                   |
+| Reported location           | Original setState call site                                                                                                                        | setState call site for direct calls; call site of the wrapper function for indirect calls |
+| Derived computation message | Separate pass (`ValidateNoDerivedComputationsInEffects`)                                                                                           | **Not supported**                                                                         |
+
+**Verdict**: Message intent is aligned. The SPEC provides richer contextual guidance when verbose mode is enabled, and has a dedicated pass for derived computations.
+
+---
+
+## 10. Key Gaps and Deviations
+
+1. **Missing Alias Propagation**: The IMPL does not track `setState` through variable aliases (e.g., `const aliased = setX; aliased()`). The SPEC propagates this through HIR `LoadLocal`/`StoreLocal` instructions.
+
+2. **Missing `@enableTreatSetIdentifiersAsStateSetters` Equivalent**: The SPEC can treat any prop named `setXxx` as a state setter via a feature flag. The IMPL has no equivalent.
+
+3. **Deferred Callback False Positives**: The IMPL reports setState in any synchronous callback defined inside the effect setup function. It cannot reliably distinguish deferred callbacks (e.g., `setTimeout(() => setState(), 10)`) from immediately invoked ones without additional interprocedural analysis.
+
+4. **Missing Verbose Error Mode**: The IMPL does not support `enableVerboseNoSetStateInEffect`. It cannot provide the detailed anti-pattern guidance that the SPEC offers.
+
+5. **Missing Derived Computation Check**: The SPEC has a separate `ValidateNoDerivedComputationsInEffects` pass that flags effects which only compute derived state. The IMPL does not implement this.
+
+6. **Ref-Derived Propagation Limitations**: The IMPL's `isInitializedFromRef` and `isArgumentUsingRefValue` cover common patterns but do not track ref values through mutations, phi-like merge points, or complex data-flow chains the way the SPEC's HIR propagation does.
+
+7. **Cleanup Function Handling**: The IMPL has a TODO comment for cleanup function checks but does not currently validate them. The SPEC treats cleanup functions as part of the effect function body and would flag synchronous setState there as well.

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
@@ -817,29 +817,12 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
-    {
-      name: "setState with ref.current inside conditional expression (rule does not detect ref in conditional)",
-      code: tsx`
-        import { useEffect, useState, useRef } from "react";
-
-        function Component() {
-          const ref = useRef(0);
-          const [data, setData] = useState(0);
-          useEffect(() => {
-            setData(flag ? ref.current : 0);
-          }, []);
-          return null;
-        }
-      `,
-      errors: [
-        {
-          data: {
-            name: "setData",
-          },
-          messageId: "default",
-        },
-      ],
-    },
+    // This case was previously reported because the rule did not detect ref in conditional
+    // expressions. Now it is correctly allowed since ref.current is used as an argument.
+    // {
+    //   name: "setState with ref.current inside conditional expression",
+    //   ...
+    // }
     {
       name: "setState with ref value inside computed member expression (rule does not detect ref in computed property)",
       code: tsx`
@@ -862,6 +845,149 @@ ruleTester.run(RULE_NAME, rule, {
           messageId: "default",
         },
       ],
+    },
+    // --- Namespace import cases ---
+    {
+      name: "setState in React.useEffect with namespace import",
+      code: tsx`
+        import * as React from "react";
+
+        function Component() {
+          const [data, setData] = React.useState(0);
+          React.useEffect(() => {
+            setData(1);
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "setData" },
+          messageId: "default",
+        },
+      ],
+    },
+    // --- useEffectEvent cases ---
+    {
+      name: "setState via useEffectEvent called in effect",
+      code: tsx`
+        import { useEffect, useState, useEffectEvent } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          const handler = useEffectEvent(() => {
+            setData(1);
+          });
+          useEffect(() => {
+            handler();
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "setData" },
+          messageId: "default",
+        },
+      ],
+    },
+    {
+      name: "setState via useEffectEvent passed directly to useEffect",
+      code: tsx`
+        import { useEffect, useState, useEffectEvent } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          const handler = useEffectEvent(() => {
+            setData(1);
+          });
+          useEffect(handler, []);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "setData" },
+          messageId: "default",
+        },
+      ],
+    },
+    // --- Dependency array cases ---
+    {
+      name: "setState in effect deps should still report",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        function Component({ prop }) {
+          const [data, setData] = useState(0);
+          useEffect(() => {
+            setData(prop);
+          }, [prop, setData]);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "setData" },
+          messageId: "default",
+        },
+      ],
+    },
+    // --- Prop-gated conditional (should still report) ---
+    {
+      name: "setState inside prop-gated if statement should still report",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        function Component({ prop }) {
+          const [data, setData] = useState(0);
+          useEffect(() => {
+            if (prop !== data) {
+              setData(prop);
+            }
+          }, []);
+          return null;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "setData" },
+          messageId: "default",
+        },
+      ],
+    },
+    // --- React Compiler fixtures: invalid ---
+    {
+      name: "setState in effect with NewExpression default param",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        function Component({ value = new Number() }) {
+          const [state, setState] = useState(0);
+          useEffect(() => {
+            setState(s => s + 1);
+          });
+          return state;
+        }
+      `,
+      errors: [{ messageId: "default" }],
+    },
+    {
+      name: "conditional setState from props in effect (derived event pattern)",
+      code: tsx`
+        import { useState, useEffect } from "react";
+
+        function VideoPlayer({ isPlaying }) {
+          const [wasPlaying, setWasPlaying] = useState(isPlaying);
+          useEffect(() => {
+            if (isPlaying !== wasPlaying) {
+              setWasPlaying(isPlaying);
+            }
+          }, [isPlaying, wasPlaying]);
+          return <video />;
+        }
+      `,
+      errors: [{ messageId: "default" }],
     },
   ],
   valid: [
@@ -1432,6 +1558,189 @@ ruleTester.run(RULE_NAME, rule, {
               )
             });
           }, [loading, navigation, onBack, onPressSave, post, submitting, t]);
+        }
+      `,
+    },
+    // --- Namespace import valid cases ---
+    {
+      name: "setState with ref via namespace import",
+      code: tsx`
+        import * as React from "react";
+
+        function Component() {
+          const [data, setData] = React.useState(0);
+          const ref = React.useRef(0);
+          React.useEffect(() => {
+            setData(ref.current);
+          }, []);
+          return null;
+        }
+      `,
+    },
+    // --- Ref-gated conditional valid cases ---
+    {
+      name: "setState inside ref-gated if statement",
+      code: tsx`
+        import { useEffect, useState, useRef } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          const prevRef = useRef(0);
+          useEffect(() => {
+            if (prevRef.current !== data) {
+              setData(prevRef.current);
+            }
+          }, []);
+          return null;
+        }
+      `,
+    },
+    {
+      name: "setState inside ref-gated conditional expression",
+      code: tsx`
+        import { useEffect, useState, useRef } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          const flagRef = useRef(false);
+          useEffect(() => {
+            flagRef.current ? setData(1) : setData(0);
+          }, []);
+          return null;
+        }
+      `,
+    },
+    {
+      name: "setState with ref.current inside conditional expression",
+      code: tsx`
+        import { useEffect, useState, useRef } from "react";
+
+        function Component() {
+          const ref = useRef(0);
+          const [data, setData] = useState(0);
+          useEffect(() => {
+            setData(flag ? ref.current : 0);
+          }, []);
+          return null;
+        }
+      `,
+    },
+    // --- React Compiler fixtures: valid ---
+    {
+      name: "setState with ref in useLayoutEffect",
+      code: tsx`
+        import { useState, useRef, useLayoutEffect } from "react";
+
+        function Tooltip() {
+          const ref = useRef(null);
+          const [tooltipHeight, setTooltipHeight] = useState(0);
+          useLayoutEffect(() => {
+            const { height } = ref.current.getBoundingClientRect();
+            setTooltipHeight(height);
+          }, []);
+          return tooltipHeight;
+        }
+      `,
+    },
+    {
+      name: "setState with ref value via arithmetic",
+      code: tsx`
+        import { useState, useRef, useLayoutEffect } from "react";
+
+        function Component() {
+          const ref = useRef({ size: 5 });
+          const [computedSize, setComputedSize] = useState(0);
+          useLayoutEffect(() => {
+            setComputedSize(ref.current.size * 10);
+          }, []);
+          return computedSize;
+        }
+      `,
+    },
+    {
+      name: "setState with ref value via array index",
+      code: tsx`
+        import { useState, useRef, useEffect } from "react";
+
+        function Component() {
+          const ref = useRef([1, 2, 3, 4, 5]);
+          const [value, setValue] = useState(0);
+          useEffect(() => {
+            const index = 2;
+            setValue(ref.current[index]);
+          }, []);
+          return value;
+        }
+      `,
+    },
+    {
+      name: "setState with ref value via function call",
+      code: tsx`
+        import { useState, useRef, useEffect } from "react";
+
+        function Component() {
+          const ref = useRef(null);
+          const [width, setWidth] = useState(0);
+          useEffect(() => {
+            function getBoundingRect(ref) {
+              if (ref.current) {
+                return ref.current.getBoundingClientRect?.()?.width ?? 100;
+              }
+              return 100;
+            }
+            setWidth(getBoundingRect(ref));
+          }, []);
+          return width;
+        }
+      `,
+    },
+    {
+      name: "setState in transitive listener via setTimeout",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        function Component() {
+          const [state, setState] = useState(0);
+          useEffect(() => {
+            const f = () => {
+              setState();
+            };
+            setTimeout(() => f(), 10);
+          });
+          return state;
+        }
+      `,
+    },
+    {
+      name: "setState controlled by ref value with external functions",
+      code: tsx`
+        import { useState, useRef, useEffect } from "react";
+
+        function Component({ x, y }) {
+          const previousXRef = useRef(null);
+          const previousYRef = useRef(null);
+          const [data, setData] = useState(null);
+
+          useEffect(() => {
+            const previousX = previousXRef.current;
+            previousXRef.current = x;
+            const previousY = previousYRef.current;
+            previousYRef.current = y;
+            if (!areEqual(x, previousX) || !areEqual(y, previousY)) {
+              const data = load({ x, y });
+              setData(data);
+            }
+          }, [x, y]);
+
+          return data;
+        }
+
+        function areEqual(a, b) {
+          return a === b;
+        }
+
+        function load({ x, y }) {
+          return x * y;
         }
       `,
     },

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -9,7 +9,13 @@ import { getStaticValue } from "@typescript-eslint/utils/ast-utils";
 import { match } from "ts-pattern";
 
 import { createRule } from "../../utils";
-import { getNestedIdentifiers, isHookDecl, isInitializedFromRef } from "./lib";
+import {
+  getNestedIdentifiers,
+  getSetStateCallExpression,
+  isHookDecl,
+  isInitializedFromRef,
+  isRefGatedContext,
+} from "./lib";
 
 export const RULE_NAME = "set-state-in-effect";
 
@@ -232,6 +238,18 @@ export function create(context: RuleContext<MessageID, []>) {
                         return isUsingRefValue(n.object);
                       case AST.CallExpression:
                         return isUsingRefValue(n.callee) || getNestedIdentifiers(n).some(isUsingRefValue);
+                      case AST.BinaryExpression:
+                      case AST.LogicalExpression:
+                        return isUsingRefValue(n.left) || isUsingRefValue(n.right);
+                      case AST.UnaryExpression:
+                      case AST.UpdateExpression:
+                        return isUsingRefValue(n.argument);
+                      case AST.ConditionalExpression:
+                        return isUsingRefValue(n.consequent) || isUsingRefValue(n.alternate);
+                      case AST.SequenceExpression:
+                        return n.expressions.some(isUsingRefValue);
+                      case AST.AssignmentExpression:
+                        return isUsingRefValue(n.right);
                       default:
                         return false;
                     }
@@ -246,6 +264,7 @@ export function create(context: RuleContext<MessageID, []>) {
                       .some((r) => isUsingRefValue(r.identifier));
                 }
                 if (isArgumentUsingRefValue(context, args0)) return;
+                if (isRefGatedContext(context, node)) return;
                 context.report({
                   data: {
                     name: context.sourceCode.getText(node.callee),
@@ -337,6 +356,7 @@ export function create(context: RuleContext<MessageID, []>) {
         };
         for (const [, calls] of setStateInEffectSetup) {
           for (const call of calls) {
+            if (isRefGatedContext(context, getSetStateCallExpression(call))) continue;
             context.report({
               data: {
                 name: call.name,
@@ -352,6 +372,7 @@ export function create(context: RuleContext<MessageID, []>) {
           }
           const setStateCalls = getSetStateCalls(context, callee);
           for (const setStateCall of setStateCalls) {
+            if (isRefGatedContext(context, getSetStateCallExpression(setStateCall))) continue;
             context.report({
               data: {
                 name: getCallName(setStateCall),
@@ -364,6 +385,7 @@ export function create(context: RuleContext<MessageID, []>) {
         for (const id of setupFnIds) {
           const setStateCalls = getSetStateCalls(context, id);
           for (const setStateCall of setStateCalls) {
+            if (isRefGatedContext(context, getSetStateCallExpression(setStateCall))) continue;
             context.report({
               data: {
                 name: getCallName(setStateCall),


### PR DESCRIPTION
…dation

- Add ref-gated conditional detection (isRefGatedContext) to skip reporting setState inside conditions controlled by ref values (e.g. `if (prevRef.current !== value) setState(...)`)
- Enhance isInitializedFromRef to recognize ref-derived variables from CallExpression init (e.g. `const { height } = ref.current.getBoundingClientRect()`)
- Extend isArgumentUsingRefValue to support BinaryExpression, UnaryExpression, ConditionalExpression, SequenceExpression, and AssignmentExpression
- Extract getSetStateCallExpression helper to eliminate duplication
- Add 16 new test cases covering:
  - namespace import (React.useEffect / React.useState)
  - useEffectEvent indirect setState detection
  - setState in effect dependency array (should still report)
  - ref-gated conditionals (if / ternary)
  - React Compiler fixture cases (NewExpression default param, derived event pattern, useLayoutEffect + ref, ref arithmetic, ref array index, ref via function call, transitive listener)
- Add spec.diff.md comparing implementation to React Compiler's ValidateNoSetStateInEffects

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [x] Feature
- [ ] Perf
- [x] Docs
- [x] Test
- [ ] Chore
- [x] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
