### PR TITLE
  fix: unwrap type expressions before inspecting AST node types

### DIFF
--- a/docs/ast-extract-unwrap-usage.md
+++ b/docs/ast-extract-unwrap-usage.md
@@ -1,0 +1,113 @@
+# Extract.unwrap Usage Guidelines
+
+`Extract.unwrap` is defined in `@eslint-react/ast` and is used to strip away wrapper nodes that do not change the semantic meaning of an expression.
+
+## Definition
+
+```ts
+export function unwrap(node: TSESTree.Node): Exclude<TSESTree.Node, TSESTreeTypeExpression> {
+  if (Check.isTypeExpression(node) || node.type === AST.ChainExpression) {
+    return unwrap(node.expression);
+  }
+  return node;
+}
+```
+
+It recursively unwraps the following wrapper node types:
+
+| Wrapper Type      | AST Node Type               | Example            |
+| ----------------- | --------------------------- | ------------------ |
+| Type assertion    | `TSAsExpression`            | `(expr as T)`      |
+| Type assertion    | `TSTypeAssertion`           | `<T>expr`          |
+| Type assertion    | `TSNonNullExpression`       | `expr!`            |
+| Type assertion    | `TSSatisfiesExpression`     | `expr satisfies T` |
+| Type assertion    | `TSInstantiationExpression` | `expr<T>`          |
+| Optional chaining | `ChainExpression`           | `(expr?.method)()` |
+
+## When to Use
+
+Whenever you access a sub-property of a node and immediately inspect its `type`, ask yourself: **could this node be wrapped in a type expression or chain expression?**
+
+The most common omission is inspecting `node.callee.type` without first unwrapping the callee.
+
+### Scenario 1: Inspecting `node.callee.type`
+
+**Always unwrap** when you check `node.callee.type` on a `CallExpression` or `NewExpression`.
+
+```ts
+// ❌ Wrong — misses (useState as any)() and (foo?.bar)()
+if (node.callee.type === AST.Identifier) {
+  return node.callee.name === "useState";
+}
+
+// ✅ Correct
+const callee = Extract.unwrap(node.callee);
+if (callee.type === AST.Identifier) {
+  return callee.name === "useState";
+}
+```
+
+### Scenario 2: Resolving a node and inspecting its type
+
+Variable resolution (`resolve()`) may return a node that is itself wrapped in a type expression. Unwrap before switching on `type`.
+
+```ts
+// ❌ Wrong
+const init = resolve(context, id);
+if (init?.type === AST.CallExpression) { /* ... */ }
+
+// ✅ Correct
+const init = resolve(context, id);
+const unwrapped = init == null ? null : Extract.unwrap(init);
+if (unwrapped?.type === AST.CallExpression) { /* ... */ }
+```
+
+### Scenario 3: Inspecting `node.parent` or `node.init`
+
+If a node comes from a parent property like `variableDeclarator.init`, it may be wrapped.
+
+```ts
+// ❌ Wrong
+if (node.init.type === AST.MemberExpression) { /* ... */ }
+
+// ✅ Correct
+const init = Extract.unwrap(node.init);
+if (init.type === AST.MemberExpression) { /* ... */ }
+```
+
+## Common Patterns That Are Already Safe
+
+The following patterns **do not** need additional unwrapping because the utility already handles it internally:
+
+- `core.isHookCall(node)` — internally unwraps `node.callee`.
+- `core.isAPICall(api)(context, node)` — internally unwraps `node.callee`.
+- `Compare.isEqual(a, b)` — internally unwraps type expressions on both sides.
+- `Check.isIdentifier(name)(node)` — does **not** unwrap; wrap the node first if needed.
+
+## Checklist Before Committing
+
+When you write or review code that inspects AST node types, verify:
+
+1. [ ] Any `node.callee.type` check is preceded by `Extract.unwrap(node.callee)`.
+2. [ ] Any resolved node (`resolve()`, `findParent()`, etc.) is unwrapped before `.type` inspection.
+3. [ ] Any `node.init`, `node.parent`, or similar property accessed for type inspection is unwrapped.
+4. [ ] Existing helper functions (`isHookCall`, `isAPICall`, etc.) are used instead of re-implementing callee checks.
+
+## Example: Before and After
+
+```ts
+// Before — silently misses wrapped calls
+function isThenCall(node: TSESTree.CallExpression) {
+  return node.callee.type === AST.MemberExpression
+    && node.callee.property.type === AST.Identifier
+    && node.callee.property.name === "then";
+}
+
+// After — correctly handles (promise.then as any)() and (promise?.then)()
+function isThenCall(node: TSESTree.CallExpression) {
+  const callee = Extract.unwrap(node.callee);
+  return callee.type === AST.MemberExpression
+    && callee.property.type === AST.Identifier
+    && callee.property.name === "then";
+}
+```

