### PR TITLE
fix(rules/no-missing-key): unwrap conditional/logical in block-bodied returns

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `no-missing-key` not detecting `ConditionalExpression`/`LogicalExpression` returned from block-bodied `.map`/`Array.from` callbacks. Closes #1766.
+- `no-missing-key` now reports both branches of a `ConditionalExpression`/`LogicalExpression` when both lack a `key`, instead of only the first.
+
 ## [5.2.3-beta.0] - 2026-04-14
 
 ### Changed

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.spec.ts
@@ -42,6 +42,26 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: "default" }],
     },
     {
+      code: tsx`[1, 2 ,3].map(x => { return x && <App x={x} /> });`,
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: '[1, 2 ,3].map(x => { return x ? <App x={x} key="1" /> : <OtherApp x={x} /> });',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: '[1, 2 ,3].map(x => { return x ? <App x={x} /> : <OtherApp x={x} key="2" /> });',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: tsx`[1, 2 ,3].map(x => { return x ? <App /> : <OtherApp /> });`,
+      errors: [{ messageId: "default" }, { messageId: "default" }],
+    },
+    {
+      code: tsx`[1, 2 ,3].map(x => x ? <App /> : <OtherApp />);`,
+      errors: [{ messageId: "default" }, { messageId: "default" }],
+    },
+    {
       code: tsx`Array.from([1, 2 ,3], function(x) { return <App /> });`,
       errors: [{ messageId: "default" }],
     },
@@ -241,6 +261,8 @@ ruleTester.run(RULE_NAME, rule, {
     "[1, 2 ,3].map(x => x && <App x={x} key={x} />);",
     '[1, 2 ,3].map(x => x ? <App x={x} key="1" /> : <OtherApp x={x} key="2" />);',
     "[1, 2, 3].map(x => { return <App key={x} /> });",
+    "[1, 2 ,3].map(x => { return x && <App x={x} key={x} /> });",
+    '[1, 2 ,3].map(x => { return x ? <App x={x} key="1" /> : <OtherApp x={x} key="2" /> });',
     "Array.from([1, 2, 3], function(x) { return <App key={x} /> });",
     "Array.from([1, 2, 3], (x => <App key={x} />));",
     "Array.from([1, 2, 3], (x => {return <App key={x} />}));",

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
@@ -49,17 +49,19 @@ export function create(context: RuleContext<MessageID, []>) {
     return null;
   }
 
-  function checkExpr(node: TSESTree.Expression): Descriptor | null {
+  function checkExpr(node: TSESTree.Expression): Descriptor[] {
     switch (node.type) {
       case AST.ConditionalExpression:
-        return check(node.consequent) ?? check(node.alternate);
+        return [...checkExpr(node.consequent), ...checkExpr(node.alternate)];
       case AST.LogicalExpression:
-        return check(node.left) ?? check(node.right);
+        return [...checkExpr(node.left), ...checkExpr(node.right)];
       case AST.JSXElement:
-      case AST.JSXFragment:
-        return check(node);
+      case AST.JSXFragment: {
+        const desc = check(node);
+        return desc == null ? [] : [desc];
+      }
       default:
-        return null;
+        return [];
     }
   }
 
@@ -67,9 +69,7 @@ export function create(context: RuleContext<MessageID, []>) {
     const descriptors: Descriptor[] = [];
     for (const stmt of getNestedReturnStatements(node)) {
       if (stmt.argument == null) continue;
-      const desc = check(stmt.argument);
-      if (desc == null) continue;
-      descriptors.push(desc);
+      descriptors.push(...checkExpr(stmt.argument));
     }
     return descriptors;
   }
@@ -100,7 +100,7 @@ export function create(context: RuleContext<MessageID, []>) {
         if (cb.body.type === AST.BlockStatement) {
           checkBlock(cb.body).forEach(report(context));
         } else {
-          report(context)(checkExpr(cb.body));
+          checkExpr(cb.body).forEach(report(context));
         }
       },
       "CallExpression:exit"(node) {


### PR DESCRIPTION
## Summary

- Fixes #1766: `no-missing-key` was silently ignoring `ConditionalExpression`/`LogicalExpression` returned from block-bodied `.map`/`Array.from` callbacks. `checkBlock` called `check` directly (which only matches `JSXElement`/`JSXFragment`); now it routes through `checkExpr`, matching the concise-body path.
- `checkExpr` now returns `Descriptor[]` instead of short-circuiting with `??`. When both branches of a ternary lack `key`, both are now reported — matching `eslint-plugin-react`'s `jsx-key` behavior. (Recursing into nested ternaries/logicals is a small bonus over upstream, which only unwraps one level.)

### Before / after

```jsx
// Was a false negative — now reported
items.map((x) => {
  return cond ? <div /> : <span />;
});

items.map((x) => {
  return cond && <div />;
});

// Was 1 error — now correctly 2 (both branches lack key)
items.map((x) => (cond ? <div /> : <span />));
```

## Test plan

- [x] Added 6 invalid + 2 valid cases to `no-missing-key.spec.ts` covering block-bodied conditional/logical returns and the both-branches-missing case.
- [x] `pnpm vitest run plugins/eslint-plugin-react-x` — all 1943 tests pass.
- [x] `tsc --noEmit` clean.