### PR TITLE
fix(rules/immutability): exempt ref mutations via naming heuristic an…

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/immutability/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `noRefLikeStateName` diagnostic to prevent state variables from being named `ref` or ending with `Ref`, which would otherwise bypass the ref exemption heuristic.
+- Added ref mutation exemption via a naming heuristic: any object whose identifier is `ref` or ends with `Ref` is treated as a mutable ref and skipped from immutability checks. This covers both local refs and refs received as props (e.g., `inputRef.current = x`, `props.myRef.current.push(1)`).
+
+### Changed
+
+- `isUseReducerCall` detection now delegates to `core.isUseReducerCall` instead of a local implementation.
+
+### Fixed
+
+- Fixed false positives when mutating `RefObject<T>` values received as props. Closes #1751. (#1751)
+
 ## [5.5.3-beta.1] - 2026-04-27
 
 ### Added

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
@@ -292,6 +292,22 @@ function Component() {
 }
 ```
 
+## Options
+
+### Shared Settings
+
+Custom state hooks can also be configured via shared ESLint settings, which apply consistently across all rules in the plugin:
+
+```json
+{
+  "settings": {
+    "react-x": {
+      "additionalStateHooks": "/^(useMyState|useCustomState)$/u",
+    }
+  }
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts)

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.diff.md
@@ -40,7 +40,7 @@ State identification uses an explicit `isStateValue()` helper tracing identifier
 
 ## 4. Exception Handling
 
-- **Ref mutations**: The SPEC explicitly allows them via `isRefOrRefLikeMutableType`. The IMPL does not explicitly track refs; they are treated as regular variables unless they happen to match state/props heuristics.
+- **Ref mutations**: The SPEC explicitly allows them via `isRefOrRefLikeMutableType`. The IMPL exempts refs via a naming heuristic (`hasRefLikeNameInChain()`): any object whose identifier is `ref` or ends with `Ref` is treated as a ref and skipped. This covers `ref.current = x`, `myRef.current.push(1)`, and `props.myRef.current = x`.
 - **Immer / Draft**: The SPEC does not mention this. The IMPL explicitly excludes any mutation whose root identifier is named `draft`.
 - **Event handler parameters**: The SPEC naturally excludes them because event handlers are not component context. The IMPL explicitly excludes them via `propsDefiningFunc` verification: the parameter's defining function must itself be a component or hook.
 - **Nested function mutations**: The SPEC covers them naturally via `fn.context`. The IMPL traces references through nested closures back to the original parameter/state declaration.
@@ -61,6 +61,7 @@ There is no direct one-to-one mapping because the rules address fundamentally di
 
 - `mutatingArrayMethod` — **No SPEC equivalent.** The SPEC does not flag array mutations directly; it flags the function containing them when frozen.
 - `mutatingAssignment` — **No SPEC equivalent.** The SPEC flags `StoreContext` on captured variables inside functions, not direct property assignments on state/props.
+- `noRefLikeStateName` — **No SPEC equivalent.** The SPEC has no naming-convention checks. This is an IMPL-only diagnostic that prevents state variables from `useState`, `useReducer`, or `additionalStateHooks`-configured custom hooks from being named `ref` or ending with `Ref`, which would otherwise bypass the naming-heuristic ref exemption.
 
 SPEC error descriptions:
 
@@ -107,5 +108,7 @@ Examples that are **valid** under the IMPL but may be caught by the compiler's b
 8. **Additional IMPL Capabilities** (not in SPEC):
    - Explicit Immer support via `draft` variable exclusion
    - Explicit event handler parameter exclusion
+   - Explicit ref mutation exemption via naming heuristic (`ref` or `*Ref`)
    - Granular array method allow-list (`MUTATING_ARRAY_METHODS`)
    - Support for `useReducer` state identification