--- a/packages/core/src/class-component.test.ts
+++ b/packages/core/src/class-component.test.ts
@@ -1,0 +1,58 @@
+/// <reference types="node" />
+
+import { parseForESLint } from "@typescript-eslint/parser";
+import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
+import { simpleTraverse } from "@typescript-eslint/typescript-estree";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { getFixturesRootDir } from "../../../test";
+import { isThisSetStateCall } from "./class-component";
+
+function parse(code: string) {
+  return parseForESLint(code, {
+    disallowAutomaticSingleRunInference: true,
+    filePath: path.join(getFixturesRootDir(), "estree.tsx"),
+  });
+}
+
+describe("isThisSetStateCall", () => {
+  it("should return true for this.setState()", () => {
+    const code = "this.setState({})";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.CallExpression) {
+          result = isThisSetStateCall(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should return true when callee is wrapped in TSAsExpression", () => {
+    const code = "(this.setState as any)({})";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.CallExpression) {
+          result = isThisSetStateCall(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should return true when callee is wrapped in TSSatisfiesExpression", () => {
+    const code = "(this.setState satisfies typeof this.setState)({})";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.CallExpression) {
+          result = isThisSetStateCall(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+});

--- a/packages/core/src/class-component.ts
+++ b/packages/core/src/class-component.ts
@@ -179,7 +179,7 @@ export function isRenderMethodCallback(node: TSESTreeFunction) {
  * @deprecated Class components are legacy. This function exists only to support legacy rules.
  */
 export function isThisSetStateCall(node: TSESTree.CallExpression) {
-  const { callee } = node;
+  const callee = Extract.unwrap(node.callee);
   return (
     callee.type === AST.MemberExpression
     && callee.object.type === AST.ThisExpression

--- a/packages/core/src/function-component.ts
+++ b/packages/core/src/function-component.ts
@@ -1,4 +1,4 @@
-import { Check, type TSESTreeDirective, type TSESTreeFunction, Traverse, isOneOf } from "@eslint-react/ast";
+import { Check, Extract, type TSESTreeDirective, type TSESTreeFunction, Traverse, isOneOf } from "@eslint-react/ast";
 /* eslint-disable perfectionist/sort-objects */
 import type { RuleContext } from "@eslint-react/eslint";
 import { JsxDetectionHint } from "@eslint-react/jsx";
@@ -279,10 +279,14 @@ export function isFunctionComponentDefinition(context: RuleContext, node: TSESTr
   }
 
   // 2. Check immediate contextual exclusions
+  const isCreateElementArg = ((): boolean => {
+    let p = node.parent;
+    while (Check.isTypeExpression(p)) p = p.parent;
+    if (p.type !== AST.CallExpression || !isCreateElementCall(context, p)) return false;
+    return p.arguments.slice(2).some((arg) => Extract.unwrap(arg) === node);
+  })();
   switch (true) {
-    case node.parent.type === AST.CallExpression
-      && isCreateElementCall(context, node.parent)
-      && node.parent.arguments.slice(2).some((arg: TSESTree.Node) => arg === node):
+    case isCreateElementArg:
       return false;
     case isRenderMethodCallback(node):
       return false;
@@ -293,6 +297,9 @@ export function isFunctionComponentDefinition(context: RuleContext, node: TSESTr
   while (Check.isTypeExpression(parent)) parent = parent.parent;
 
   // 4. Apply contextual exclusions via hints
+  const parentCallee = parent.type === AST.CallExpression
+    ? Extract.unwrap(parent.callee)
+    : null;
   switch (true) {
     case isOneOf([AST.ArrowFunctionExpression, AST.FunctionExpression])(node)
       && parent.type === AST.Property
@@ -313,16 +320,16 @@ export function isFunctionComponentDefinition(context: RuleContext, node: TSESTr
     case parent.type === AST.ArrayExpression:
       if (hint & FunctionComponentDetectionHint.DoNotIncludeFunctionDefinedAsArrayExpressionElement) return false;
       break;
-    case parent.type === AST.CallExpression
-      && parent.callee.type === AST.MemberExpression
-      && parent.callee.property.type === AST.Identifier
-      && parent.callee.property.name === "map":
+    case parentCallee != null
+      && parentCallee.type === AST.MemberExpression
+      && parentCallee.property.type === AST.Identifier
+      && parentCallee.property.name === "map":
       if (hint & FunctionComponentDetectionHint.DoNotIncludeFunctionDefinedAsArrayMapCallback) return false;
       break;
-    case parent.type === AST.CallExpression
-      && parent.callee.type === AST.MemberExpression
-      && parent.callee.property.type === AST.Identifier
-      && parent.callee.property.name === "flatMap":
+    case parentCallee != null
+      && parentCallee.type === AST.MemberExpression
+      && parentCallee.property.type === AST.Identifier
+      && parentCallee.property.name === "flatMap":
       if (hint & FunctionComponentDetectionHint.DoNotIncludeFunctionDefinedAsArrayFlatMapCallback) return false;
       break;
     case parent.type === AST.CallExpression

--- a/packages/core/src/function.test.ts
+++ b/packages/core/src/function.test.ts
@@ -1,0 +1,67 @@
+/// <reference types="node" />
+
+import { parseForESLint } from "@typescript-eslint/parser";
+import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
+import { simpleTraverse } from "@typescript-eslint/typescript-estree";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { getFixturesRootDir } from "../../../test";
+import { getFunctionInitPath, isFunctionHasCallInInitPath } from "./function";
+
+function parse(code: string) {
+  return parseForESLint(code, {
+    disallowAutomaticSingleRunInference: true,
+    filePath: path.join(getFixturesRootDir(), "estree.tsx"),
+  });
+}
+
+describe("isFunctionHasCallInInitPath", () => {
+  it("should detect memo call when callee is wrapped in TSAsExpression", () => {
+    const code = "const Component = (memo as any)(() => {})";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.ArrowFunctionExpression) {
+          const initPath = getFunctionInitPath(node);
+          if (initPath != null) {
+            result = isFunctionHasCallInInitPath("memo", initPath);
+          }
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should detect React.memo call when callee is wrapped in TSAsExpression", () => {
+    const code = "const Component = (React.memo as any)(() => {})";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.ArrowFunctionExpression) {
+          const initPath = getFunctionInitPath(node);
+          if (initPath != null) {
+            result = isFunctionHasCallInInitPath("memo", initPath);
+          }
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should detect memo call when callee is wrapped in TSSatisfiesExpression", () => {
+    const code = "const Component = (memo satisfies typeof memo)(() => {})";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.ArrowFunctionExpression) {
+          const initPath = getFunctionInitPath(node);
+          if (initPath != null) {
+            result = isFunctionHasCallInInitPath("memo", initPath);
+          }
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+});

--- a/packages/core/src/function.ts
+++ b/packages/core/src/function.ts
@@ -1,4 +1,4 @@
-import { Check, type TSESTreeDirective, type TSESTreeFunction } from "@eslint-react/ast";
+import { Check, Extract, type TSESTreeDirective, type TSESTreeFunction } from "@eslint-react/ast";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 import type { SemanticFunc } from "./semantic";
@@ -234,7 +234,7 @@ export function isFunctionHasCallInInitPath(callName: string, initPath: Function
       return false;
     }
 
-    const { callee } = node;
+    const callee = Extract.unwrap(node.callee);
 
     // Check direct function calls: memo(...)
     if (callee.type === AST.Identifier) {

--- a/packages/jsx/src/is-jsx-like.test.ts
+++ b/packages/jsx/src/is-jsx-like.test.ts
@@ -1,0 +1,64 @@
+/// <reference types="node" />
+
+import type { RuleContext } from "@eslint-react/eslint";
+import { parseForESLint } from "@typescript-eslint/parser";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { getFixturesRootDir } from "../../../test";
+import { isJsxLike } from "./is-jsx-like";
+
+function parse(code: string) {
+  return parseForESLint(code, {
+    disallowAutomaticSingleRunInference: true,
+    filePath: path.join(getFixturesRootDir(), "estree.tsx"),
+  });
+}
+
+function findFirstCallExpression(node: TSESTree.Node): TSESTree.CallExpression | null {
+  if (node.type === AST.CallExpression) return node;
+  for (const key of Object.keys(node)) {
+    const child = (node as unknown as Record<string, unknown>)[key];
+    if (child != null && typeof child === "object") {
+      if (Array.isArray(child)) {
+        for (const item of child) {
+          if (item != null && typeof item === "object" && "type" in item) {
+            const found = findFirstCallExpression(item as TSESTree.Node);
+            if (found != null) return found;
+          }
+        }
+      } else if ("type" in child) {
+        const found = findFirstCallExpression(child as TSESTree.Node);
+        if (found != null) return found;
+      }
+    }
+  }
+  return null;
+}
+
+describe("isJsxLike", () => {
+  it("should detect createElement when callee is wrapped in TSAsExpression", () => {
+    const code = "(createElement as any)('div', null, null)";
+    const ast = parse(code).ast;
+    const callExpr = findFirstCallExpression(ast);
+    expect(callExpr).not.toBeNull();
+    const result = isJsxLike(
+      { sourceCode: { getScope: () => ({}) } } as unknown as RuleContext,
+      callExpr,
+    );
+    expect(result).toBe(true);
+  });
+
+  it("should detect React.createElement when callee is wrapped in TSAsExpression", () => {
+    const code = "(React.createElement as any)('div', null, null)";
+    const ast = parse(code).ast;
+    const callExpr = findFirstCallExpression(ast);
+    expect(callExpr).not.toBeNull();
+    const result = isJsxLike(
+      { sourceCode: { getScope: () => ({}) } } as unknown as RuleContext,
+      callExpr,
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/packages/jsx/src/is-jsx-like.ts
+++ b/packages/jsx/src/is-jsx-like.ts
@@ -1,4 +1,4 @@
-import { Check } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/eslint";
 import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -97,12 +97,13 @@ export function isJsxLike(
       if (hint & Hint.DoNotIncludeJsxWithCreateElementValue) {
         return false;
       }
-      switch (node.callee.type) {
+      const callee = Extract.unwrap(node.callee);
+      switch (callee.type) {
         case AST.Identifier:
-          return node.callee.name === "createElement";
+          return callee.name === "createElement";
         case AST.MemberExpression:
-          return node.callee.property.type === AST.Identifier
-            && node.callee.property.name === "createElement";
+          return callee.property.type === AST.Identifier
+            && callee.property.name === "createElement";
       }
       return false;
     }

--- a/packages/var/src/compute-object-type.test.ts
+++ b/packages/var/src/compute-object-type.test.ts
@@ -276,5 +276,27 @@ describe("computeObjectType", () => {
         return null;
       });
     });
+
+    it("FIXED: CallExpression callee wrapped in TSAsExpression is recognized", () => {
+      const code = "const x = (Array as any)();";
+      const result = runInRule(code, (context, ast) => {
+        const node = findFirst<TSESTree.CallExpression>(ast, AST.CallExpression);
+        expect(node).toBeDefined();
+        return computeObjectType(context, node!);
+      });
+      expect(result).not.toBeNull();
+      expect(result!.kind).toBe("array");
+    });
+
+    it("FIXED: CallExpression callee wrapped in TSSatisfiesExpression is recognized", () => {
+      const code = "const x = (Array.from satisfies typeof Array.from)([1, 2]);";
+      const result = runInRule(code, (context, ast) => {
+        const node = findFirst<TSESTree.CallExpression>(ast, AST.CallExpression);
+        expect(node).toBeDefined();
+        return computeObjectType(context, node!);
+      });
+      expect(result).not.toBeNull();
+      expect(result!.kind).toBe("array");
+    });
   });
 });

--- a/packages/var/src/compute-object-type.ts
+++ b/packages/var/src/compute-object-type.ts
@@ -1,4 +1,4 @@
-import { Check } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/eslint";
 import { DefinitionType } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -116,29 +116,30 @@ export function computeObjectType(
       );
     }
     case AST.CallExpression: {
+      const callee = Extract.unwrap(node.callee);
       switch (true) {
-        case Check.isIdentifier("Boolean")(node.callee):
+        case Check.isIdentifier("Boolean")(callee):
           return null;
-        case Check.isIdentifier("String")(node.callee):
+        case Check.isIdentifier("String")(callee):
           return null;
-        case Check.isIdentifier("Number")(node.callee):
+        case Check.isIdentifier("Number")(callee):
           return null;
-        case Check.isIdentifier("Object")(node.callee):
+        case Check.isIdentifier("Object")(callee):
           return { kind: "plain", node } as const;
-        case Check.isIdentifier("Array")(node.callee):
+        case Check.isIdentifier("Array")(callee):
           return { kind: "array", node } as const;
-        case Check.isIdentifier("RegExp")(node.callee):
+        case Check.isIdentifier("RegExp")(callee):
           return { kind: "regexp", node } as const;
       }
 
       // Handle static factory methods (e.g. Array.from(), Object.create())
       if (
-        node.callee.type === AST.MemberExpression
-        && node.callee.object.type === AST.Identifier
-        && node.callee.property.type === AST.Identifier
+        callee.type === AST.MemberExpression
+        && callee.object.type === AST.Identifier
+        && callee.property.type === AST.Identifier
       ) {
-        const objName = node.callee.object.name;
-        const methodName = node.callee.property.name;
+        const objName = callee.object.name;
+        const methodName = callee.property.name;
         switch (objName) {
           case "Array":
             if (methodName === "from" || methodName === "of") {

--- a/packages/var/src/get-require-expression-arguments.ts
+++ b/packages/var/src/get-require-expression-arguments.ts
@@ -1,6 +1,5 @@
-import { identity } from "@local/eff";
+import { Extract } from "@eslint-react/ast";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
-import { P, match } from "ts-pattern";
 
 /**
  * Get the arguments of a require expression
@@ -9,26 +8,15 @@ import { P, match } from "ts-pattern";
  * @internal
  */
 export function getRequireExpressionArguments(node: TSESTree.Node) {
-  return match<typeof node, TSESTree.CallExpressionArgument[] | null>(node)
-    .with(
-      {
-        // require("source")
-        type: AST.CallExpression,
-        arguments: P.select(),
-        callee: {
-          type: AST.Identifier,
-          name: "require",
-        },
-      },
-      identity,
-    )
-    .with(
-      {
-        // require("source").variable
-        type: AST.MemberExpression,
-        object: P.select(),
-      },
-      getRequireExpressionArguments,
-    )
-    .otherwise(() => null);
+  const unwrapped = Extract.unwrap(node);
+  if (unwrapped.type === AST.CallExpression) {
+    const callee = Extract.unwrap(unwrapped.callee);
+    if (callee.type === AST.Identifier && callee.name === "require") {
+      return unwrapped.arguments;
+    }
+  }
+  if (unwrapped.type === AST.MemberExpression) {
+    return getRequireExpressionArguments(unwrapped.object);
+  }
+  return null;
 }

--- a/packages/var/src/resolve-import-source.test.ts
+++ b/packages/var/src/resolve-import-source.test.ts
@@ -75,4 +75,44 @@ describe("resolveImportSource", () => {
 
     expect(result).toBeNull();
   });
+
+  it("should resolve require call wrapped in TSAsExpression", () => {
+    const code = `const React = require("react") as any;`;
+    const { scopeManager } = parse(code);
+    const moduleScope = scopeManager.globalScope!.childScopes[0]!;
+
+    const result = resolveImportSource("React", moduleScope);
+
+    expect(result).toBe("react");
+  });
+
+  it("should resolve identifier alias wrapped in TSAsExpression", () => {
+    const code = `import { useState } from "react";\nconst x = useState as any;`;
+    const { scopeManager } = parse(code);
+    const moduleScope = scopeManager.globalScope!.childScopes[0]!;
+
+    const result = resolveImportSource("x", moduleScope);
+
+    expect(result).toBe("react");
+  });
+
+  it("should resolve member expression alias wrapped in TSAsExpression", () => {
+    const code = `import * as React from "react";\nconst useState = React.useState as any;`;
+    const { scopeManager } = parse(code);
+    const moduleScope = scopeManager.globalScope!.childScopes[0]!;
+
+    const result = resolveImportSource("useState", moduleScope);
+
+    expect(result).toBe("react");
+  });
+
+  it("should resolve require call wrapped in TSAsExpression with member access", () => {
+    const code = `const x = (require("react") as any).useState;`;
+    const { scopeManager } = parse(code);
+    const moduleScope = scopeManager.globalScope!.childScopes[0]!;
+
+    const result = resolveImportSource("x", moduleScope);
+
+    expect(result).toBe("react");
+  });
 });

--- a/packages/var/src/resolve-import-source.ts
+++ b/packages/var/src/resolve-import-source.ts
@@ -1,4 +1,4 @@
-import { Check } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import type { Scope } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
@@ -16,7 +16,7 @@ export function resolveImportSource(
   if (latestDef == null) return null;
   const { node, parent } = latestDef;
   if (node.type === AST.VariableDeclarator && node.init != null) {
-    const { init } = node;
+    const init = Extract.unwrap(node.init);
     // check for: variable = Source.variable
     if (init.type === AST.MemberExpression && init.object.type === AST.Identifier) {
       return resolveImportSource(init.object.name, initialScope, visited);

--- a/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.spec.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.spec.ts
@@ -1994,6 +1994,13 @@ ruleTester.run(RULE_NAME, rule, {
     "items.map((() => <div />) as any)",
     "items.map((() => <div />) satisfies any)",
     "items.map((() => <div />)! as any)",
+    // Callee of .map() wrapped in type expressions — excluded by
+    // DoNotIncludeFunctionDefinedAsArrayMapCallback
+    "(items.map as any)((x) => <div />)",
+    "(items.map satisfies typeof items.map)((x) => <div />)",
+    // Named function passed to createElement wrapped in type expression
+    // (node.parent is TSAsExpression, not CallExpression, so L282-289 misses it)
+    "React.createElement('div', null, (function App() { return <div />; }) as any)",
     // Anonymous function in .flatMap() wrapped in type expressions — excluded by
     // DoNotIncludeFunctionDefinedAsArrayFlatMapCallback
     "items.flatMap((() => <div />) as any)",

--- a/plugins/eslint-plugin-react-dom/package.json
+++ b/plugins/eslint-plugin-react-dom/package.json
@@ -43,6 +43,7 @@
     "publish": "pnpm run build && pnpm run lint:publish"
   },
   "dependencies": {
+    "@eslint-react/ast": "workspace:*",
     "@eslint-react/eslint": "workspace:*",
     "@eslint-react/jsx": "workspace:*",
     "@eslint-react/shared": "workspace:*",

--- a/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.spec.ts
@@ -59,6 +59,18 @@ ruleTester.run(RULE_NAME, rule, {
         hydrateRoot(rootEl, <Component />);
       `,
     },
+    {
+      code: tsx`
+        import { hydrate } from "react-dom";
+        (hydrate as any)(<div />, document.body);
+      `,
+      errors: [{ messageId: "default" }],
+      output: tsx`
+        import { hydrateRoot } from "react-dom/client";
+        import { hydrate } from "react-dom";
+        hydrateRoot(document.body, <div />);
+      `,
+    },
   ],
   valid: [
     tsx`

--- a/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
@@ -1,3 +1,4 @@
+import { Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleFixer, merge } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -46,10 +47,11 @@ export function create(context: RuleContext<MessageID, []>) {
   return merge(
     {
       CallExpression(node) {
+        const callee = Extract.unwrap(node.callee);
         switch (true) {
           // Case 1: Direct call to `hydrate()`.
-          case node.callee.type === AST.Identifier
-            && hydrateNames.has(node.callee.name):
+          case callee.type === AST.Identifier
+            && hydrateNames.has(callee.name):
             context.report({
               fix: getFix(context, node),
               messageId: "default",
@@ -57,11 +59,11 @@ export function create(context: RuleContext<MessageID, []>) {
             });
             return;
           // Case 2: Call on a `react-dom` import, like `ReactDOM.hydrate()`
-          case node.callee.type === AST.MemberExpression
-            && node.callee.object.type === AST.Identifier
-            && node.callee.property.type === AST.Identifier
-            && node.callee.property.name === hydrate
-            && reactDomNames.has(node.callee.object.name):
+          case callee.type === AST.MemberExpression
+            && callee.object.type === AST.Identifier
+            && callee.property.type === AST.Identifier
+            && callee.property.name === hydrate
+            && reactDomNames.has(callee.object.name):
             context.report({
               fix: getFix(context, node),
               messageId: "default",

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.spec.ts
@@ -67,6 +67,20 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    {
+      code: tsx`
+        import { render } from "react-dom";
+        const result = (render as any)(<div />, document.body);
+      `,
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: tsx`
+        import { render } from "react-dom";
+        const result = (render(<div />, document.body) as any);
+      `,
+      errors: [{ messageId: "default" }],
+    },
   ],
   valid: [
     "ReactDOM.render(<div />, document.body);",

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
@@ -1,3 +1,4 @@
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
@@ -17,6 +18,12 @@ const banParentTypes = [
   AST.ArrowFunctionExpression,
   AST.AssignmentExpression,
 ];
+
+function isReturnValueUsed(node: TSESTree.CallExpression) {
+  let parent = node.parent;
+  while (Check.isTypeExpression(parent)) parent = parent.parent;
+  return banParentTypes.includes(parent.type);
+}
 
 export default createRule<[], MessageID>({
   meta: {
@@ -43,25 +50,26 @@ export function create(context: RuleContext<MessageID, []>) {
     {
       // Checks for calls to 'render' or 'ReactDOM.render' and reports if their return value is used
       CallExpression(node) {
+        const callee = Extract.unwrap(node.callee);
         switch (true) {
           // Handles direct calls to 'render' (ex: from `import { render } from 'react-dom'`)
-          case node.callee.type === AST.Identifier
-            && renderNames.has(node.callee.name)
+          case callee.type === AST.Identifier
+            && renderNames.has(callee.name)
             // Check if the return value is being used
-            && banParentTypes.includes(node.parent.type):
+            && isReturnValueUsed(node):
             context.report({
               messageId: "default",
               node,
             });
             return;
           // Handles member expression calls like 'ReactDOM.render'
-          case node.callee.type === AST.MemberExpression
-            && node.callee.object.type === AST.Identifier
-            && node.callee.property.type === AST.Identifier
-            && node.callee.property.name === "render"
-            && reactDomNames.has(node.callee.object.name)
+          case callee.type === AST.MemberExpression
+            && callee.object.type === AST.Identifier
+            && callee.property.type === AST.Identifier
+            && callee.property.name === "render"
+            && reactDomNames.has(callee.object.name)
             // Check if the return value is being used
-            && banParentTypes.includes(node.parent.type):
+            && isReturnValueUsed(node):
             context.report({
               messageId: "default",
               node,

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.spec.ts
@@ -79,6 +79,18 @@ ruleTester.run(RULE_NAME, rule, {
         createRoot(rootEl).render(<Component />);
       `,
     },
+    {
+      code: tsx`
+        import { render } from "react-dom";
+        (render as any)(<div />, document.body);
+      `,
+      errors: [{ messageId: "default" }],
+      output: tsx`
+        import { createRoot } from "react-dom/client";
+        import { render } from "react-dom";
+        createRoot(document.body).render(<div />);
+      `,
+    },
   ],
   valid: [
     tsx`

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
@@ -1,3 +1,4 @@
+import { Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleFixer, merge } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -46,10 +47,11 @@ export function create(context: RuleContext<MessageID, []>) {
     {
       // Visitor for call expressions, e.g., render() or ReactDOM.render()
       CallExpression(node) {
+        const callee = Extract.unwrap(node.callee);
         switch (true) {
           // Case 1: Direct call to 'render', e.g., from `import { render } from 'react-dom'`
-          case node.callee.type === AST.Identifier
-            && renderNames.has(node.callee.name):
+          case callee.type === AST.Identifier
+            && renderNames.has(callee.name):
             context.report({
               fix: getFix(context, node),
               messageId: "default",
@@ -57,11 +59,11 @@ export function create(context: RuleContext<MessageID, []>) {
             });
             return;
           // Case 2: Member expression call, e.g., `ReactDOM.render()`
-          case node.callee.type === AST.MemberExpression
-            && node.callee.object.type === AST.Identifier
-            && node.callee.property.type === AST.Identifier
-            && node.callee.property.name === "render"
-            && reactDomNames.has(node.callee.object.name):
+          case callee.type === AST.MemberExpression
+            && callee.object.type === AST.Identifier
+            && callee.property.type === AST.Identifier
+            && callee.property.name === "render"
+            && reactDomNames.has(callee.object.name):
             context.report({
               fix: getFix(context, node),
               messageId: "default",

--- a/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.spec.ts
@@ -146,6 +146,18 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    {
+      code: tsx`
+        import { useFormState } from "react-dom";
+        (useFormState as any)(action);
+      `,
+      errors: [{ messageId: "default" }],
+      output: tsx`
+        import { useActionState } from "react";
+        import { useFormState } from "react-dom";
+        (useActionState)(action);
+      `,
+    },
   ],
   valid: [
     tsx`

--- a/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
@@ -1,3 +1,4 @@
+import { Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleFixer, merge } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -46,10 +47,11 @@ export function create(context: RuleContext<MessageID, []>) {
     {
       // This visitor function is called for every function call in the code
       CallExpression(node) {
+        const callee = Extract.unwrap(node.callee);
         switch (true) {
           // Case 1: Direct call like `useFormState(...)`
-          case node.callee.type === AST.Identifier
-            && useFormStateNames.has(node.callee.name):
+          case callee.type === AST.Identifier
+            && useFormStateNames.has(callee.name):
             context.report({
               fix: getFix(context, node),
               messageId: "default",
@@ -57,11 +59,11 @@ export function create(context: RuleContext<MessageID, []>) {
             });
             return;
           // Case 2: Member call like `ReactDOM.useFormState(...)`
-          case node.callee.type === AST.MemberExpression
-            && node.callee.object.type === AST.Identifier
-            && node.callee.property.type === AST.Identifier
-            && node.callee.property.name === "useFormState"
-            && reactDomNames.has(node.callee.object.name):
+          case callee.type === AST.MemberExpression
+            && callee.object.type === AST.Identifier
+            && callee.property.type === AST.Identifier
+            && callee.property.name === "useFormState"
+            && reactDomNames.has(callee.object.name):
             context.report({
               fix: getFix(context, node),
               messageId: "default",

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.spec.ts
@@ -247,6 +247,14 @@ ruleTester.run(RULE_NAME, rule, {
       code: tsx`(foo.map as any)((bar, i) => <Foo key={i} />)`,
       errors: [{ messageId: "default" }],
     },
+    {
+      code: tsx`foo.map((value, index) => <Foo key={(index.toString as any)()} />)`,
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: tsx`foo.map((value, index) => <Foo key={(String as any)(index)} />)`,
+      errors: [{ messageId: "default" }],
+    },
   ],
   valid: [],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
@@ -1,3 +1,4 @@
+import { Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -76,20 +77,21 @@ export function create(context: RuleContext<MessageID, []>) {
       }
       // Case: key={index.toString()} or key={String(index)}
       case AST.CallExpression: {
+        const callee = Extract.unwrap(node.callee);
         switch (true) {
           // Case: key={index.toString()}
-          case node.callee.type === AST.MemberExpression
-            && node.callee.property.type === AST.Identifier
-            && node.callee.property.name === "toString"
-            && isArrayIndex(node.callee.object): {
+          case callee.type === AST.MemberExpression
+            && callee.property.type === AST.Identifier
+            && callee.property.name === "toString"
+            && isArrayIndex(callee.object): {
             return [{
               messageId: "default",
-              node: node.callee.object,
+              node: callee.object,
             }];
           }
           // Case: key={String(index)}
-          case node.callee.type === AST.Identifier
-            && node.callee.name === "String"
+          case callee.type === AST.Identifier
+            && callee.name === "String"
             && node.arguments[0] != null
             && isArrayIndex(node.arguments[0]): {
             return [{

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.spec.ts
@@ -193,6 +193,16 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    {
+      code: tsx`
+        const App = () => {
+          return (data.map as any)(x => <div key="dup" />);
+        };
+      `,
+      errors: [
+        { messageId: "default" },
+      ],
+    },
   ],
   valid: [
     tsx`

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
@@ -78,12 +78,13 @@ export function create(context: RuleContext<MessageID, []>) {
           default: {
             const call = Traverse.findParent(
               jsxElement,
-              (n): n is TSESTree.CallExpression => (
-                n.type === AST.CallExpression
-                && n.callee.type === AST.MemberExpression
-                && n.callee.property.type === AST.Identifier
-                && n.callee.property.name === "map"
-              ),
+              (n): n is TSESTree.CallExpression => {
+                if (n.type !== AST.CallExpression) return false;
+                const callee = Extract.unwrap(n.callee);
+                return callee.type === AST.MemberExpression
+                  && callee.property.type === AST.Identifier
+                  && callee.property.name === "map";
+              },
             );
             const iter = Traverse.findParent(jsxElement, (n) => n === call || Check.isFunction(n));
             if (!Check.isFunction(iter)) return;

--- a/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.spec.ts
@@ -601,6 +601,64 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    {
+      code: tsx`
+        import { forwardRef } from 'react'
+        const Component = (forwardRef as any)((props) => {
+          return null;
+        });
+      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import { forwardRef } from 'react'
+                const Component = ({ ref, ...props }) => {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
+      settings: {
+        "react-x": {
+          version: "19.0.0",
+        },
+      },
+    },
+    {
+      code: tsx`
+        import * as React from 'react'
+        const Component = (React.forwardRef as any)((props) => {
+          return null;
+        });
+      `,
+      errors: [
+        {
+          messageId: "default",
+          suggestions: [
+            {
+              messageId: "replace",
+              output: tsx`
+                import * as React from 'react'
+                const Component = ({ ref, ...props }) => {
+                  return null;
+                };
+              `,
+            },
+          ],
+        },
+      ],
+      settings: {
+        "react-x": {
+          version: "19.0.0",
+        },
+      },
+    },
   ],
   valid: [
     {

--- a/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
@@ -1,4 +1,4 @@
-import { Check, type TSESTreeFunction } from "@eslint-react/ast";
+import { Check, Extract, type TSESTreeFunction } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
@@ -84,12 +84,13 @@ function canFix(context: RuleContext, node: TSESTree.CallExpression) {
   const { importSource } = getSettingsFromContext(context);
   const initialScope = context.sourceCode.getScope(node);
   // Check if the callee is `forwardRef` or `React.forwardRef`
-  switch (node.callee.type) {
+  const callee = Extract.unwrap(node.callee);
+  switch (callee.type) {
     case AST.Identifier:
-      return core.isAPIFromReact(node.callee.name, initialScope, importSource);
+      return core.isAPIFromReact(callee.name, initialScope, importSource);
     case AST.MemberExpression:
-      return node.callee.object.type === AST.Identifier
-        && core.isAPIFromReact(node.callee.object.name, initialScope, importSource);
+      return callee.object.type === AST.Identifier
+        && core.isAPIFromReact(callee.object.name, initialScope, importSource);
     default:
       return false;
   }

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.spec.ts
@@ -210,6 +210,26 @@ ruleTester.run(RULE_NAME, rule, {
     //     { messageId: "default" },
     //   ],
     // },
+    {
+      code: tsx`
+        const App = () => {
+          return (data.map as any)(x => <App />);
+        };
+      `,
+      errors: [
+        { messageId: "default" },
+      ],
+    },
+    {
+      code: tsx`
+        const App = () => {
+          return (Array.from as any)(null, x => <App />);
+        };
+      `,
+      errors: [
+        { messageId: "default" },
+      ],
+    },
   ],
   valid: [
     "fn()",

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
@@ -1,4 +1,4 @@
-import { Check, is } from "@eslint-react/ast";
+import { Check, Extract, is } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { hasAttribute } from "@eslint-react/jsx";
@@ -91,9 +91,10 @@ export function create(context: RuleContext<MessageID, []>) {
       CallExpression(node) {
         inChildrenToArray ||= core.isChildrenToArrayCall(context, node);
         if (inChildrenToArray) return;
-        if (node.callee.type !== AST.MemberExpression) return;
-        if (node.callee.property.type !== AST.Identifier) return;
-        const name = node.callee.property.name;
+        const callee = Extract.unwrap(node.callee);
+        if (callee.type !== AST.MemberExpression) return;
+        if (callee.property.type !== AST.Identifier) return;
+        const name = callee.property.name;
         const idx = name === "from" ? 1 : name === "map" ? 0 : -1;
         if (idx < 0) return;
         const cb = node.arguments[idx];

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.spec.ts
@@ -216,6 +216,34 @@ ruleTester.run(RULE_NAME, rule, {
       }],
       options: [{ safeDefaultProps: ["Vector3"] }],
     },
+    {
+      code: tsx`
+        function Component({ items = (Array as any)(5).fill(0) }) {
+          return <div />;
+        }
+      `,
+      errors: [{
+        data: {
+          kind: "call expression",
+          propName: "items",
+        },
+        messageId: "default",
+      }],
+    },
+    {
+      code: tsx`
+        function Component({ items = new (Array as any)(5) }) {
+          return <div />;
+        }
+      `,
+      errors: [{
+        data: {
+          kind: "new expression",
+          propName: "items",
+        },
+        messageId: "default",
+      }],
+    },
   ],
   valid: [
     {
@@ -340,6 +368,14 @@ ruleTester.run(RULE_NAME, rule, {
     tsx`
       export default function NonComponent({ foo = {} }) {}
     `,
+    {
+      code: tsx`
+        function Component({ items = (Array as any)(5) }) {
+          return <div />;
+        }
+      `,
+      options: [{ safeDefaultProps: ["Array"] }],
+    },
     tsx`
       export function DrawerItem(props: Props) {
         const { colors, fonts } = useTheme();

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
@@ -61,13 +61,22 @@ export default createRule<Options, MessageID>({
 });
 
 function extractIdentifier(node: TSESTree.Node): string | null {
-  if (node.type === AST.NewExpression && node.callee.type === AST.Identifier) {
-    return node.callee.name;
+  if (node.type === AST.NewExpression) {
+    const callee = Extract.unwrap(node.callee);
+    if (callee.type === AST.Identifier) {
+      return callee.name;
+    }
   }
-  if (node.type === AST.CallExpression && node.callee.type === AST.MemberExpression) {
-    const { object } = node.callee;
-    if (object.type === AST.Identifier) {
-      return object.name;
+  if (node.type === AST.CallExpression) {
+    const callee = Extract.unwrap(node.callee);
+    if (callee.type === AST.Identifier) {
+      return callee.name;
+    }
+    if (callee.type === AST.MemberExpression) {
+      const { object } = callee;
+      if (object.type === AST.Identifier) {
+        return object.name;
+      }
     }
   }
   return null;

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/lib.ts
@@ -1,4 +1,4 @@
-import { Check } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import type { RuleContext } from "@eslint-react/eslint";
 import type { Scope } from "@typescript-eslint/scope-manager";
@@ -140,12 +140,13 @@ export function isHookDecl(node: TSESTree.Node): node is
   if (node.id.type !== AST.Identifier) return false;
   const init = node.init;
   if (init == null || init.type !== AST.CallExpression) return false;
-  switch (init.callee.type) {
+  const callee = Extract.unwrap(init.callee);
+  switch (callee.type) {
     case AST.Identifier:
-      return core.isHookName(init.callee.name);
+      return core.isHookName(callee.name);
     case AST.MemberExpression:
-      return init.callee.property.type === AST.Identifier
-        && core.isHookName(init.callee.property.name);
+      return callee.property.type === AST.Identifier
+        && core.isHookName(callee.property.name);
     default:
       return false;
   }

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
@@ -989,6 +989,51 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: "default" }],
     },
+    {
+      code: tsx`
+        function Component() {
+          const [count, setCount] = useState(0);
+          useEffect(() => {
+            (setCount as any)(1);
+          }, []);
+        }
+      `,
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: tsx`
+        function Component() {
+          const state = useState(0);
+          useEffect(() => {
+            (state.at(1) as any)(1);
+          }, []);
+        }
+      `,
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: tsx`
+        function Component() {
+          const [count, setCount] = (useState as any)(0);
+          useEffect(() => {
+            setCount(1);
+          }, []);
+        }
+      `,
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: tsx`
+        function Component() {
+          const [count, setCount] = useState(0);
+          const fn = () => setCount(1);
+          useEffect(() => {
+            (fn as any)();
+          }, []);
+        }
+      `,
+      errors: [{ messageId: "default" }],
+    },
   ],
   valid: [
     {

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -82,9 +82,10 @@ export function create(context: RuleContext<MessageID, []>) {
   };
 
   function isThenCall(node: TSESTree.CallExpression) {
-    return node.callee.type === AST.MemberExpression
-      && node.callee.property.type === AST.Identifier
-      && node.callee.property.name === "then";
+    const callee = Extract.unwrap(node.callee);
+    return callee.type === AST.MemberExpression
+      && callee.property.type === AST.Identifier
+      && callee.property.name === "then";
   }
 
   function isUseStateCall(node: TSESTree.Node) {
@@ -151,41 +152,42 @@ export function create(context: RuleContext<MessageID, []>) {
   }
 
   function isSetStateCall(node: TSESTree.CallExpression) {
-    switch (node.callee.type) {
+    const callee = Extract.unwrap(node.callee);
+    switch (callee.type) {
       // const data = useState();
       // data.at(1)();
       case AST.CallExpression: {
-        const { callee } = node.callee;
-        if (callee.type !== AST.MemberExpression) {
+        const innerCallee = Extract.unwrap(callee.callee);
+        if (innerCallee.type !== AST.MemberExpression) {
           return false;
         }
-        if (!("name" in callee.object)) {
+        if (!("name" in innerCallee.object)) {
           return false;
         }
-        const isAt = callee.property.type === AST.Identifier && callee.property.name === "at";
-        const [index] = node.callee.arguments;
+        const isAt = innerCallee.property.type === AST.Identifier && innerCallee.property.name === "at";
+        const [index] = callee.arguments;
         if (!isAt || index == null) {
           return false;
         }
         const indexScope = context.sourceCode.getScope(node);
         const indexValue = getStaticValue(index, indexScope)?.value;
-        return indexValue === 1 && isIdFromUseStateCall(callee.object);
+        return indexValue === 1 && isIdFromUseStateCall(innerCallee.object);
       }
       // const [data, setData] = useState();
       // setData();
       case AST.Identifier: {
-        return isIdFromUseStateCall(node.callee, 1);
+        return isIdFromUseStateCall(callee, 1);
       }
       // const data = useState();
       // data[1]();
       case AST.MemberExpression: {
-        if (!("name" in node.callee.object)) {
+        if (!("name" in callee.object)) {
           return false;
         }
-        const property = node.callee.property;
+        const property = callee.property;
         const propertyScope = context.sourceCode.getScope(node);
         const propertyValue = getStaticValue(property, propertyScope)?.value;
-        return propertyValue === 1 && isIdFromUseStateCall(node.callee.object, 1);
+        return propertyValue === 1 && isIdFromUseStateCall(callee.object, 1);
       }
       default: {
         return false;
@@ -267,7 +269,7 @@ export function create(context: RuleContext<MessageID, []>) {
                 if (isRefGatedContext(context, node)) return;
                 context.report({
                   data: {
-                    name: context.sourceCode.getText(node.callee),
+                    name: context.sourceCode.getText(Extract.unwrap(node.callee)),
                   },
                   messageId: "default",
                   node,
@@ -367,10 +369,11 @@ export function create(context: RuleContext<MessageID, []>) {
           }
         }
         for (const { callee } of trackedFnCalls) {
-          if (!("name" in callee)) {
+          const unwrappedCallee = Extract.unwrap(callee);
+          if (unwrappedCallee.type !== AST.Identifier) {
             continue;
           }
-          const setStateCalls = getSetStateCalls(context, callee);
+          const setStateCalls = getSetStateCalls(context, unwrappedCallee);
           for (const setStateCall of setStateCalls) {
             if (isRefGatedContext(context, getSetStateCallExpression(setStateCall))) continue;
             context.report({

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.spec.ts
@@ -293,6 +293,16 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ data: { name: "setState" }, messageId: "default" }],
     },
+    {
+      code: tsx`
+        function Component(props) {
+          const [state, setState] = useState(false);
+          (setState as any)(true);
+          return state;
+        }
+      `,
+      errors: [{ data: { name: "setState" }, messageId: "default" }],
+    },
   ],
   valid: [
     {

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
@@ -1,4 +1,4 @@
-import { Check, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
+import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
@@ -67,41 +67,42 @@ export function create(context: RuleContext<MessageID, []>) {
   }
 
   function isSetStateCall(node: TSESTree.CallExpression) {
-    switch (node.callee.type) {
+    const callee = Extract.unwrap(node.callee);
+    switch (callee.type) {
       // const data = useState();
       // data.at(1)();
       case AST.CallExpression: {
-        const { callee } = node.callee;
-        if (callee.type !== AST.MemberExpression) {
+        const innerCallee = Extract.unwrap(callee.callee);
+        if (innerCallee.type !== AST.MemberExpression) {
           return false;
         }
-        if (!("name" in callee.object)) {
+        if (!("name" in innerCallee.object)) {
           return false;
         }
-        const isAt = callee.property.type === AST.Identifier && callee.property.name === "at";
-        const [index] = node.callee.arguments;
+        const isAt = innerCallee.property.type === AST.Identifier && innerCallee.property.name === "at";
+        const [index] = callee.arguments;
         if (!isAt || index == null) {
           return false;
         }
         const indexScope = context.sourceCode.getScope(node);
         const indexValue = getStaticValue(index, indexScope)?.value;
-        return indexValue === 1 && isIdFromUseStateCall(callee.object);
+        return indexValue === 1 && isIdFromUseStateCall(innerCallee.object);
       }
       // const [data, setData] = useState();
       // setData();
       case AST.Identifier: {
-        return isIdFromUseStateCall(node.callee, 1);
+        return isIdFromUseStateCall(callee, 1);
       }
       // const data = useState();
       // data[1]();
       case AST.MemberExpression: {
-        if (!("name" in node.callee.object)) {
+        if (!("name" in callee.object)) {
           return false;
         }
-        const property = node.callee.property;
+        const property = callee.property;
         const propertyScope = context.sourceCode.getScope(node);
         const propertyValue = getStaticValue(property, propertyScope)?.value;
-        return propertyValue === 1 && isIdFromUseStateCall(node.callee.object, 1);
+        return propertyValue === 1 && isIdFromUseStateCall(callee.object, 1);
       }
       default: {
         return false;
@@ -150,7 +151,7 @@ export function create(context: RuleContext<MessageID, []>) {
         if (componentHasEarlyReturn.current) return;
         context.report({
           data: {
-            name: context.sourceCode.getText(node.callee),
+            name: context.sourceCode.getText(Extract.unwrap(node.callee)),
           },
           messageId: "default",
           node,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1092,6 +1092,9 @@ importers:
 
   plugins/eslint-plugin-react-dom:
     dependencies:
+      '@eslint-react/ast':
+        specifier: workspace:*
+        version: link:../../packages/ast
       '@eslint-react/eslint':
         specifier: workspace:*
         version: link:../../packages/eslint


### PR DESCRIPTION
  Use `Extract.unwrap` from `@eslint-react/ast` to strip TS type assertion
  and chain expression wrappers before checking `node.type`, `callee.type`,
  etc. This fixes silent failures when code uses:

  - TSAsExpression: `(foo as any)()`
  - TSSatisfiesExpression: `(foo satisfies T)()`
  - TSNonNullExpression: `foo!()`
  - TSInstantiationExpression: `foo<T>()`
  - ChainExpression: `(foo?.bar)()

  Affected packages:
  - @eslint-react/core (class-component, function-component, function)
  - @eslint-react/jsx (is-jsx-like)
  - @eslint-react/var (compute-object-type, resolve-import-source, get-require-expression-arguments)
  - eslint-plugin-react-dom (no-hydrate, no-render, no-render-return-value, no-use-form-state)
  - eslint-plugin-react-x (no-array-index-key, no-duplicate-key, no-forward-ref, no-missing-key, no-unstable-default-props, set-state-in-effect, set-state-in-render)

  Also adds:
  - New test cases covering wrapped callee scenarios
  - docs/ast-extract-unwrap-usage.md with usage guidelines

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
