### PR TITLE
feat(eslint-plugin-react-jsx): support createElement in no-children-prop and no-children-prop-with-children rules

### DIFF
--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/lib.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/lib.ts
@@ -1,6 +1,68 @@
+import { Extract } from "@eslint-react/ast";
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/eslint";
-import type { TSESTree } from "@typescript-eslint/types";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
+
+// ---------------------------------------------------------------------------
+// Object property helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a `children` property inside an ObjectExpression.
+ * @param node The object expression.
+ * @returns The Property node whose key is "children", or null.
+ */
+export function findChildrenProperty(node: TSESTree.ObjectExpression): TSESTree.Property | null {
+  for (const prop of node.properties) {
+    if (prop.type !== AST.Property) continue;
+    const key = Extract.unwrap(prop.key);
+    if (key.type === AST.Identifier && key.name === "children") return prop;
+    if (key.type === AST.Literal && key.value === "children") return prop;
+  }
+  return null;
+}
+
+/**
+ * Compute the removal range for an ObjectExpression property, consuming any
+ * leading or trailing comma and whitespace so the resulting object stays clean.
+ * @param context The rule context.
+ * @param prop The property to remove.
+ * @param parent The parent ObjectExpression.
+ */
+export function getObjectPropertyRemovalRange(
+  context: RuleContext,
+  prop: TSESTree.Property,
+  parent: TSESTree.ObjectExpression,
+): [start: number, end: number] {
+  const { sourceCode } = context;
+  const props = parent.properties;
+  const propIndex = props.indexOf(prop);
+  let start = prop.range[0];
+  let end = prop.range[1];
+
+  if (propIndex < props.length - 1) {
+    // Not the last property: remove trailing comma
+    const afterText = sourceCode.text.slice(end);
+    const commaMatch = /^\s*,/.exec(afterText);
+    if (commaMatch != null) {
+      end += commaMatch[0].length;
+    }
+  } else {
+    // Last property: remove leading comma
+    const beforeText = sourceCode.text.slice(0, start);
+    const lastComma = beforeText.lastIndexOf(",");
+    if (lastComma >= parent.range[0]) {
+      start = lastComma;
+    }
+  }
+
+  // Walk backwards over whitespace
+  while (start > parent.range[0] && /\s/.test(sourceCode.text[start - 1]!)) {
+    start--;
+  }
+
+  return [start, end];
+}
 
 // ---------------------------------------------------------------------------
 // Attribute helpers (single JSXAttribute + source text)

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.spec.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.spec.ts
@@ -265,6 +265,27 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    // createElement
+    {
+      code: 'React.createElement("div", { children: "Children" }, "Children");',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'createElement("div", { children: "Children" }, "Children");',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'React.createElement("div", { className: "x", children: "Children" }, "Children");',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'React.createElement("div", { children: <span /> }, <span />);',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'React.createElement("div", { children: "Children" }, "a", "b");',
+      errors: [{ messageId: "default" }],
+    },
   ],
   valid: [
     "<div />;",
@@ -296,5 +317,12 @@ ruleTester.run(RULE_NAME, rule, {
     "<div children></div>;",
     // Whitespace-only tab characters
     tsx`<div children="x">\t\t</div>;`,
+    // createElement with children as extra args only
+    'React.createElement("div", null, "Children");',
+    'React.createElement("div", { className: "x" }, "Children");',
+    'createElement("div", null, "Children");',
+    // createElement with children prop only
+    'React.createElement("div", { children: "Children" });',
+    'createElement("div", { children: "Children" });',
   ],
 });

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.ts
@@ -1,8 +1,9 @@
 import { createRule } from "@/utils/create-rule";
+import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { findAttribute, hasChildren } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import { getChildrenContentRange, getPropRemovalRange } from "./lib";
+import { findChildrenProperty, getChildrenContentRange, getPropRemovalRange } from "./lib";
 
 export const RULE_NAME = "no-children-prop-with-children";
 