+   - Support for custom state hooks via shared settings (`additionalStateHooks`)

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.ts
@@ -6,6 +6,51 @@ import rule, { RULE_NAME } from "./immutability";
 ruleTester.run(RULE_NAME, rule, {
   invalid: [
     // -------------------------------------------------------------------------
+    // State variables named ref or ending with Ref
+    // -------------------------------------------------------------------------
+    {
+      code: tsx`
+        import { useState } from "react";
+
+        function Component() {
+          const [ref, setRef] = useState(0);
+          return <div>{ref}</div>;
+        }
+      `,
+      errors: [{
+        data: { name: "ref" },
+        messageId: "noRefLikeStateName",
+      }],
+    },
+    {
+      code: tsx`
+        import { useState } from "react";
+
+        function Component() {
+          const [itemsRef, setItemsRef] = useState([1, 2, 3]);
+          return <div>{itemsRef.length}</div>;
+        }
+      `,
+      errors: [{
+        data: { name: "itemsRef" },
+        messageId: "noRefLikeStateName",
+      }],
+    },
+    {
+      code: tsx`
+        import { useReducer } from "react";
+
+        function Component() {
+          const [stateRef, dispatch] = useReducer(reducer, {});
+          return <div>{stateRef}</div>;
+        }
+      `,
+      errors: [{
+        data: { name: "stateRef" },
+        messageId: "noRefLikeStateName",
+      }],
+    },
+    // -------------------------------------------------------------------------
     // Mutating array methods on state
     // -------------------------------------------------------------------------
     {
@@ -1425,6 +1470,73 @@ ruleTester.run(RULE_NAME, rule, {
               Click
             </button>
           );
+        }
+      `,
+    },
+    // -------------------------------------------------------------------------
+    // Ref mutations are allowed (refs are mutable by design)
+    // The rule uses a naming heuristic: any object named `ref` or ending in
+    // `Ref` is treated as a ref and exempted from immutability checks.
+    // -------------------------------------------------------------------------
+    {
+      code: tsx`
+        function Component() {
+          const ref = { current: null };
+          ref.current = 1;
+          return <div>{ref.current}</div>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+          const ref = { current: { count: 0 } };
+          ref.current.count = 1;
+          return <div>{ref.current.count}</div>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+          const ref = { current: [1, 2, 3] };
+          ref.current.push(4);
+          ref.current.sort();
+          return <div>{ref.current.length}</div>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+          const inputRef = { current: null };
+          inputRef.current = "value";
+          return <div>{inputRef.current}</div>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function useMyHook() {
+          const counterRef = { current: 0 };
+          counterRef.current += 1;
+          return counterRef.current;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component(props) {
+          props.myRef.current = 1;
+          return <div>{props.myRef.current}</div>;
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component(props) {
+          props.itemsRef.push(4);
+          return <div>{props.itemsRef.length}</div>;
         }
       `,
     },

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
@@ -7,7 +7,7 @@ import { resolve } from "@eslint-react/var";
 import { DefinitionType } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
-import { MUTATING_ARRAY_METHODS } from "./lib";
+import { MUTATING_ARRAY_METHODS, hasRefLikeNameInChain, identifierExistsInPattern, isRefLikeName } from "./lib";
 
 export const RULE_NAME = "immutability";
 
@@ -17,7 +17,8 @@ export const RULE_FEATURES = [
 
 export type MessageID =
   | "mutatingArrayMethod"
-  | "mutatingAssignment";
+  | "mutatingAssignment"
+  | "noRefLikeStateName";
 
 export default createRule<[], MessageID>({
   meta: {
@@ -30,6 +31,8 @@ export default createRule<[], MessageID>({
         "Do not call '{{method}}()' on '{{name}}'. Props and state are immutable — create a new array instead.",
       mutatingAssignment:
         "Do not mutate '{{name}}' directly. Props and state are immutable — create a new object instead.",
+      noRefLikeStateName:
+        "State variable '{{name}}' should not be named 'ref' or end with 'Ref'. Use a different name to avoid confusion with mutable refs.",
     },
     schema: [],
   },
@@ -69,18 +72,6 @@ export function create(context: RuleContext<MessageID, []>) {
     return core.isUseStateLikeCall(node, additionalStateHooks);
   }
 
-  function isUseReducerCall(node: TSESTree.CallExpression): boolean {
-    const callee = Extract.unwrap(node.callee);
-    if (callee.type === AST.Identifier) return callee.name === "useReducer";
-    if (callee.type === AST.MemberExpression) {
-      const root = Extract.getRootIdentifier(callee);
-      if (root?.name === "React") {
-        return Extract.getPropertyName(callee.property) === "useReducer";
-      }
-    }
-    return false;
-  }
-
   /**
    * Return true when `id` is the *value* variable (index 0) produced by a
    * `useState(…)` or `useReducer(…)` call.
@@ -91,7 +82,7 @@ export function create(context: RuleContext<MessageID, []>) {
     const initNode = resolve(context, id);
 
     if (initNode == null || initNode.type !== AST.CallExpression) return false;
-    if (!isUseStateCall(initNode) && !isUseReducerCall(initNode)) return false;
+    if (!isUseStateCall(initNode) && !core.isUseReducerCall(context, initNode)) return false;
 
     // If the result is not destructured into an array, the entire
     // result is a state container — treat it as a state value.
@@ -106,36 +97,6 @@ export function create(context: RuleContext<MessageID, []>) {
       (el) => el?.type === AST.Identifier && el.name === id.name,
     );
     return idx === 0;
-  }
-
-  /**
-   * Check if `name` appears anywhere inside a parameter pattern.
-   * @param pattern - The parameter pattern to search in.
-   * @param name - The identifier name to look for.
-   */
-  function identifierExistsInPattern(pattern: TSESTree.Node, name: string): boolean {
-    switch (pattern.type) {
-      case AST.Identifier:
-        return pattern.name === name;
-      case AST.ObjectPattern:
-        return pattern.properties.some((p) => {
-          if (p.type === AST.Property) return identifierExistsInPattern(p.value, name);
-          if (p.type === AST.RestElement) return identifierExistsInPattern(p.argument, name);
-          return false;
-        });
-      case AST.ArrayPattern:
-        return pattern.elements.some((el) => el != null && identifierExistsInPattern(el, name));
-      case AST.RestElement:
-        return identifierExistsInPattern(pattern.argument, name);
-      case AST.AssignmentPattern:
-        return identifierExistsInPattern(pattern.left, name);
-      case AST.MemberExpression: {
-        const root = Extract.getRootIdentifier(pattern);
-        return root?.name === name;
-      }
-      default:
-        return false;
-    }
   }
 
   /**
@@ -200,6 +161,21 @@ export function create(context: RuleContext<MessageID, []>) {
        * @param node The CallExpression node to analyze.
        */
       CallExpression(node: TSESTree.CallExpression) {
+        // Detect useState/useReducer state variables named ref or *Ref
+        if (isUseStateCall(node) || core.isUseReducerCall(context, node)) {
+          const declarator = node.parent;
+          if (declarator?.type === AST.VariableDeclarator && declarator.id?.type === AST.ArrayPattern) {
+            const [firstElement] = declarator.id.elements;
+            if (firstElement?.type === AST.Identifier && isRefLikeName(firstElement.name)) {
+              context.report({
+                data: { name: firstElement.name },
+                messageId: "noRefLikeStateName",
+                node: firstElement,
+              });
+            }
+          }
+        }
+
         const callee = Extract.unwrap(node.callee);
         if (callee.type !== AST.MemberExpression) return;
         const { object, property } = callee;
@@ -210,6 +186,7 @@ export function create(context: RuleContext<MessageID, []>) {
         const rootId = Extract.getRootIdentifier(object);
         if (rootId == null) return;
         if (rootId.name === "draft") return;
+        if (hasRefLikeNameInChain(object)) return;
 
         const enclosingFn = Traverse.findParent(node, Check.isFunction);
         if (enclosingFn == null) return;
@@ -244,6 +221,7 @@ export function create(context: RuleContext<MessageID, []>) {
         const rootId = Extract.getRootIdentifier(node.left);
         if (rootId == null) return;
         if (rootId.name === "draft") return;
+        if (hasRefLikeNameInChain(node.left.object)) return;
 
         const enclosingFn = Traverse.findParent(node, Check.isFunction);
         if (enclosingFn == null) return;

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/lib.ts
@@ -1,3 +1,6 @@
+import { Extract } from "@eslint-react/ast";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
+
 /**
  * Array methods that mutate the array in place.
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
@@ -13,3 +16,57 @@ export const MUTATING_ARRAY_METHODS = new Set([
   "splice",
   "unshift",
 ]);
+
+/**
+ * Check if a name is ref-like ("ref" or ends with "Ref").
+ * Refs are mutable by design and exempted from immutability checks.
+ */
+export function isRefLikeName(name: string): boolean {
+  return name === "ref" || name.endsWith("Ref");
+}
+
+/**
+ * Check if any identifier or property name in a member-expression chain
+ * is ref-like.
+ */
+export function hasRefLikeNameInChain(node: TSESTree.Node): boolean {
+  if (node.type === AST.Identifier) {
+    return isRefLikeName(node.name);
+  }
+  if (node.type === AST.MemberExpression) {
+    const propName = Extract.getPropertyName(node.property);
+    if (propName != null && isRefLikeName(propName)) return true;
+    return hasRefLikeNameInChain(node.object);
+  }
+  return false;
+}
+
+/**
+ * Check if `name` appears anywhere inside a parameter pattern.
+ * @param pattern - The parameter pattern to search in.
+ * @param name - The identifier name to look for.
+ */
+export function identifierExistsInPattern(pattern: TSESTree.Node, name: string): boolean {
+  switch (pattern.type) {
+    case AST.Identifier:
+      return pattern.name === name;
+    case AST.ObjectPattern:
+      return pattern.properties.some((p) => {
+        if (p.type === AST.Property) return identifierExistsInPattern(p.value, name);
+        if (p.type === AST.RestElement) return identifierExistsInPattern(p.argument, name);
+        return false;
+      });
+    case AST.ArrayPattern:
+      return pattern.elements.some((el) => el != null && identifierExistsInPattern(el, name));
+    case AST.RestElement:
+      return identifierExistsInPattern(pattern.argument, name);
+    case AST.AssignmentPattern:
+      return identifierExistsInPattern(pattern.left, name);
+    case AST.MemberExpression: {
+      const root = Extract.getRootIdentifier(pattern);
+      return root?.name === name;
+    }
+    default:
+      return false;
+  }
+}

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
@@ -81,14 +81,7 @@ export function create(context: RuleContext<MessageID, []>) {
           : callee.type === AST.MemberExpression
           ? Extract.getPropertyName(callee.property)
           : null;
-        if (
-          calleeName != null && (
-            calleeName.startsWith("use")
-            || calleeName === "mergeRefs"
-          )
-        ) {
-          return;
-        }
+        if (calleeName != null && (calleeName.startsWith("use") || calleeName === "mergeRefs")) return;
         for (const arg of node.arguments) {
           const unwrapped = Extract.unwrap(arg);
           if (unwrapped.type !== AST.Identifier) continue;


### PR DESCRIPTION
…d add noRefLikeStateName diagnostic

- Exempt mutations on objects named 'ref' or ending with 'Ref' from immutability checks to fix false positives on RefObject<T> props.
- Add 'noRefLikeStateName' diagnostic to prevent state variables from using ref-like names, which would otherwise bypass the exemption.
- Delegate isUseReducerCall to core.isUseReducerCall.
- Move identifierExistsInPattern to shared lib.ts.
- Update docs and CHANGELOG.

Closes #1751

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
