### PR TITLE
fix(plugins/eslint-plugin-react-x): use reference/definition analysis…

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/lib.ts
@@ -1,6 +1,7 @@
 import { Check, Traverse } from "@eslint-react/ast";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
+import type { Scope } from "@typescript-eslint/utils/ts-eslint";
 
 export function isInsideNestedFunction(
   node: TSESTree.Node,
@@ -10,6 +11,15 @@ export function isInsideNestedFunction(
   while (current && current !== boundary) {
     if (Check.isFunction(current)) return true;
     current = current.parent;
+  }
+  return false;
+}
+
+export function isDeclaredInsideCallback(variable: Scope.Variable, callback: TSESTree.FunctionLike): boolean {
+  let scope: Scope.Scope | null = variable.scope;
+  while (scope != null) {
+    if (scope.block === callback) return true;
+    scope = scope.upper;
   }
   return false;
 }

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
@@ -794,5 +794,79 @@ ruleTester.run(RULE_NAME, rule, {
         return <div>{value}</div>;
       }
     `,
+    // Rule 3 valid: Reassigning block-scoped variable inside for…of loop (issue #1734)
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ columns }) {
+        const widths = useMemo(() => {
+          const result = [];
+          for (const column of columns) {
+            let width = column.defaultWidth;
+            if (typeof width === "number") {
+              width = Math.min(width, column.maxWidth);
+            } else {
+              width = column.minWidth;
+            }
+            result.push(width);
+          }
+          return result;
+        }, [columns]);
+        return <div>{widths.join(", ")}</div>;
+      }
+    `,
+    // Rule 3 valid: Reassigning block-scoped variable inside for loop
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ items }) {
+        const sum = useMemo(() => {
+          let total = 0;
+          for (let i = 0; i < items.length; i++) {
+            let value = items[i];
+            value = value * 2;
+            total += value;
+          }
+          return total;
+        }, [items]);
+        return <div>{sum}</div>;
+      }
+    `,
+    // Rule 3 valid: Reassigning block-scoped variable inside if block
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ flag, a, b }) {
+        const value = useMemo(() => {
+          if (flag) {
+            let temp = a;
+            temp = temp + 1;
+            return temp;
+          }
+          return b;
+        }, [flag, a, b]);
+        return <div>{value}</div>;
+      }
+    `,
+    // Rule 3 valid: Reassigning block-scoped variable inside switch case
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ type, value }) {
+        const result = useMemo(() => {
+          switch (type) {
+            case "number": {
+              let n = value;
+              n = n * 2;
+              return n;
+            }
+            default: {
+              return value;
+            }
+          }
+        }, [type, value]);
+        return <div>{result}</div>;
+      }
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
@@ -4,8 +4,9 @@ import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
+import { findVariable } from "@typescript-eslint/utils/ast-utils";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
-import { getNestedReturnStatements, isInsideNestedFunction } from "./lib";
+import { getNestedReturnStatements, isDeclaredInsideCallback, isInsideNestedFunction } from "./lib";
 
 export const RULE_NAME = "use-memo";
 
@@ -48,8 +49,6 @@ export function create(context: RuleContext<MessageID, []>) {
 
   function validateNoOuterVariableReassignment(callback: TSESTree.FunctionLike): ReportDescriptor<MessageID>[] {
     const violations: ReportDescriptor<MessageID>[] = [];
-    const callbackScope = context.sourceCode.getScope(callback);
-    const localVars = new Set(callbackScope.variables.map((v) => v.name));
     if (callback.body == null) return violations;
     simpleTraverse(callback.body, {
       enter(node) {
@@ -58,8 +57,14 @@ export function create(context: RuleContext<MessageID, []>) {
         // Only flag direct variable reassignment (x = …), not property mutations (ref.current = …)
         // to match React Compiler's StoreContext semantics.
         if (left.type !== AST.Identifier) return;
-        if (localVars.has(left.name)) return;
         if (isInsideNestedFunction(node, callback)) return;
+
+        const scope = context.sourceCode.getScope(left);
+        const variable = findVariable(scope, left);
+        if (variable != null && variable.defs.length > 0 && isDeclaredInsideCallback(variable, callback)) {
+          return;
+        }
+
         violations.push({
           messageId: "noReassigningOuterVariables",
           node: left,


### PR DESCRIPTION
… for noReassigningOuterVariables in use-memo rule

Fixes false positives when block-scoped variables (let/const) declared inside loops or conditionals within useMemo callbacks were incorrectly flagged as outer variable reassignments.

Closes #1734

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
