### PR TITLE
feat(no-unused-class-component-members): flag shouldComponentUpdate i…

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
@@ -25,6 +25,8 @@ react-x/no-unused-class-component-members
 
 This rule warns about class component methods and properties that are defined but never used. Removing unused members helps keep the codebase clean and reduces confusion.
 
+Note that `shouldComponentUpdate` is considered unused when defined in a class extending `PureComponent`, since `PureComponent` implements its own `shouldComponentUpdate` with shallow prop and state comparison.
+
 ## Common Violations
 
 ### Invalid

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.spec.ts
@@ -356,6 +356,42 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    {
+      code: tsx`
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+          render() {
+            return null;
+          }
+        }
+      `,
+      errors: [
+        {
+          data: { className: "Foo", methodName: "shouldComponentUpdate" },
+          messageId: "default",
+        },
+      ],
+    },
+    {
+      code: tsx`
+        class Foo extends PureComponent {
+          shouldComponentUpdate = () => {
+            return true;
+          }
+          render() {
+            return null;
+          }
+        }
+      `,
+      errors: [
+        {
+          data: { className: "Foo", methodName: "shouldComponentUpdate" },
+          messageId: "default",
+        },
+      ],
+    },
   ],
   valid: [
     tsx`

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
@@ -66,9 +66,18 @@ export function create(context: RuleContext<MessageID, []>) {
       if (methodName == null) {
         continue;
       }
-      // If a member is used or is a lifecycle method, skip it
-      if (((usages?.has(methodName)) ?? false) || LIFECYCLE_METHODS.has(methodName)) {
+      // If a member is used, skip it
+      if (usages?.has(methodName) ?? false) {
         continue;
+      }
+      // If a member is a lifecycle method, skip it
+      // except for shouldComponentUpdate in PureComponent, which is implicitly unused
+      if (LIFECYCLE_METHODS.has(methodName)) {
+        if (methodName === "shouldComponentUpdate" && core.isPureComponent(currentClass)) {
+          // shouldComponentUpdate is unused in PureComponent
+        } else {
+          continue;
+        }
       }
       // Report members that are defined but not used
       context.report({


### PR DESCRIPTION
…n PureComponent as unused

When a class extends PureComponent, defining shouldComponentUpdate is redundant since PureComponent already provides its own implementation with shallow prop and state comparison. This change treats shouldComponentUpdate as an unused member in PureComponent subclasses.

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [x] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