@@ -38,6 +39,23 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>) {
   return merge({
+    CallExpression(node) {
+      if (!core.isCreateElementCall(context, node)) return;
+
+      const [, propsArg, firstExtra] = node.arguments;
+      if (propsArg == null || propsArg.type !== AST.ObjectExpression) return;
+
+      const childrenProp = findChildrenProperty(propsArg);
+      if (childrenProp == null) return;
+
+      // createElement has extra children arguments when there are extra args
+      if (firstExtra == null) return;
+
+      context.report({
+        messageId: "default",
+        node: childrenProp,
+      });
+    },
     JSXElement(node) {
       const childrenProp = findAttribute(context, node, "children");
       if (childrenProp == null) return;

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/lib.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/lib.ts
@@ -1,4 +1,4 @@
-import { Check } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
@@ -22,6 +22,67 @@ export function trimLikeReact(text: string): string {
     : text.length;
 
   return text.slice(start, end);
+}
+
+// ---------------------------------------------------------------------------
+// Object property helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find a `children` property inside an ObjectExpression.
+ * @param node The object expression.
+ * @returns The Property node whose key is "children", or null.
+ */
+export function findChildrenProperty(node: TSESTree.ObjectExpression): TSESTree.Property | null {
+  for (const prop of node.properties) {
+    if (prop.type !== AST.Property) continue;
+    const key = Extract.unwrap(prop.key);
+    if (key.type === AST.Identifier && key.name === "children") return prop;
+    if (key.type === AST.Literal && key.value === "children") return prop;
+  }
+  return null;
+}
+
+/**
+ * Compute the removal range for an ObjectExpression property, consuming any
+ * leading or trailing comma and whitespace so the resulting object stays clean.
+ * @param context The rule context.
+ * @param prop The property to remove.
+ * @param parent The parent ObjectExpression.
+ */
+export function getObjectPropertyRemovalRange(
+  context: RuleContext,
+  prop: TSESTree.Property,
+  parent: TSESTree.ObjectExpression,
+): [start: number, end: number] {
+  const { sourceCode } = context;
+  const props = parent.properties;
+  const propIndex = props.indexOf(prop);
+  let start = prop.range[0];
+  let end = prop.range[1];
+
+  if (propIndex < props.length - 1) {
+    // Not the last property: remove trailing comma
+    const afterText = sourceCode.text.slice(end);
+    const commaMatch = /^\s*,/.exec(afterText);
+    if (commaMatch != null) {
+      end += commaMatch[0].length;
+    }
+  } else {
+    // Last property: remove leading comma
+    const beforeText = sourceCode.text.slice(0, start);
+    const lastComma = beforeText.lastIndexOf(",");
+    if (lastComma >= parent.range[0]) {
+      start = lastComma;
+    }
+  }
+
+  // Walk backwards over whitespace
+  while (start > parent.range[0] && /\s/.test(sourceCode.text[start - 1]!)) {
+    start--;
+  }
+
+  return [start, end];
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.spec.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.spec.ts
@@ -271,6 +271,27 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    // createElement
+    {
+      code: 'React.createElement("div", { children: "Children" });',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'createElement("div", { children: "Children" });',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'React.createElement("div", { className: "x", children: "Children" });',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'React.createElement("div", { children: <span /> });',
+      errors: [{ messageId: "default" }],
+    },
+    {
+      code: 'React.createElement("div", { children: "Children" }, "extra");',
+      errors: [{ messageId: "default" }],
+    },
   ],
   valid: [
     "<div />;",
@@ -288,5 +309,8 @@ ruleTester.run(RULE_NAME, rule, {
     "<Foo.Bar>Children</Foo.Bar>;",
     '<div id="a" className="b" />;',
     "<xml:svg></xml:svg>;",
+    'React.createElement("div", null, "Children");',
+    'React.createElement("div", { className: "x" }, "Children");',
+    'createElement("div", null, "Children");',
   ],
 });

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.ts
@@ -1,8 +1,9 @@
 import { createRule } from "@/utils/create-rule";
+import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
 import { findAttribute } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import { getChildrenPropText, getPropRemovalRange } from "./lib";
+import { findChildrenProperty, getChildrenPropText, getPropRemovalRange } from "./lib";
 
 export const RULE_NAME = "no-children-prop";
 
@@ -105,6 +106,20 @@ export function create(context: RuleContext<MessageID, []>) {
             messageId: "moveChildrenToContent",
           },
         ],
+      });
+    },
+    CallExpression(node) {
+      if (!core.isCreateElementCall(context, node)) return;
+
+      const [, propsArg] = node.arguments;
+      if (propsArg == null || propsArg.type !== AST.ObjectExpression) return;
+
+      const childrenProp = findChildrenProperty(propsArg);
+      if (childrenProp == null) return;
+
+      context.report({
+        messageId: "default",
+        node: childrenProp,
       });
     },
   });


### PR DESCRIPTION
Adds `CallExpression` handlers to detect `React.createElement(...)` / `createElement(...)` usage for both rules:

- `no-children-prop`: report `children` property in createElement props object
- `no-children-prop-with-children`: report when `children` prop exists alongside extra children arguments

Includes helper utilities (`findChildrenProperty`, `getObjectPropertyRemovalRange`) and expanded test coverage.