### PR TITLE
docs: fix links to rule docs for jsx and rsc plugins

### DIFF
--- a/plugins/eslint-plugin-react-jsx/src/utils/create-rule.ts
+++ b/plugins/eslint-plugin-react-jsx/src/utils/create-rule.ts
@@ -1,7 +1,7 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 
 function getDocsUrl(ruleName: string) {
-  return `https://eslint-react.xyz/docs/rules/${ruleName}`;
+  return `https://eslint-react.xyz/docs/rules/jsx-${ruleName}`;
 }
 
 export const createRule = ESLintUtils.RuleCreator(getDocsUrl);

--- a/plugins/eslint-plugin-react-rsc/src/utils/create-rule.ts
+++ b/plugins/eslint-plugin-react-rsc/src/utils/create-rule.ts
@@ -1,7 +1,7 @@
 import { ESLintUtils } from "@typescript-eslint/utils";
 
 function getDocsUrl(ruleName: string) {
-  return `https://eslint-react.xyz/docs/rules/${ruleName}`;
+  return `https://eslint-react.xyz/docs/rules/rsc-${ruleName}`;
 }
 
 export const createRule = ESLintUtils.RuleCreator(getDocsUrl);


### PR DESCRIPTION
Added missing rule docs prefixes for `jsx` and `rsc` plugins, previously the links led to the 404 page for these plugins

---

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
