### PR TITLE
docs: restructure rule documentation to new Examples-based format

### DIFF
--- a/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.mdx
+++ b/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.mdx
@@ -15,43 +15,68 @@ react-debug/function-component
 
 ## Rule Details
 
+This rule reports all function components in JSON format. It detects function declarations, arrow functions, components wrapped with `React.memo` or `React.forwardRef`, components that call Hooks, and components containing the `"use memo"` or `"use no memo"` directive.
+
+## Examples
+
+### Function declaration as a component
+
 ```tsx
+// This rule reports function declarations that return JSX.
 function MyComponent() {
   return <button />;
 }
 ```
 
+### Arrow function as a component
+
 ```tsx
+// This rule reports arrow functions that return JSX.
 const MyComponent = () => <button />;
 ```
 
+### Component wrapped with React.memo
+
 ```tsx
 import React from "react";
 
+// This rule reports components wrapped with React.memo.
 const MyComponent = React.memo(() => <button />);
 ```
 
+### Component wrapped with React.forwardRef
+
 ```tsx
 import React from "react";
 
+// This rule reports components wrapped with React.forwardRef.
 const MyComponent = React.forwardRef(() => <button />);
 ```
 
-```tsx
-import React,{ useEffect } from "react";
+### Component that calls a Hook inside
 
+```tsx
+import React, { useEffect } from "react";
+
+// This rule reports function components that use React Hooks.
 function MyComponent() {
-  useEffect(() => {}}, []);
+  useEffect(() => {}, []);
 }
 ```
 
+### Component with the "use memo" directive
+
 ```tsx
+// This rule reports components that contain the "use memo" directive.
 function MyComponent() {
   "use memo";
 }
 ```
 
+### Component with the "use no memo" directive
+
 ```tsx
+// This rule reports components that contain the "use no memo" directive.
 function MyComponent() {
   "use no memo";
 }

--- a/plugins/eslint-plugin-react-debug/src/rules/hook/hook.mdx
+++ b/plugins/eslint-plugin-react-debug/src/rules/hook/hook.mdx
@@ -15,9 +15,16 @@ react-debug/hook
 
 ## Rule Details
 
+This rule reports all React Hooks in JSON format. It detects built-in Hooks (such as `useState`, `useEffect`) as well as custom Hooks that follow the `use` prefix naming convention.
+
+## Examples
+
+### Built-in hook used inside a custom hook
+
 ```tsx
 import React, { useState } from "react";
 
+// This rule reports calls to built-in React Hooks.
 function useToggle() {
   const [value, setValue] = useState(false);
 

--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.mdx
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.mdx
@@ -15,13 +15,23 @@ react-debug/is-from-react
 
 ## Rule Details
 
+This rule reports all identifiers initialized from React in JSON format. It tracks named imports, default imports, namespace accesses, and chained member accesses originating from the configured React `importSource`.
+
+## Examples
+
+### Named imports from React
+
 ```tsx
+// This rule reports named imports that originate from React.
 import { useState } from "react";
 //       ^^^^^^^^
 //       - [initialized from react] name: 'useState', import source: 'react'.
 ```
 
+### Default import and namespace access
+
 ```tsx
+// This rule reports the default React import and member accesses.
 import React from "react";
 //     ^^^^^
 //     - [initialized from react] name: 'React', import source: 'react'.
@@ -31,7 +41,12 @@ const Children = React.Children;
 //    |          |     - [initialized from react] name: 'Children', import source: 'react'.
 //    |          - [initialized from react] name: 'React', import source: 'react'.
 //    - [initialized from react] name: 'Children', import source: 'react'.
+```
 
+### Chained member access from React imports
+
+```tsx
+// This rule reports identifiers derived from React through chained access.
 const toArray = Children.toArray;
 //    ^^^^^^^   ^^^^^^^^ ^^^^^^^
 //    |         |        - [initialized from react] name: 'toArray', import source: 'react'.
@@ -39,9 +54,12 @@ const toArray = Children.toArray;
 //    - [initialized from react] name: 'Children', import source: 'react'.
 ```
 
-### When [`settings["react-x"].importSource`](https://eslint-react.xyz/docs/configuration#importsource) is set to `"@pika/react"`
+### Custom React import source
+
+When [`settings["react-x"].importSource`](https://eslint-react.xyz/docs/configuration#importsource) is set to `"@pika/react"`:
 
 ```tsx
+// This rule respects the custom importSource setting.
 import { useState } from "@pika/react";
 //       ^^^^^^^^
 //       - [initialized from react] name: 'useState', import source: '@pika/react'.
@@ -57,7 +75,9 @@ const Children = React.Children;
 //    |          |     - [initialized from react] name: 'Children', import source: '@pika/react'.
 //    |          - [initialized from react] name: 'React', import source: '@pika/react'.
 //    - [initialized from react] name: 'Children', import source: '@pika/react'.
+```
 
+```tsx
 const toArray = Children.toArray;
 //    ^^^^^^^   ^^^^^^^^ ^^^^^^^
 //    |         |        - [initialized from react] name: 'toArray', import source: '@pika/react'.

--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.mdx
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.mdx
@@ -15,13 +15,34 @@ react-debug/is-from-ref
 
 ## Rule Details
 
+This rule reports all identifiers initialized or derived from refs in JSON format. It detects variables assigned from `useRef` and values read from `ref.current`.
+
+## Examples
+
+### Ref initialized with useRef
+
+```tsx
+import React from "react";
+
+function MyComponent() {
+  // This rule reports identifiers initialized from a ref.
+  const myRef = React.useRef(42);
+  //    ^^^^^
+  //    - {"name": "myRef", "init": "React.useRef(42)"}
+
+  return null;
+}
+```
+
+### Value read from a ref
+
 ```tsx
 import React from "react";
 
 function MyComponent() {
   const myRef = React.useRef(42);
-  //    ^^^^^
-  //    - {"name": "myRef", "init": "React.useRef(42)"}
+
+  // This rule reports identifiers derived from reading ref.current.
   const value = myRef.current;
   //    ^^^^^
   //    - {"name": "value", "init": "myRef.current"}

--- a/plugins/eslint-plugin-react-debug/src/rules/jsx/jsx.mdx
+++ b/plugins/eslint-plugin-react-debug/src/rules/jsx/jsx.mdx
@@ -15,6 +15,12 @@ react-debug/jsx
 
 ## Rule Details
 
+This rule reports all JSX elements and fragments in JSON format. It includes information about the JSX runtime (automatic or classic), factory, fragment factory, and import source derived from `tsconfig.json` or pragma comments.
+
+## Examples
+
+### Automatic runtime JSX
+
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
@@ -29,10 +35,13 @@ react-debug/jsx
 ```tsx
 import React from "react";
 
+// This rule reports JSX elements and includes automatic runtime information.
 const element = <div>Hello World</div>;
 //              ^^^^^^^^^^^^^^^^^^^^^^
 //              - [jsx element] jsx: 'react-jsx', jsxFactory: 'React.createElement', jsxFragmentFactory: 'React.Fragment', jsxRuntime: 'automatic', jsxImportSource: 'react'
 ```
+
+### Classic runtime with pragma comments
 
 ```tsx
 /** @jsx Preact.h */
@@ -42,6 +51,7 @@ const element = <div>Hello World</div>;
 
 import Preact from "preact";
 
+// This rule reports JSX elements and includes classic runtime information from pragma comments.
 const element = <div>Hello World</div>;
 //              ^^^^^^^^^^^^^^^^^^^^^^
 //              - [jsx element] jsx: 'react', jsxFactory: 'Preact.h', jsxFragmentFactory: 'Preact.Fragment', jsxRuntime: 'classic', jsxImportSource: 'preact'

--- a/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children/no-dangerously-set-innerhtml-with-children.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children/no-dangerously-set-innerhtml-with-children.mdx
@@ -29,11 +29,15 @@ react-dom/no-dangerously-set-innerhtml-with-children
 
 When using `dangerouslySetInnerHTML`, the content of the DOM element is set from the `__html` property. The content of the DOM element is completely replaced, so the children will not be rendered as expected.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `dangerouslySetInnerHTML` together with children
+
+When you set `dangerouslySetInnerHTML`, React replaces the element's contents entirely, so any children you provide are silently ignored.
 
 ```tsx
+// Problem: dangerouslySetInnerHTML and children are used together.
+// The <p> child will not be rendered.
 function MyComponent() {
   return (
     <div dangerouslySetInnerHTML={{ __html: "Hello World" }}>
@@ -43,9 +47,8 @@ function MyComponent() {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: use only dangerouslySetInnerHTML without children.
 function MyComponent() {
   return <div dangerouslySetInnerHTML={{ __html: "Hello World" }} />;
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml/no-dangerously-set-innerhtml.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml/no-dangerously-set-innerhtml.mdx
@@ -27,15 +27,18 @@ react-dom/no-dangerously-set-innerhtml
 
 ## Rule Details
 
-This should be used with extreme caution! If the HTML inside isn’t trusted (for example, if it’s based on user data), you risk introducing an [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerability.
+This should be used with extreme caution! If the HTML inside isn't trusted (for example, if it's based on user data), you risk introducing an [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerability.
 
 Read more about using [dangerouslySetInnerHTML](https://react.dev/reference/react-dom/components/common#dangerously-setting-the-inner-html).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `dangerouslySetInnerHTML` to render raw HTML
+
+Using `dangerouslySetInnerHTML` bypasses React's built-in XSS protections and should be avoided whenever possible.
 
 ```tsx
+// Problem: dangerouslySetInnerHTML exposes the application to XSS risks.
 function MyComponent() {
   return <div dangerouslySetInnerHTML={{ __html: "Hello, World!" }} />;
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.mdx
@@ -29,11 +29,14 @@ react-dom/no-find-dom-node
 
 This API will be removed in a future major version of React. [See the alternatives](https://react.dev/reference/react-dom/findDOMNode#alternatives).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `findDOMNode` to access a DOM node
+
+`findDOMNode` is a legacy API that will be removed. Use refs instead to reliably access DOM nodes.
 
 ```tsx
+// Problem: findDOMNode is deprecated and will be removed.
 import React, { Component } from "react";
 import { findDOMNode } from "react-dom";
 
@@ -51,9 +54,8 @@ class AutoSelectingInput extends Component {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: use createRef to access the underlying DOM node.
 import React, { Component } from "react";
 
 class AutoSelectingInput extends Component {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.mdx
@@ -31,11 +31,14 @@ react-dom/no-flush-sync
 
 Most of the time, `flushSync` can be avoided, so use `flushSync` as a last resort.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `flushSync` to force synchronous updates
+
+`flushSync` forces React to flush pending work synchronously, which can degrade performance and cause Suspense fallbacks to appear unexpectedly.
 
 ```tsx
+// Problem: flushSync hurts performance and can trigger unexpected fallback states.
 import { flushSync } from "react-dom";
 
 flushSync(() => {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.mdx
@@ -33,20 +33,22 @@ react-dom/no-hydrate
 
 `ReactDOM.hydrate()` is deprecated in React 18. This rule encourages migrating to the new `hydrateRoot()` API which provides better error handling and concurrent features support.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using the deprecated `ReactDOM.hydrate()` API
+
+In React 18, `ReactDOM.hydrate()` is deprecated in favor of `hydrateRoot()`.
 
 ```tsx
+// Problem: ReactDOM.hydrate() is deprecated.
 import Component from "Component";
 import ReactDOM from "react-dom";
 
 ReactDOM.hydrate(<Component />, document.getElementById("app"));
 ```
 
-### Valid
-
 ```tsx
+// Recommended: use hydrateRoot() for better error handling and concurrent features.
 import Component from "Component";
 import ReactDOM from "react-dom";
 import { hydrateRoot } from "react-dom/client";

--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.mdx
@@ -31,20 +31,22 @@ The default `type` of a button is `submit`, which causes the submission of a for
 
 Allowed button types are `submit`, `button`, or `reset`.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Rendering a `<button>` without an explicit `type`
+
+A button without a `type` attribute defaults to `submit`, which can unintentionally submit forms.
 
 ```tsx
+// Problem: missing explicit type; defaults to submit.
 function MyComponent() {
   return <button>Click me</button>;
   //     ^^^ Missing 'type' attribute on button component.
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: explicitly declare the button type.
 function MyComponent() {
   return <button type="button">Click me</button>;
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.mdx
@@ -29,20 +29,22 @@ react-dom/no-missing-iframe-sandbox
 
 The sandbox attribute enables an extra set of restrictions for the content in the iframe. Using the sandbox attribute is considered a good security practice.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Rendering an `<iframe>` without a `sandbox` attribute
+
+An iframe without `sandbox` allows the embedded content unrestricted capabilities, which is a security risk.
 
 ```tsx
+// Problem: missing sandbox attribute leaves the iframe unrestricted.
 function MyComponent() {
   return <iframe src="https://eslint-react.xyz" />;
   //     ^^^ Missing 'sandbox' attribute on iframe component.
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: add a sandbox attribute to restrict the iframe's capabilities.
 function MyComponent() {
   return <iframe src="https://eslint-react.xyz" sandbox="allow-popups" />;
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.mdx
@@ -29,20 +29,22 @@ react-dom/no-render-return-value
 
 `ReactDOM.render()` currently returns a reference to the root React component instance. However, using this return value is legacy and should be avoided because future versions of React may render components asynchronously in some cases. If you need a reference to the root React component instance, the preferred solution is to attach a [callback ref](https://react.dev/learn/manipulating-the-dom-with-refs) to the root element.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Capturing the return value of `ReactDOM.render()`
+
+The return value of `ReactDOM.render()` is considered legacy and may break with future React updates.
 
 ```tsx
+// Problem: depending on the return value of ReactDOM.render().
 import ReactDOM from "react-dom";
 
 const instance = ReactDOM.render(<div id="app" />, document.body);
 //    ^^^ Do not depend on the return value from '{{objectName}}.render'.
 ```
 
-### Valid
-
 ```tsx
+// Recommended: use a callback ref on the root element instead.
 import ReactDOM from "react-dom";
 
 function doSomethingWithInst(inst: HTMLDivElement | null) {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.mdx
@@ -31,23 +31,23 @@ react-dom/no-render
 
 ## Rule Details
 
-## Common Violations
+## Examples
 
-### Invalid
+### Bootstrapping a React app with the legacy API
 
 ```tsx
 import Component from "Component";
 import ReactDOM from "react-dom";
 
+// Problem: ReactDOM.render() is the legacy API and will be removed in React 18+
 ReactDOM.render(<Component />, document.getElementById("app"));
 ```
-
-### Valid
 
 ```tsx
 import Component from "Component";
 import { createRoot } from "react-dom/client";
 
+// Recommended: Use createRoot() from "react-dom/client" instead
 createRoot(document.getElementById("app")).render(<Component />);
 ```
 

--- a/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.mdx
@@ -29,21 +29,21 @@ react-dom/no-script-url
 
 `javascript:` URLs are a form of [XSS](https://en.wikipedia.org/wiki/Cross-site_scripting) attack. They allow an attacker to execute arbitrary JavaScript in the context of your website, which can be used to steal user data, deface your website, or perform other malicious actions.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Passing URLs to link or resource attributes
 
 ```tsx
 function MyComponent() {
+  // Problem: `javascript:` URLs are a security risk and should be avoided
   return <a href="javascript:alert('Hello, world!')">Click me</a>;
   //        ^^^ Using a `javascript:` URL is a security risk and should be avoided.
 }
 ```
 
-### Valid
-
 ```tsx
 function MyComponent() {
+  // Recommended: Use a safe URL instead
   return <a href="/some-page">Click me</a>;
 }
 ```

--- a/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.mdx
@@ -25,20 +25,20 @@ react-dom/no-string-style-prop
 
 Using a string value for the `style` prop is not valid in React. The style prop must be an object with camelCased CSS properties. This rule helps catch incorrect string usage that would cause runtime errors.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Setting inline styles on JSX elements
 
 ```tsx
 function MyComponent() {
+  // Problem: Passing a CSS string to the style prop causes a runtime error
   return <div style="color: red;" />;
 }
 ```
 
-### Valid
-
 ```tsx
 function MyComponent() {
+  // Recommended: Pass an object with camelCased CSS properties
   return <div style={{ color: "red" }} />;
 }
 ```

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.mdx
@@ -23,36 +23,44 @@ react-dom/no-unknown-property
 
 In JSX, most DOM properties and attributes should be camel-cased to be consistent with standard JavaScript style. This can be a source of error if you are used to writing plain HTML. Only `data-*` and `aria-*` attributes use hyphens and lowercase letters in JSX.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Writing standard HTML attributes in JSX
 
 ```tsx
+// Problem: HTML attributes like `class` must be written as `className` in JSX
 const Hello = <div class="hello">Hello World</div>;
 const Alphabet = <div abc="something">Alphabet</div>;
-
-// Invalid aria-* attribute
-const IconButton = <div aria-foo="bar" />;
 ```
 
-### Valid
-
 ```tsx
+// Recommended: Use React's camelCase property names for DOM elements
 const Hello = <div className="hello">Hello World</div>;
 const Button = <button disabled>Cannot click me</button>;
 const Img = <img src={catImage} alt="A cat sleeping on a keyboard" />;
+```
 
-// aria-* attributes
+### Using ARIA and data attributes
+
+```tsx
+// Problem: Non-standard aria-* attributes are not valid
+const IconButton = <div aria-foo="bar" />;
+```
+
+```tsx
+// Recommended: Use valid aria-* and data-* attributes
 const IconButton = <button aria-label="Close" onClick={this.close}>{closeIcon}</button>;
-
-// data-* attributes
 const Data = <div data-index={12}>Some data</div>;
+```
 
-// React components are ignored
+### Passing arbitrary props to React components and custom elements
+
+```tsx
+// OK: React components can accept any props you define
 const MyComponent = <App class="foo-bar" />;
 const AnotherComponent = <Foo.bar for="bar" />;
 
-// Custom web components are ignored
+// OK: Custom web components are also ignored
 const MyElem = <div class="foo" is="my-elem"></div>;
 const AtomPanel = <atom-panel class="foo"></atom-panel>;
 ```

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.mdx
@@ -25,13 +25,15 @@ react-dom/no-unsafe-iframe-sandbox
 
 This rule reports cases where the attribute contains `allow-scripts` and `allow-same-origin` at the same time, as this combination allows the embedded document to remove the sandbox attribute and bypass the restrictions.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Sandboxing third-party content in an iframe
 
 ```tsx
 function MyComponent() {
   return (
+    // Problem: allow-scripts together with allow-same-origin lets the embedded
+    // document escape the sandbox by removing the attribute via JavaScript
     <iframe
       src="https://eslint-react.xyz"
       sandbox="allow-scripts allow-same-origin"
@@ -40,10 +42,9 @@ function MyComponent() {
 }
 ```
 
-### Valid
-
 ```tsx
 function MyComponent() {
+  // Recommended: Use a safer sandbox value that does not combine both flags
   return <iframe src="https://eslint-react.xyz" sandbox="allow-popups" />;
 }
 ```

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank/no-unsafe-target-blank.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank/no-unsafe-target-blank.mdx
@@ -29,13 +29,14 @@ react-dom/no-unsafe-target-blank
 
 When using `target="_blank"` on links without `rel="noreferrer noopener"`, the opened page can access the `window.opener` property of the original page, which creates a security vulnerability known as tabnabbing.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Opening external links in a new tab
 
 ```tsx
 function MyComponent() {
   return (
+    // Problem: target="_blank" without rel allows the opened page to access window.opener
     <a href="https://eslint-react.xyz" target="_blank">
       Example
     </a>
@@ -43,11 +44,10 @@ function MyComponent() {
 }
 ```
 
-### Valid
-
 ```tsx
 function MyComponent() {
   return (
+    // Recommended: Always add rel="noreferrer noopener" when using target="_blank"
     <a href="https://eslint-react.xyz" target="_blank" rel="noreferrer noopener">
       Example
     </a>

--- a/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.mdx
@@ -31,9 +31,9 @@ react-dom/no-use-form-state
 
 ## Rule Details
 
-## Common Violations
+## Examples
 
-### Invalid
+### Managing form state with server actions
 
 ```tsx
 import { useFormState } from "react-dom";
@@ -43,6 +43,7 @@ async function increment(previousState, formData) {
 }
 
 function StatefulForm({}) {
+  // Problem: useFormState from "react-dom" is deprecated in favor of useActionState
   const [state, formAction] = useFormState(increment, 0);
   return (
     <form>
@@ -53,8 +54,6 @@ function StatefulForm({}) {
 }
 ```
 
-### Valid
-
 ```tsx
 import { useActionState } from "react";
 
@@ -63,6 +62,7 @@ async function increment(previousState, formData) {
 }
 
 function StatefulForm({}) {
+  // Recommended: Use useActionState from "react" instead
   const [state, formAction] = useActionState(increment, 0);
   return (
     <form>

--- a/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children/no-void-elements-with-children.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children/no-void-elements-with-children.mdx
@@ -31,11 +31,12 @@ Self-closing HTML elements (ex: `<img />`, `<br />`, `<hr />`) are collectively 
 
 > Invariant Violation: img is a void element tag and must neither have children nor use dangerouslySetInnerHTML.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Adding children or inner HTML to elements
 
 ```tsx
+// Problem: Void elements like <br> cannot contain children
 <br>Children</br>
 <br children="Children" />
 <br dangerouslySetInnerHTML={{ __html: 'HTML' }} />
@@ -44,9 +45,8 @@ React.createElement('br', { children: 'Children' })
 React.createElement('br', { dangerouslySetInnerHTML: { __html: 'HTML' } })
 ```
 
-### Valid
-
 ```tsx
+// Recommended: Use non-void container elements for children or inner HTML
 <div>Children</div>
 <div children="Children" />
 <div dangerouslySetInnerHTML={{ __html: 'HTML' }} />

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.mdx
@@ -33,9 +33,9 @@ react-jsx/no-children-prop-with-children
 
 When using JSX, `children` should be passed either as a prop or as nested content between the opening and closing tags, but not both. Passing `children` both ways is redundant and can lead to confusion about which children will actually be rendered.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Passing children both as a prop and as nested content
 
 ```tsx
 interface MyComponentProps {
@@ -43,17 +43,17 @@ interface MyComponentProps {
 }
 
 function MyComponent({ children }: MyComponentProps) {
-  // ❌ Don't use children prop when element already has nested children
+  // Problem: Don't use children prop when element already has nested children
   return <div children={children}>{children}</div>;
 }
 ```
 
 ```tsx
-// ❌ Don't use children prop when element already has nested children
+// Problem: Don't use children prop when element already has nested children
 <Component children="text">text</Component>
 ```
 
-### Valid
+### Passing children only as nested content
 
 ```tsx
 interface MyComponentProps {
@@ -61,16 +61,20 @@ interface MyComponentProps {
 }
 
 function MyComponent({ children }: MyComponentProps) {
-  // ✅ Use nested children
+  // Recommended: Use nested children
   return <div>{children}</div>;
 }
 ```
 
 ```tsx
-// ✅ Use nested children
+// Recommended: Use nested children
 <Component>text</Component>
+```
 
-// ✅ Or use children prop (when no nested children)
+### Passing children only as a prop
+
+```tsx
+// OK: Use children prop when no nested children
 <Component children="text" />
 ```
 

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.mdx
@@ -35,9 +35,9 @@ Most of the time, `children` should be actual children, not passed in as a prop.
 
 When using JSX, `children` should be nested between the opening and closing tags. When not using JSX, `children` should be passed as additional arguments to `React.createElement`.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Passing children as a prop
 
 ```tsx
 interface MyComponentProps {
@@ -45,12 +45,13 @@ interface MyComponentProps {
 }
 
 function MyComponent({ children }: MyComponentProps) {
+  // Problem: Children should always be actual children, not passed in as a prop.
   return <div children={children} />;
   //          ^^^ Children should always be actual children, not passed in as a prop.
 }
 ```
 
-### Valid
+### Passing children as nested content
 
 ```tsx
 interface MyComponentProps {
@@ -58,6 +59,7 @@ interface MyComponentProps {
 }
 
 function MyComponent({ children }: MyComponentProps) {
+  // Recommended: Nest children between opening and closing tags
   return <div>{children}</div>;
 }
 ```

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-comment-textnodes/no-comment-textnodes.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-comment-textnodes/no-comment-textnodes.mdx
@@ -31,28 +31,28 @@ This rule prevents comment strings (ex: beginning with `//` or `/*`) from being 
 
 Comments inside JSX elements should be placed inside braces (`{/* comment */}`) to prevent them from being rendered as text.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Writing JavaScript-style comments directly inside JSX
 
 ```tsx
 function MyComponent() {
   return (
     <div>
-      // This will be rendered as text
-      /* This will also be rendered as text */
+      // Problem: This will be rendered as text
+      /* Problem: This will also be rendered as text */
     </div>
   );
 }
 ```
 
-### Valid
+### Using proper JSX comment syntax
 
 ```tsx
 function MyComponent() {
   return (
     <div>
-      {/* This is a valid comment inside JSX */}
+      {/* Recommended: This is a valid comment inside JSX */}
       <span>Hello</span>
     </div>
   );

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.mdx
@@ -31,20 +31,26 @@ When using the JSX automatic runtime, `key` is a special prop in the JSX transfo
 
 If the `key` prop is before any spread props, it is passed as the `key` argument of the `_jsx` / `_jsxs` / `_jsxDev` function. But if the `key` prop is after spread props, the compiler uses `createElement` instead and passes `key` as a regular prop.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `key` after spread props
 
 ```tsx
+// Problem: The 'key' prop must be placed before any spread props when using the new JSX transform.
 <div {...props} key="2" />;
 //              ^^^ The 'key' prop must be placed before any spread props when using the new JSX transform.
 ```
 
-### Valid
+### Using `key` before or without spread props
 
 ```tsx
+// Recommended: 'key' placed before spread props
 <div key="1" {...props} />;
+
+// Recommended: 'key' without spread props
 <div key="3" className="" />;
+
+// OK: 'key' can also appear after regular props
 <div className="" key="3" />;
 ```
 

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-dollar/no-leaked-dollar.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-dollar/no-leaked-dollar.mdx
@@ -49,34 +49,35 @@ function MyComponent({ user }) {
 
 In this example, the `$` before `{user.name}` is unnecessary and will be rendered as part of the output.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Leaving `$` from template literals when refactoring to JSX
 
 ```tsx
 function MyComponent({ user }) {
+  // Problem: Possible unintentional '$' sign before expression.
   return <div>Hello ${user.name}</div>;
-  //                ^ Possible unintentional '$' sign before expression.
 }
 ```
 
 ```tsx
 function MyComponent({ user }) {
+  // Problem: Possible unintentional '$' sign before expression.
   return <div>${user.name} is your name</div>;
-  //          ^ Possible unintentional '$' sign before expression.
 }
 ```
 
 ```tsx
 function MyComponent({ count, total }) {
+  // Problem: Possible unintentional '$' sign before expression.
   return <div>Progress: ${count} / ${total}</div>;
-  //                     ^         ^ Possible unintentional '$' sign before expression.
 }
 ```
 
-### Valid
+### Using correct JSX expression syntax
 
 ```tsx
+// OK: Template literals are fine outside JSX
 function MyComponent({ user }) {
   return `Hello ${user.name}`;
 }
@@ -84,12 +85,16 @@ function MyComponent({ user }) {
 
 ```tsx
 function MyComponent({ user }) {
+  // Recommended: Remove the '$' when using JSX expressions
   return <div>Hello {user.name}</div>;
 }
 ```
 
+### Intentionally rendering `$` before a value
+
 ```tsx
 function MyComponent({ price }) {
+  // OK: Intentionally rendering '$' as literal text before a JSX expression
   return <div>${price}</div>;
 }
 ```

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-semicolon/no-leaked-semicolon.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-semicolon/no-leaked-semicolon.mdx
@@ -45,11 +45,12 @@ return (
 );
 ```
 
-## Common Violations
+## Examples
 
-### Invalid
+### Accidentally leaving semicolons inside JSX
 
 ```tsx
+// Problem: Semicolon leaks into rendered text
 function MyComponent() {
   return (
     <div>
@@ -60,6 +61,7 @@ function MyComponent() {
 ```
 
 ```tsx
+// Problem: Semicolon leaks into rendered text
 function MyComponent() {
   return (
     <div>
@@ -71,9 +73,10 @@ function MyComponent() {
 }
 ```
 
-### Valid
+### Proper JSX without leaked semicolons
 
 ```tsx
+// Recommended: No semicolon after JSX elements
 function MyComponent() {
   return (
     <div>
@@ -83,7 +86,10 @@ function MyComponent() {
 }
 ```
 
+### Intentionally rendering semicolons as text
+
 ```tsx
+// OK: Semicolon is intentionally placed as separate text
 function MyComponent() {
   return (
     <div>

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-namespace/no-namespace.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-namespace/no-namespace.mdx
@@ -29,38 +29,40 @@ react-jsx/no-namespace
 
 React does not support XML namespaced tags (e.g. `<ns:Component />`). Although the JSX specification permits namespaces, React does not implement them. Using a namespaced element will cause a runtime error.
 
-### Invalid
+## Examples
+
+### Using namespace tags in JSX
 
 ```tsx
-// ❌ Namespace tag — not supported by React.
-<ns:testcomponent />;
+// Problem: Namespace tag — not supported by React.
+<ns:testcomponent />
 ```
 
 ```tsx
-// ❌ PascalCase namespace is also not allowed.
-<Ns:TestComponent />;
+// Problem: PascalCase namespace is also not allowed.
+<Ns:TestComponent />
 ```
 
 ```tsx
-// ❌ SVG-style namespace is also not allowed.
-<svg:circle cx="50" cy="50" r="40" />;
+// Problem: SVG-style namespace is also not allowed.
+<svg:circle cx="50" cy="50" r="40" />
 ```
 
-### Valid
+### Using standard JSX tags
 
 ```tsx
-// ✅ Plain element — no namespace.
-<testcomponent />;
-```
-
-```tsx
-// ✅ Member expression — not a namespace.
-<object.TestComponent />;
+// Recommended: Plain element — no namespace.
+<testcomponent />
 ```
 
 ```tsx
-// ✅ PascalCase component.
-<TestComponent />;
+// Recommended: Member expression — not a namespace.
+<object.TestComponent />
+```
+
+```tsx
+// Recommended: PascalCase component.
+<TestComponent />
 ```
 
 ## Resources

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.mdx
@@ -29,17 +29,31 @@ react-jsx/no-useless-fragment
 
 A fragment is redundant if it contains only one child or if it is the child of an host element and is not a [keyed fragment](https://react.dev/reference/react/Fragment#caveats).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Returning a single element wrapped in a fragment
 
 ```tsx
+// Problem: Fragment with only one child is redundant
 <><Foo /></>
+```
 
-<p><>foo</></p>
+### Using empty fragments
 
+```tsx
+// Problem: Empty fragment serves no purpose
 <></>
+```
 
+### Wrapping children unnecessarily inside a host element
+
+```tsx
+// Problem: Fragment inside a host element is redundant
+<p><>foo</></p>
+```
+
+```tsx
+// Problem: Fragment inside a host element with no key is redundant
 <section>
   <>
     <div />
@@ -48,35 +62,65 @@ A fragment is redundant if it contains only one child or if it is the child of a
 </section>
 ```
 
-### Valid
+### Returning a single expression directly
 
 ```tsx
+// Recommended: Return the expression directly instead of wrapping in a fragment
 {foo}
+```
 
+```tsx
+// Recommended: Return the element directly instead of wrapping in a fragment
 <Foo />
+```
 
+### Using fragments with multiple children or expressions
+
+```tsx
+// Recommended: Fragment with multiple children
 <>
   <Foo />
   <Bar />
 </>
+```
 
+```tsx
+// OK: Text and expression children (multiple children)
 <>foo {bar}</>
+```
 
+```tsx
+// OK: Leading space with expression (multiple children)
 <> {foo}</>
+```
 
+```tsx
+// OK: Expression child (allowed by default via allowExpressions)
 <>{children}</>
+```
 
+```tsx
+// OK: Expression child (allowed by default via allowExpressions)
 <>{props.children}</>
+```
 
+```tsx
+// OK: Single text node assigned to a variable
 const cat = <>meow</>
+```
 
+```tsx
+// OK: Fragment inside a custom component (preserves grouping)
 <SomeComponent>
   <>
     <div />
     <div />
   </>
 </SomeComponent>
+```
 
+```tsx
+// OK: Keyed fragment
 <Fragment key={item.id}>{item.value}</Fragment>
 ```
 

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
@@ -28,41 +28,44 @@ react-naming-convention/context-name
 
 Enforces that the context has a valid component name with the suffix `Context`.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Naming context without the `Context` suffix
 
 ```tsx
+// Problem: Context name should end with 'Context'
 const theme = createContext("");
 ```
 
 ```tsx
+// Problem: Context name should end with 'Context'
 const Theme = createContext("");
 ```
 
 ```tsx
+// Problem: Context name should be PascalCase and end with 'Context'
 const themecontext = createContext("");
 ```
 
 ```tsx
+// Problem: Context name should be PascalCase and end with 'Context'
 const themeContext = createContext("");
 ```
 
-### Valid
-
 ```tsx
-const ThemeContext = createContext("");
-```
-
-### Invalid
-
-```tsx
+// Problem: Context name should be PascalCase and end with 'Context'
 const context = createContext("");
 ```
 
-### Valid
+### Naming context correctly
 
 ```tsx
+// Recommended: PascalCase with 'Context' suffix
+const ThemeContext = createContext("");
+```
+
+```tsx
+// Recommended: PascalCase with 'Context' suffix
 const Context = createContext("");
 ```
 

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
@@ -28,36 +28,42 @@ react-naming-convention/id-name
 
 Enforces identifier names assigned from `useId` calls to be either `id` or end with `Id`.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Assigning `useId` to a variable without the `Id` suffix
 
 ```tsx
+// Problem: A variable assigned from `useId()` must be named 'id' or end with 'Id'.
 const value = useId();
 //    ^^^ A variable assigned from `useId()` must be named 'id' or end with 'Id'.
 ```
 
 ```tsx
+// Problem: A variable assigned from `useId()` must be named 'id' or end with 'Id'.
 const unique = useId();
 //    ^^^ A variable assigned from `useId()` must be named 'id' or end with 'Id'.
 ```
 
 ```tsx
+// Problem: A variable assigned from `useId()` must be named 'id' or end with 'Id'.
 const foo = useId();
-//    ^ A variable assigned from `useId()` must be named 'id' or end with 'Id'.
+//    ^^^ A variable assigned from `useId()` must be named 'id' or end with 'Id'.
 ```
 
-### Valid
+### Assigning `useId` to a properly named variable
 
 ```tsx
+// Recommended: Simple 'id' name
 const id = useId();
 ```
 
 ```tsx
+// Recommended: Descriptive name ending with 'Id'
 const inputId = useId();
 ```
 
 ```tsx
+// Recommended: Descriptive name ending with 'Id'
 const dialogTitleId = useId();
 ```
 

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
@@ -28,40 +28,47 @@ react-naming-convention/ref-name
 
 Enforces identifier names assigned from `useRef` calls to be either `ref` or end with `Ref`.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Assigning `useRef` to a variable without the `Ref` suffix
 
 ```tsx
+// Problem: A ref identifier must be named 'ref' or end in 'Ref'.
 const count = useRef(0);
 //    ^^^ A ref identifier must be named 'ref' or end in 'Ref'.
 ```
 
 ```tsx
+// Problem: A ref identifier must be named 'ref' or end in 'Ref'.
 const input = useRef<HTMLInputElement>(null);
 //    ^^^ A ref identifier must be named 'ref' or end in 'Ref'.
 ```
 
 ```tsx
+// Problem: A ref identifier must be named 'ref' or end in 'Ref'.
 const value = useRef(null);
 //    ^^^ A ref identifier must be named 'ref' or end in 'Ref'.
 ```
 
-### Valid
+### Assigning `useRef` to a properly named variable
 
 ```tsx
+// Recommended: Simple 'ref' name
 const ref = useRef(0);
 ```
 
 ```tsx
+// Recommended: Descriptive name ending with 'Ref'
 const countRef = useRef(0);
 ```
 
 ```tsx
+// Recommended: Descriptive name ending with 'Ref'
 const inputRef = useRef<HTMLInputElement>(null);
 ```
 
 ```tsx
+// Recommended: Descriptive name ending with 'Ref'
 const valueRef = useRef(null);
 ```
 

--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.mdx
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.mdx
@@ -43,11 +43,12 @@ It includes the following checks:
 4. `'use client'` and `'use server'` directives must be written with single or double quotes, not backticks.
 5. The `'use client'` directive must not be used inside a function body.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Server functions not marked as async
 
 ```tsx
+// Problem: Exported server functions must be async
 'use server';
 
 export function serverFunction1() {
@@ -64,6 +65,7 @@ export const serverFunction3 = () => {
 ```
 
 ```tsx
+// Problem: Server functions inside components must be async
 export function Component() {
   function serverFunction1() {
     'use server';
@@ -84,9 +86,10 @@ export function Component() {
 }
 ```
 
-### Valid
+### Correctly marking server functions as async
 
 ```tsx
+// Recommended: Exported async server functions
 'use server';
 
 export async function serverFunction1() {
@@ -103,6 +106,7 @@ export const serverFunction3 = async () => {
 ```
 
 ```tsx
+// Recommended: Async server functions inside components
 export function Component() {
   async function serverFunction1() {
     'use server';
@@ -123,15 +127,17 @@ export function Component() {
 }
 ```
 
-### Invalid
+### Incorrect directive placement or syntax
 
 ```tsx
+// Problem: Directive must be at the very beginning of the file, before imports
 import { useState } from 'react';
 
 'use client';
 ```
 
 ```tsx
+// Problem: Directive must be at the very beginning of the function body
 export function Component() {
   const x = 1;
 
@@ -143,10 +149,12 @@ export function Component() {
 ```
 
 ```tsx
+// Problem: Directives must use single or double quotes, not backticks
 `use client`;
 ```
 
 ```tsx
+// Problem: 'use client' must not be used inside a function body
 export function Component() {
   function serverFunction() {
     'use client';
@@ -155,15 +163,17 @@ export function Component() {
 }
 ```
 
-### Valid
+### Correct directive placement and syntax
 
 ```tsx
+// Recommended: Directive at the top of the file before imports
 'use client';
 
 import { useState } from 'react';
 ```
 
 ```tsx
+// Recommended: Directive at the beginning of the function body
 export function Component() {
   async function serverFunction() {
     'use server';
@@ -173,6 +183,7 @@ export function Component() {
 ```
 
 ```tsx
+// Recommended: Double quotes are also acceptable
 "use client";
 
 import { useState } from 'react';

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.mdx
@@ -29,15 +29,16 @@ react-web-api/no-leaked-event-listener
 
 Adding an event listener without removing it can lead to memory leaks and unexpected behavior because the event listener will continue to exist even after the component or hook is unmounted.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Adding event listener without cleanup in class components
 
 ```tsx
 import React, { Component } from "react";
 
 class MyComponent extends Component {
   componentDidMount() {
+    // Problem: An 'addEventListener' in 'componentDidMount' should have a corresponding 'removeEventListener' in the 'componentWillUnmount' method.
     document.addEventListener("click", this.handleClick);
     //                                 ^^^ An 'addEventListener' in 'componentDidMount' should have a corresponding 'removeEventListener' in the 'componentWillUnmount' method.
   }
@@ -52,6 +53,8 @@ class MyComponent extends Component {
 }
 ```
 
+### Adding event listener without cleanup in useEffect
+
 ```tsx
 import React, { useEffect } from "react";
 
@@ -61,6 +64,7 @@ function MyComponent() {
       console.log("clicked");
     };
 
+    // Problem: An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
     document.addEventListener("click", handleClick);
     //                                 ^^^ An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
   }, []);
@@ -69,11 +73,14 @@ function MyComponent() {
 }
 ```
 
+### Using inline listener functions
+
 ```tsx
 import React, { useEffect } from "react";
 
 function MyComponent() {
   useEffect(() => {
+    // Problem: An 'addEventListener' should not have an inline listener function.
     document.addEventListener("click", () => console.log("clicked"));
     //                                 ^^^ An 'addEventListener' should not have an inline listener function.
   }, []);
@@ -81,6 +88,8 @@ function MyComponent() {
   return null;
 }
 ```
+
+### Mismatched options between add and remove
 
 ```tsx
 import React, { useEffect } from "react";
@@ -92,9 +101,11 @@ function MyComponent() {
     };
 
     document.addEventListener("click", handleClick, { capture: true });
+    // Problem: An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
     //                                 ^^^ An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
 
     return () => {
+      // Problem: Options don't match — removeEventListener must use the same capture value
       document.removeEventListener("click", handleClick, { capture: false });
     };
   }, []);
@@ -103,18 +114,7 @@ function MyComponent() {
 }
 ```
 
-```tsx
-function useCustomHook() {
-  useEffect(() => {
-    const handleClick = () => {
-      console.log("clicked");
-    };
-
-    document.addEventListener("click", handleClick);
-    //                                 ^^^ An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
-  }, []);
-}
-```
+### Dynamic entries that may differ between setup and cleanup
 
 ```tsx
 import { useEffect } from "react";
@@ -124,13 +124,15 @@ function MyComponent() {
     if (!el) {
       return;
     }
-    // The following cases are intentionally considered possible leaks:
+
+    // Problem: The entries are not guaranteed to be the same as those in the effect cleanup function.
     for (const [name, handler] of Object.entries(handlers)) {
       //                          ^^^ The entries are not guaranteed to be the same as those in the effect cleanup function.
       el.addEventListener(name, handler);
     }
 
     return () => {
+      // Problem: The entries are not guaranteed to be the same as those in the effect setup function.
       for (const [name, handler] of Object.entries(handlers)) {
         //                          ^^^ The entries are not guaranteed to be the same as those in the effect setup function.
         el.removeEventListener(name, handler);
@@ -142,17 +144,19 @@ function MyComponent() {
 }
 ```
 
-### Valid
+### Proper cleanup in class components
 
 ```tsx
 import React, { Component } from "react";
 
 class MyComponent extends Component {
   componentDidMount() {
+    // Recommended: Add listener in mount
     document.addEventListener("click", this.handleClick);
   }
 
   componentWillUnmount() {
+    // Recommended: Remove listener in unmount
     document.removeEventListener("click", this.handleClick);
   }
 
@@ -166,6 +170,8 @@ class MyComponent extends Component {
 }
 ```
 
+### Proper cleanup in useEffect
+
 ```tsx
 import React, { useEffect } from "react";
 
@@ -175,9 +181,11 @@ function MyComponent() {
       console.log("clicked");
     };
 
+    // Recommended: Add listener in effect setup
     document.addEventListener("click", handleClick);
 
     return () => {
+      // Recommended: Remove listener in effect cleanup
       document.removeEventListener("click", handleClick);
     };
   }, []);
@@ -185,6 +193,8 @@ function MyComponent() {
   return null;
 }
 ```
+
+### Matching options between add and remove
 
 ```tsx
 import React, { useEffect } from "react";
@@ -198,6 +208,7 @@ function MyComponent() {
     document.addEventListener("click", handleClick, { capture: true });
 
     return () => {
+      // Recommended: Use identical options in both add and remove
       document.removeEventListener("click", handleClick, { capture: true });
     };
   }, []);
@@ -205,6 +216,8 @@ function MyComponent() {
   return null;
 }
 ```
+
+### Using stable arrays for multiple listeners
 
 ```tsx
 import { useEffect } from "react";
@@ -221,6 +234,7 @@ function MyComponent() {
     const handleActivity = () => {};
 
     events.forEach((event) => {
+      // Recommended: Use a stable array for consistent setup and cleanup
       window.addEventListener(event, handleActivity);
     });
 
@@ -235,46 +249,7 @@ function MyComponent() {
 }
 ```
 
-```tsx
-import { useEffect } from "react";
-
-function MyComponent() {
-  useEffect(() => {
-    const events = [
-      ["mousemove", () => {}],
-      ["mousedown", () => {}],
-    ];
-
-    for (const [event, handler] of events) {
-      window.addEventListener(event, handler);
-    }
-
-    return () => {
-      for (const [event, handler] of events) {
-        window.removeEventListener(event, handler);
-      }
-    };
-  }, []);
-
-  return null;
-}
-```
-
-```tsx
-function useCustomHook() {
-  useEffect(() => {
-    const handleClick = () => {
-      console.log("clicked");
-    };
-
-    document.addEventListener("click", handleClick);
-
-    return () => {
-      document.removeEventListener("click", handleClick);
-    };
-  }, []);
-}
-```
+### Pre-computing entries for consistency
 
 ```tsx
 import { useEffect } from "react";
@@ -285,7 +260,7 @@ function MyComponent() {
       return;
     }
 
-    // Instead, always use the same entries in both the setup and cleanup functions:
+    // Recommended: Always use the same entries in both the setup and cleanup functions:
     const handlerEntries = Object.entries(handlers); // <- Use the same entries array
 
     for (const [name, handler] of handlerEntries) {

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.mdx
@@ -42,9 +42,9 @@ re-runs on a dependency change. If the resolved handler calls `setState` or
 writes to a ref the component reads, the UI will display data for a component
 instance that no longer exists, or overwrite fresh data with stale data.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Starting fetch without an AbortController
 
 ```tsx
 import { useEffect, useState } from "react";
@@ -53,6 +53,7 @@ function UserProfile({ id }: { id: string }) {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
+    // Problem: A 'fetch' started in 'useEffect' must be aborted in the cleanup function.
     fetch(`/api/user/${id}`)
     // ^^^ A 'fetch' started in 'useEffect' must be aborted in the cleanup function.
       .then((r) => r.json())
@@ -63,7 +64,7 @@ function UserProfile({ id }: { id: string }) {
 }
 ```
 
-### Valid
+### Using AbortController with fetch
 
 ```tsx
 import { useEffect, useState } from "react";
@@ -72,10 +73,12 @@ function UserProfile({ id }: { id: string }) {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
+    // Recommended: Create an AbortController and pass its signal to fetch
     const ctrl = new AbortController();
     fetch(`/api/user/${id}`, { signal: ctrl.signal })
       .then((r) => r.json())
       .then(setUser);
+    // Recommended: Abort the request in the cleanup function
     return () => ctrl.abort();
   }, [id]);
 

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.mdx
@@ -27,11 +27,11 @@ react-web-api/no-leaked-interval
 
 ## Rule Details
 
-Scheduling an interval within the setup function of `useEffect` without canceling it in the cleanup function can lead to unwanted `setInterval` callback executions and may also result in using stale values captured by previous renders’ effects after each subsequent re-render.
+Scheduling an interval within the setup function of `useEffect` without canceling it in the cleanup function can lead to unwanted `setInterval` callback executions and may also result in using stale values captured by previous renders' effects after each subsequent re-render.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Setting interval without cleanup in useEffect
 
 ```tsx
 import React, { useEffect, useState } from "react";
@@ -40,6 +40,7 @@ function MyComponent() {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
+    // Problem: A 'setInterval' created in 'useEffect' must be cleared in the cleanup function.
     const intervalId = setInterval(() => console.log(count), 1000);
     //                 ^^^ A 'setInterval' created in 'useEffect' must be cleared in the cleanup function.
   }, []);
@@ -48,7 +49,7 @@ function MyComponent() {
 }
 ```
 
-### Valid
+### Clearing interval in useEffect cleanup
 
 ```tsx
 import React, { useEffect, useState } from "react";
@@ -57,7 +58,9 @@ function MyComponent() {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
+    // Recommended: Store the interval ID
     const intervalId = setInterval(() => console.log(count), 1000);
+    // Recommended: Clear the interval in the cleanup function
     return () => clearInterval(intervalId);
   }, []);
 

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.mdx
@@ -29,9 +29,9 @@ react-web-api/no-leaked-resize-observer
 
 Creating a `ResizeObserver` without disconnecting it can lead to memory leaks and unexpected behavior.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Creating ResizeObserver without disconnecting in useEffect
 
 ```tsx
 import React, { useEffect, useRef } from "react";
@@ -41,6 +41,7 @@ function MyComponent() {
 
   useEffect(() => {
     if (!ref.current) return;
+    // Problem: A 'ResizeObserver' in 'useEffect' should have a corresponding 'resizeObserver.disconnect()' in its cleanup function.
     const ro = new ResizeObserver(() => console.log("resize"));
     //         ^^^ A 'ResizeObserver' in 'useEffect' should have a corresponding 'resizeObserver.disconnect()' in its cleanup function.
     ro.observe(ref.current);
@@ -50,7 +51,7 @@ function MyComponent() {
 }
 ```
 
-### Valid
+### Disconnecting ResizeObserver in useEffect cleanup
 
 ```tsx
 import React, { useEffect, useRef } from "react";
@@ -60,8 +61,10 @@ function MyComponent() {
 
   useEffect(() => {
     if (!ref.current) return;
+    // Recommended: Create and use ResizeObserver
     const ro = new ResizeObserver(() => console.log("resize"));
     ro.observe(ref.current);
+    // Recommended: Disconnect in the cleanup function
     return () => ro.disconnect();
   }, []);
 

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.mdx
@@ -29,9 +29,9 @@ react-web-api/no-leaked-timeout
 
 Scheduling a timeout within the setup function of `useEffect` without canceling it in the cleanup function can lead to unwanted `setTimeout` callback executions and may also result in stale values captured by previous renders' effects after each subsequent re-render.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Setting timeout without cleanup in useEffect
 
 ```tsx
 import React, { useEffect, useState } from "react";
@@ -40,6 +40,7 @@ function MyComponent() {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
+    // Problem: A 'setTimeout' created in 'useEffect' must be cleared in the cleanup function.
     const timeoutId = setTimeout(() => console.log(count), 1000);
     //                ^^^ A 'setTimeout' created in 'useEffect' must be cleared in the cleanup function.
   }, []);
@@ -48,7 +49,7 @@ function MyComponent() {
 }
 ```
 
-### Valid
+### Clearing timeout in useEffect cleanup
 
 ```tsx
 import React, { useEffect, useState } from "react";
@@ -57,7 +58,9 @@ function MyComponent() {
   const [count, setCount] = useState(0);
 
   useEffect(() => {
+    // Recommended: Store the timeout ID
     const timeoutId = setTimeout(() => console.log(count), 1000);
+    // Recommended: Clear the timeout in the cleanup function
     return () => clearTimeout(timeoutId);
   }, []);
 

--- a/plugins/eslint-plugin-react-x/README.md
+++ b/plugins/eslint-plugin-react-x/README.md
@@ -1,6 +1,6 @@
 # eslint-plugin-react-x
 
-4-7x faster, composable ESLint rules for libraries and frameworks that use React as a UI runtime.
+Performant, composable ESLint rules for libraries and frameworks that use React as a UI runtime.
 
 ## Install
 

--- a/plugins/eslint-plugin-react-x/src/rules/error-boundaries/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/error-boundaries/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added spec documentation (`error-boundaries.spec.md`) documenting algorithms, validation rules, edge cases, and examples.
-- Added IMPL vs SPEC diff document (`error-boundaries.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`error-boundaries.spec.diff.md`) for tracking deviations from the React Compiler specification.
 
 ### Changed
 

--- a/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.mdx
@@ -3,13 +3,13 @@ title: error-boundaries
 description: Validates usage of Error Boundaries instead of try/catch for errors in child components.
 ---
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/error-boundaries
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/error-boundaries
@@ -31,12 +31,14 @@ Try/catch blocks can't catch errors that happen during React's rendering process
 
 Similarly, the `use` hook doesn't throw errors in the traditional sense — it suspends component execution. When `use` encounters a rejected promise, only Error Boundaries (and Suspense boundaries) can handle these cases. A catch block around `use` would never run.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Wrapping JSX in try/catch
+
+React's rendering is declarative. When you write `return <ChildComponent />`, you're describing what the UI should look like — you're not imperatively executing `ChildComponent`. If a child throws during rendering, React handles that error propagation internally through the component tree, bypassing any try/catch in JavaScript's call stack.
 
 ```tsx
-// ❌ Try/catch won't catch render errors from child components
+// Problem: try/catch cannot catch rendering errors in child components
 function Parent() {
   try {
     return <ChildComponent />;
@@ -48,7 +50,22 @@ function Parent() {
 ```
 
 ```tsx
-// ❌ Try/catch around `use` hook
+// Recommended: Use an Error Boundary to catch rendering errors
+function Parent() {
+  return (
+    <ErrorBoundary fallback={<div>Error occurred</div>}>
+      <ChildComponent />
+    </ErrorBoundary>
+  );
+}
+```
+
+### Using try/catch with the `use` hook
+
+The `use` hook doesn't throw errors in the traditional sense — it suspends component execution. When `use` encounters a pending promise, it suspends the component and lets React show a fallback. When the promise rejects, React propagates the error through the component tree to the nearest Error Boundary.
+
+```tsx
+// Problem: The catch block will never execute
 function Component({ promise }) {
   try {
     const data = use(promise);
@@ -60,21 +77,8 @@ function Component({ promise }) {
 }
 ```
 
-### Valid
-
 ```tsx
-// ✅ Using an Error Boundary to catch rendering errors
-function Parent() {
-  return (
-    <ErrorBoundary fallback={<div>Error occurred</div>}>
-      <ChildComponent />
-    </ErrorBoundary>
-  );
-}
-```
-
-```tsx
-// ✅ Error Boundary with Suspense for async data
+// Recommended: Use an Error Boundary with Suspense to handle async data
 function App() {
   return (
     <ErrorBoundary fallback={<div>Failed to load</div>}>
@@ -86,8 +90,12 @@ function App() {
 }
 ```
 
+### Non-rendering operations
+
+Try/catch is perfectly valid for synchronous operations like `JSON.parse`, `localStorage` access, or data transformations that happen before JSX is returned. It is also valid inside event handlers and effects. The rule only flags try/catch blocks that wrap JSX return statements or `use` hook calls inside component functions.
+
 ```tsx
-// ✅ Try/catch is fine for non-rendering operations
+// OK: Synchronous data processing
 function Component() {
   let data;
   try {
@@ -100,7 +108,7 @@ function Component() {
 ```
 
 ```tsx
-// ✅ Try/catch is fine inside event handlers and effects
+// OK: Error handling in event handlers
 function Component() {
   const handleClick = () => {
     try {
@@ -112,20 +120,6 @@ function Component() {
   return <button onClick={handleClick}>Click</button>;
 }
 ```
-
-## Troubleshooting
-
-### Why is the linter telling me not to wrap JSX in try/catch?
-
-React's rendering is declarative. When you write `return <ChildComponent />`, you're describing what the UI should look like — you're not imperatively executing `ChildComponent`. If `ChildComponent` throws during rendering, React handles that error propagation internally through the component tree, bypassing any try/catch in JavaScript's call stack. Only an Error Boundary (a class component with `componentDidCatch` or `getDerivedStateFromError`) can intercept these errors.
-
-### Why is the linter telling me not to wrap `use` in try/catch?
-
-The `use` hook doesn't throw errors in the traditional sense — it suspends component execution. When `use` encounters a pending promise, it suspends the component and lets React show a fallback. When the promise rejects, React propagates the error through the component tree to the nearest Error Boundary. The linter warns against try/catch around `use` because the catch block would never run.
-
-### What about try/catch for non-rendering logic?
-
-Try/catch is perfectly valid for synchronous operations like `JSON.parse`, `localStorage` access, or data transformations that happen _before_ JSX is returned. The rule only flags try/catch blocks that wrap JSX return statements or `use` hook calls inside component functions.
 
 ## Resources
 

--- a/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.spec.diff.md
@@ -1,4 +1,4 @@
-# error-boundaries IMPL vs. SPEC Report
+# error-boundaries IMPL–SPEC Diff Report
 
 **IMPL**: `error-boundaries.ts` (ESLint rule)\
 **SPEC**: `error-boundaries.spec.md` (React Compiler `ValidateNoJSXInTryStatement`)

--- a/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps/exhaustive-deps.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps/exhaustive-deps.mdx
@@ -3,13 +3,13 @@ title: exhaustive-deps
 description: Verifies the list of dependencies for Hooks like 'useEffect' and similar.
 ---
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/exhaustive-deps
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/exhaustive-deps
@@ -33,11 +33,13 @@ react-x/exhaustive-deps
 
 React hooks like `useEffect`, `useMemo`, and `useCallback` accept dependency arrays. When a value referenced inside these hooks is not included in the dependency array, React won't re-run the effect or recalculate the value when that dependency changes. This causes stale closures where the hook uses outdated values.
 
-## Common Violations
-
 If you find yourself fighting with this rule, you likely need to restructure your code rather than suppress the warning. See [Removing Effect Dependencies](https://react.dev/learn/removing-effect-dependencies) to learn how.
 
-### Invalid
+## Examples
+
+### Missing dependencies in `useEffect`
+
+When a prop or state value is used inside `useEffect` but omitted from the dependency array, the effect will see a stale value after the component re-renders.
 
 ```tsx
 import { useEffect } from "react";
@@ -51,6 +53,20 @@ function MyComponent({ userId }) {
 ```
 
 ```tsx
+import { useEffect } from "react";
+
+function MyComponent({ userId }) {
+  useEffect(() => {
+    fetchUser(userId);
+  }, [userId]);
+}
+```
+
+### Missing dependencies in `useMemo`
+
+`useMemo` will return a cached result until its dependencies change. Omitting a dependency means the memoized value won't update when that input changes.
+
+```tsx
 import { useMemo } from "react";
 
 function MyComponent({ items, sortOrder }) {
@@ -58,29 +74,6 @@ function MyComponent({ items, sortOrder }) {
     return items.sort(sortOrder);
     //                ^^^ 'sortOrder' is missing from the dependency array.
   }, [items]); // Missing 'sortOrder'
-}
-```
-
-```tsx
-import { useCallback } from "react";
-
-function MyComponent({ onSave, value }) {
-  const handleClick = useCallback(() => {
-    onSave(value);
-    //     ^^^ 'value' is missing from the dependency array.
-  }, [onSave]); // Missing 'value'
-}
-```
-
-### Valid
-
-```tsx
-import { useEffect } from "react";
-
-function MyComponent({ userId }) {
-  useEffect(() => {
-    fetchUser(userId);
-  }, [userId]);
 }
 ```
 
@@ -94,6 +87,21 @@ function MyComponent({ items, sortOrder }) {
 }
 ```
 
+### Missing dependencies in `useCallback`
+
+A `useCallback` with incomplete dependencies may call a handler with stale prop or state values.
+
+```tsx
+import { useCallback } from "react";
+
+function MyComponent({ onSave, value }) {
+  const handleClick = useCallback(() => {
+    onSave(value);
+    //     ^^^ 'value' is missing from the dependency array.
+  }, [onSave]); // Missing 'value'
+}
+```
+
 ```tsx
 import { useCallback } from "react";
 
@@ -104,14 +112,12 @@ function MyComponent({ onSave, value }) {
 }
 ```
 
-## Troubleshooting
-
 ### Adding a function dependency causes infinite loops
 
-When a function is defined in the component body, it is recreated on every render, causing the effect to re-run endlessly:
+When a function is defined in the component body, it is recreated on every render. Adding it to a dependency array causes the effect to re-run endlessly.
 
 ```tsx
-// ❌ Causes infinite loop — logItems is a new reference on every render
+// Problem: logItems is a new reference on every render, causing an infinite loop
 function MyComponent({ items }) {
   const logItems = () => {
     console.log(items);
@@ -126,7 +132,7 @@ function MyComponent({ items }) {
 In most cases, move the function call out of the effect or inline the logic directly:
 
 ```tsx
-// ✅ Inline the logic inside the effect
+// Recommended: Inline the logic directly into the effect
 function MyComponent({ items }) {
   useEffect(() => {
     console.log(items);
@@ -137,7 +143,7 @@ function MyComponent({ items }) {
 If the function is genuinely needed as a stable reference, wrap it with `useCallback`:
 
 ```tsx
-// ✅ useCallback keeps the function reference stable
+// Recommended: Use useCallback to keep the function reference stable
 function MyComponent({ items }) {
   const logItems = useCallback(() => {
     console.log(items);
@@ -151,10 +157,10 @@ function MyComponent({ items }) {
 
 ### Running an effect only once on mount
 
-You want to run an effect once on mount, but the linter complains about missing dependencies:
+You want to run an effect once on mount, but the linter complains about missing dependencies. Omitting a dependency that is used inside the effect means the effect will see a stale value when that prop changes.
 
 ```tsx
-// ❌ Missing dependency
+// Problem: missing dependency causes stale closure
 function MyComponent({ userId }) {
   useEffect(() => {
     sendAnalytics(userId);
@@ -165,7 +171,7 @@ function MyComponent({ userId }) {
 The recommended fix is to include the dependency. If `userId` changes and you want the effect to re-run, this is the correct behavior:
 
 ```tsx
-// ✅ Include the dependency
+// Recommended: Include all dependencies
 function MyComponent({ userId }) {
   useEffect(() => {
     sendAnalytics(userId);
@@ -176,7 +182,7 @@ function MyComponent({ userId }) {
 If you truly need to run once and read the latest value without reacting to changes, use a ref:
 
 ```tsx
-// ✅ Use a ref guard if you only want to run once
+// Recommended: Use a ref as a run-once guard
 function MyComponent({ userId }) {
   const sent = useRef(false);
 

--- a/plugins/eslint-plugin-react-x/src/rules/globals/globals.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/globals/globals.mdx
@@ -7,13 +7,13 @@ description: Validates against assignment/mutation of globals during render, par
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 
-**Full Name in [`eslint-plugin-react-x@rc`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/globals
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin@rc`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/globals
@@ -25,53 +25,25 @@ react-x/globals
 
 ## Rule Details
 
-Global variables exist outside React's control. When you modify them during render, you break React's assumption that rendering is pure. This can cause components to behave differently in development vs production, break Fast Refresh, and make your app impossible to optimize with features like React Compiler.
+Global variables exist outside React's control. When you modify them during render, you break React's assumption that rendering is pure. This can cause components to behave differently between development and production, break Fast Refresh, and make your app impossible to optimize with features like React Compiler.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Mutating module-level variables during render
+
+Module-level variables are shared across all component instances. Mutating them during render creates hidden shared state that React cannot track.
 
 ```tsx
-// ❌ Global counter
+// Problem: Global counter
 let renderCount = 0;
 function Component() {
-  renderCount++; // Mutating global
+  renderCount++; // Mutating a global variable during render
   return <div>Count: {renderCount}</div>;
 }
 ```
 
 ```tsx
-// ❌ Modifying window properties
-function Component({ userId }) {
-  window.currentUser = userId; // Global mutation
-  return <div>User: {userId}</div>;
-}
-```
-
-```tsx
-// ❌ Global array push
-const events = [];
-function Component({ event }) {
-  events.push(event); // Mutating global array
-  return <div>Events: {events.length}</div>;
-}
-```
-
-```tsx
-// ❌ Cache manipulation
-const cache = {};
-function Component({ id }) {
-  if (!cache[id]) {
-    cache[id] = fetchData(id); // Modifying cache during render
-  }
-  return <div>{cache[id]}</div>;
-}
-```
-
-### Valid
-
-```tsx
-// ✅ Use state for counters
+// Recommended: Use useState to manage the count
 function Component() {
   const [clickCount, setClickCount] = useState(0);
   const handleClick = () => {
@@ -85,21 +57,69 @@ function Component() {
 }
 ```
 
+### Modifying `window` or DOM globals during render
+
+Writing to browser globals during render causes side effects that leak outside the component and may behave differently between server and client.
+
 ```tsx
-// ✅ Use context for global values
+// Problem: Modifying a window property
+function Component({ userId }) {
+  window.currentUser = userId; // Global side effect
+  return <div>User: {userId}</div>;
+}
+```
+
+```tsx
+// Recommended: Sync external state in an effect
+function Component({ title }) {
+  useEffect(() => {
+    document.title = title; // Side effect moved out of the render phase
+  }, [title]);
+  return <div>Page: {title}</div>;
+}
+```
+
+### Mutating global arrays or objects
+
+Pushing to or modifying global collections during render makes their state unpredictable across renders and component instances.
+
+```tsx
+// Problem: Mutating a global array
+const events = [];
+function Component({ event }) {
+  events.push(event); // Global array mutation
+  return <div>Events: {events.length}</div>;
+}
+```
+
+```tsx
+// Recommended: Use Context to pass global values
 function Component() {
   const user = useContext(UserContext);
   return <div>User: {user.id}</div>;
 }
 ```
 
+### Cache manipulation during render
+
+Even caches that seem local can be mutated during render, making their contents depend on render order rather than predictable data flow.
+
 ```tsx
-// ✅ Synchronize external state with React
-function Component({ title }) {
-  useEffect(() => {
-    document.title = title; // OK in effect
-  }, [title]);
-  return <div>Page: {title}</div>;
+// Problem: Modifying a cache during render
+const cache = {};
+function Component({ id }) {
+  if (!cache[id]) {
+    cache[id] = fetchData(id); // Mutating the cache during render
+  }
+  return <div>{cache[id]}</div>;
+}
+```
+
+```tsx
+// Recommended: Use useMemo to compute and cache the value
+function Component({ id }) {
+  const data = useMemo(() => fetchData(id), [id]);
+  return <div>{data}</div>;
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/globals/globals.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/globals/globals.spec.diff.md
@@ -1,4 +1,4 @@
-# globals IMPL vs. SPEC Report
+# globals IMPL–SPEC Diff Report
 
 **IMPL**: `globals.ts` (ESLint rule)\
 **SPEC**: `globals.spec.md` (React Compiler `InferMutationAliasingEffects` — `StoreGlobal` / `MutateGlobal`)

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added spec documentation (`immutability.spec.md`) documenting algorithms, validation rules, edge cases, and examples.
-- Added IMPL vs SPEC diff document (`immutability.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`immutability.spec.diff.md`) for tracking deviations from the React Compiler specification.
 
 ### Changed
 

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
@@ -7,13 +7,13 @@ description: Validates against mutating props, state, and other values that are 
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/immutability
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/immutability
@@ -29,46 +29,26 @@ A component's props and state are immutable snapshots. Never mutate them directl
 
 Mutations are invisible to React — because the object or array reference hasn't changed, React has no way to know that something changed. As a result, the UI won't re-render, and your app will show stale data.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Adding items to an array
+
+Array methods like `push()` mutate the original array in place. React cannot detect this change because the array reference remains the same.
 
 ```tsx
-// ❌ Array push mutation
+// Problem: Mutating the array directly
 function Component() {
   const [items, setItems] = useState([1, 2, 3]);
   const addItem = () => {
-    items.push(4); // Mutating!
-    setItems(items); // Same reference, no re-render
+    items.push(4); // Directly mutating the original array
+    // ^^^ Do not call 'push()' on 'items'. Props and state are immutable — create a new array instead.
+    setItems(items); // Same reference, won't trigger a re-render
   };
 }
 ```
 
 ```tsx
-// ❌ Object property assignment
-function Component() {
-  const [user, setUser] = useState({ name: "Alice" });
-  const updateName = () => {
-    user.name = "Bob"; // Mutating!
-    setUser(user); // Same reference
-  };
-}
-```
-
-```tsx
-// ❌ Sort without spreading
-function Component() {
-  const [items, setItems] = useState([3, 1, 2]);
-  const sortItems = () => {
-    setItems(items.sort()); // sort mutates!
-  };
-}
-```
-
-### Valid
-
-```tsx
-// ✅ Create new array
+// Recommended: Create a new array
 function Component() {
   const [items, setItems] = useState([1, 2, 3]);
   const addItem = () => {
@@ -77,8 +57,24 @@ function Component() {
 }
 ```
 
+### Updating object properties
+
+Directly assigning to an object's property mutates the existing object. React compares object references, not their contents, so the update is ignored.
+
 ```tsx
-// ✅ Create new object
+// Problem: Mutating object properties directly
+function Component() {
+  const [user, setUser] = useState({ name: "Alice" });
+  const updateName = () => {
+    user.name = "Bob"; // Directly mutating the original object
+    // ^^^ Do not mutate 'user' directly. Props and state are immutable — create a new object instead.
+    setUser(user); // Same reference
+  };
+}
+```
+
+```tsx
+// Recommended: Create a new object
 function Component() {
   const [user, setUser] = useState({ name: "Alice" });
   const updateName = () => {
@@ -87,8 +83,22 @@ function Component() {
 }
 ```
 
+### Sorting or reversing lists
+
+`Array.prototype.sort()` and `Array.prototype.reverse()` mutate the array in place. If you call them directly on state, you mutate React's internal snapshot.
+
 ```tsx
-// ✅ Spread before sorting
+// Problem: sort mutates the original array
+function Component() {
+  const [items, setItems] = useState([3, 1, 2]);
+  const sortItems = () => {
+    setItems(items.sort()); // sort mutates the original array
+  };
+}
+```
+
+```tsx
+// Recommended: Spread into a new array before sorting
 function Component() {
   const [items, setItems] = useState([3, 1, 2]);
   const sortItems = () => {
@@ -97,82 +107,30 @@ function Component() {
 }
 ```
 
-## Troubleshooting
+### Updating nested objects
 
-### I need to add items to an array
-
-Mutating arrays with methods like `push()` won't trigger re-renders:
+Mutating nested properties doesn't change the top-level object reference, so React won't detect the update at any level.
 
 ```tsx
-// ❌ Wrong: Mutating the array
-function TodoList() {
-  const [todos, setTodos] = useState([]);
-  const addTodo = (id, text) => {
-    todos.push({ id, text });
-    setTodos(todos); // Same array reference!
-  };
-  return (
-    <ul>
-      {todos.map((todo) => (
-        <li key={todo.id}>{todo.text}</li>
-      ))}
-    </ul>
-  );
-}
-```
-
-Create a new array instead:
-
-```tsx
-// ✅ Better: Create a new array
-function TodoList() {
-  const [todos, setTodos] = useState([]);
-  const addTodo = (id, text) => {
-    setTodos([...todos, { id, text }]);
-    // Or: setTodos((todos) => [...todos, { id: Date.now(), text }])
-  };
-  return (
-    <ul>
-      {todos.map((todo) => (
-        <li key={todo.id}>{todo.text}</li>
-      ))}
-    </ul>
-  );
-}
-```
-
-### I need to update nested objects
-
-Mutating nested properties doesn't trigger re-renders:
-
-```tsx
-// ❌ Wrong: Mutating nested object
+// Problem: Mutating a nested object
 function UserProfile() {
   const [user, setUser] = useState({
     name: "Alice",
-    settings: {
-      theme: "light",
-      notifications: true,
-    },
+    settings: { theme: "light", notifications: true },
   });
   const toggleTheme = () => {
-    user.settings.theme = "dark"; // Mutation!
+    user.settings.theme = "dark"; // Mutating a nested property
     setUser(user); // Same object reference
   };
 }
 ```
 
-Spread at each level that needs updating:
-
 ```tsx
-// ✅ Better: Create new objects at each level
+// Recommended: Create new objects at every level
 function UserProfile() {
   const [user, setUser] = useState({
     name: "Alice",
-    settings: {
-      theme: "light",
-      notifications: true,
-    },
+    settings: { theme: "light", notifications: true },
   });
   const toggleTheme = () => {
     setUser({
@@ -186,12 +144,67 @@ function UserProfile() {
 }
 ```
 
-### I need to sort or reverse a list
+### Mutating props directly
 
-`Array.prototype.sort()` and `Array.prototype.reverse()` sort and reverse the array in place, mutating the original:
+Props are owned by the parent component. A child should never modify its props.
 
 ```tsx
-// ❌ Wrong: sort/reverse mutates the state array
+// Problem: Mutating props directly
+function Component(props) {
+  props.name = "Bob"; // Child components should not mutate props
+  // ^^^ Do not mutate 'props' directly. Props and state are immutable — create a new object instead.
+  return <div>{props.name}</div>;
+}
+```
+
+```tsx
+// Recommended: Notify the parent via a callback
+function Component({ name, onNameChange }) {
+  return <button onClick={() => onNameChange("Bob")}>{name}</button>;
+}
+```
+
+### Complete component examples
+
+Real components often mix state updates with JSX. Here are fuller examples showing how mutations silently break rendering in complete component contexts.
+
+```tsx
+// Problem: Mutating the array in a list component
+function TodoList() {
+  const [todos, setTodos] = useState([]);
+  const addTodo = (id, text) => {
+    todos.push({ id, text }); // Directly mutating the original array
+    setTodos(todos); // Same reference, won't trigger a re-render
+  };
+  return (
+    <ul>
+      {todos.map((todo) => (
+        <li key={todo.id}>{todo.text}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```tsx
+// Recommended: Create a new array so React detects the change
+function TodoList() {
+  const [todos, setTodos] = useState([]);
+  const addTodo = (id, text) => {
+    setTodos([...todos, { id, text }]); // New array
+  };
+  return (
+    <ul>
+      {todos.map((todo) => (
+        <li key={todo.id}>{todo.text}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```tsx
+// Problem: sort mutates the state array inside a button handler
 function SortedList() {
   const [items, setItems] = useState([3, 1, 2]);
   const sort = () => {
@@ -201,94 +214,14 @@ function SortedList() {
 }
 ```
 
-Spread into a new array first:
-
 ```tsx
-// ✅ Correct: spread into a new array before sorting
+// Recommended: Spread into a new array before sorting
 function SortedList() {
   const [items, setItems] = useState([3, 1, 2]);
   const sort = () => {
     setItems([...items].sort());
   };
   return <button onClick={sort}>Sort</button>;
-}
-```
-
-## Common Violations
-
-### Invalid
-
-```tsx
-import { useState } from "react";
-
-function Component() {
-  const [items, setItems] = useState([1, 2, 3]);
-  const addItem = () => {
-    items.push(4);
-    // ^^^ Do not call 'push()' on 'items'. Props and state are immutable — create a new array instead.
-    setItems(items);
-  };
-  return <div>{items.length}</div>;
-}
-```
-
-```tsx
-import { useState } from "react";
-
-function Component() {
-  const [user, setUser] = useState({ name: "Alice" });
-  const updateName = () => {
-    user.name = "Bob";
-    // ^^^ Do not mutate 'user' directly. Props and state are immutable — create a new object instead.
-    setUser(user);
-  };
-  return <div>{user.name}</div>;
-}
-```
-
-```tsx
-function Component(props) {
-  props.name = "Bob";
-  // ^^^ Do not mutate 'props' directly. Props and state are immutable — create a new object instead.
-  return <div>{props.name}</div>;
-}
-```
-
-### Valid
-
-```tsx
-import { useState } from "react";
-
-function Component() {
-  const [items, setItems] = useState([1, 2, 3]);
-  const addItem = () => {
-    setItems([...items, 4]); // ✅ New array
-  };
-  return <div>{items.length}</div>;
-}
-```
-
-```tsx
-import { useState } from "react";
-
-function Component() {
-  const [user, setUser] = useState({ name: "Alice" });
-  const updateName = () => {
-    setUser({ ...user, name: "Bob" }); // ✅ New object
-  };
-  return <div>{user.name}</div>;
-}
-```
-
-```tsx
-import { useState } from "react";
-
-function Component() {
-  const [items, setItems] = useState([3, 1, 2]);
-  const sortItems = () => {
-    setItems([...items].sort()); // ✅ Spread first, then sort
-  };
-  return <div>{items.length}</div>;
 }
 ```
 
@@ -302,7 +235,7 @@ Custom state hooks can also be configured via shared ESLint settings, which appl
 {
   "settings": {
     "react-x": {
-      "additionalStateHooks": "/^(useMyState|useCustomState)$/u",
+      "additionalStateHooks": "/^(useMyState|useCustomState)$/u"
     }
   }
 }

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.diff.md
@@ -1,4 +1,4 @@
-# immutability IMPL vs. SPEC Report
+# immutability IMPL–SPEC Diff Report
 
 **IMPL**: `immutability.ts` (ESLint rule)\
 **SPEC**: `immutability.spec.md` (React Compiler `ValidateNoFreezingKnownMutableFunctions`)

--- a/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.mdx
@@ -29,11 +29,14 @@ react-x/no-access-state-in-setstate
 
 Using `this.state` inside `setState` calls might result in errors when two state updates are batched, causing references to the old state rather than the current state.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Incrementing state based on the previous value
+
+When multiple `setState` calls are batched together, reading `this.state` directly may give you a stale value. The updater function receives the latest state as an argument, ensuring correctness even with batching.
 
 ```tsx
+// Problem: Reading this.state directly inside setState may get a stale value when batched
 import React from "react";
 
 interface MyComponentProps {}
@@ -56,9 +59,8 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: Use an updater function; React passes the latest state
 import React from "react";
 
 interface MyComponentProps {}

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.mdx
@@ -29,11 +29,14 @@ react-x/no-array-index-key
 
 The order of items in list rendering can change over time if an item is inserted, deleted, or the array is reordered. Using indexes as keys often leads to subtle, confusing errors.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Rendering a list with stable identities
+
+When your data items have a unique identifier, use it as the `key` so React can correctly track each element across reorders, insertions, and deletions.
 
 ```tsx
+// Problem: Using the array index as a key causes state issues when sorting, adding, or removing items
 interface MyComponentProps {
   items: { id: string; name: string }[];
 }
@@ -50,9 +53,8 @@ function MyComponent({ items }: MyComponentProps) {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: Use the data's own unique identifier as the key
 interface MyComponentProps {
   items: { id: string; name: string }[];
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.mdx
@@ -29,11 +29,14 @@ react-x/no-children-count
 
 Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Counting children to conditionally render
+
+Relying on `Children.count` makes your component tightly coupled to React's internal children representation. Instead, let the parent decide what to render or use standard JavaScript patterns.
 
 ```tsx
+// Problem: Using Children.count to determine the number of children
 import React, { Children } from "react";
 
 interface MyComponentProps {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.mdx
@@ -29,11 +29,14 @@ react-x/no-children-for-each
 
 Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Iterating over children to augment them
+
+Using `Children.forEach` to walk through and transform children is brittle because it relies on React's internal children structure. Prefer letting the parent handle iteration with standard array methods or restructuring your component API.
 
 ```tsx
+// Problem: Using Children.forEach to iterate over and transform children
 import React, { Children } from "react";
 
 interface MyComponentProps {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.mdx
@@ -29,11 +29,14 @@ react-x/no-children-map
 
 Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Wrapping each child in a layout element
+
+Using `Children.map` to wrap children assumes a specific React internals structure that may break. Instead, accept an array of data or let the parent map over items directly.
 
 ```tsx
+// Problem: Using Children.map to wrap each child in a styled container
 import React, { Children } from "react";
 
 interface MyComponentProps {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.mdx
@@ -29,11 +29,14 @@ react-x/no-children-only
 
 Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Enforcing a single child
+
+Using `Children.only` to assert that a component receives exactly one child is fragile. If you need to restrict children, consider documenting the prop type or using a different API design.
 
 ```tsx
+// Problem: Using Children.only to enforce a single child
 import React, { Children } from "react";
 
 interface MyComponentProps {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.mdx
@@ -29,11 +29,14 @@ react-x/no-children-to-array
 
 Using `Children.toArray` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Converting children to an array for manipulation
+
+Using `Children.toArray` to turn children into an array assumes internal React details that may change. If you need to reorder or filter items, accept structured data as props instead.
 
 ```tsx
+// Problem: Using Children.toArray to convert children into an array for manipulation
 import React, { Children } from "react";
 
 interface MyComponentProps {

--- a/plugins/eslint-plugin-react-x/src/rules/no-class-component/no-class-component.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-class-component/no-class-component.mdx
@@ -23,15 +23,18 @@ react-x/no-class-component
 
 ## Rule Details
 
-Component is the base class for React components defined as JavaScript classes. Class components are still supported by React, but we don’t recommend using them in new code.
+Component is the base class for React components defined as JavaScript classes. Class components are still supported by React, but we don't recommend using them in new code.
 
 We recommend defining components as functions instead of classes. [See how to migrate](https://react.dev/reference/react/Component#alternatives).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Writing a new component
+
+For new code, prefer function components with Hooks. They are simpler, easier to compose, and align with React's current direction.
 
 ```tsx
+// Problem: Using a class component for new logic
 import React from "react";
 
 interface MyComponentProps {
@@ -45,9 +48,8 @@ class MyComponent extends React.Component<MyComponentProps> {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: Use a function component instead
 interface MyComponentProps {
   name: string;
 }
@@ -57,14 +59,18 @@ function MyComponent({ name }: MyComponentProps) {
 }
 ```
 
+### Defining an error boundary
+
+Error boundaries must currently be implemented as class components because `componentDidCatch` and `getDerivedStateFromError` have no function-component equivalent. This is an allowed exception.
+
 ```tsx
+// OK: Error boundaries must be implemented as class components
 import React, { Component } from "react";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
 }
 
-// This is an exception to the rule, as ErrorBoundary is a special case.
 class ErrorBoundary extends Component<ErrorBoundaryProps> {
   state = { hasError: false };
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.mdx
@@ -29,11 +29,14 @@ react-x/no-clone-element
 
 Using `cloneElement` is uncommon and can lead to fragile code. It also makes it harder to trace data flow. Try the [alternatives](https://react.dev/reference/react/cloneElement#alternatives) instead.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Augmenting an element's props dynamically
+
+Using `cloneElement` to inject props into a child element hides the data flow and breaks component encapsulation. Prefer passing props explicitly through render props or composition patterns.
 
 ```tsx
+// Problem: Using cloneElement to dynamically inject props into a child element
 import { cloneElement } from "react";
 
 const clonedElement = cloneElement(

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount/no-component-will-mount.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount/no-component-will-mount.mdx
@@ -33,11 +33,14 @@ react-x/no-component-will-mount
 
 This API was renamed from `componentWillMount` to `UNSAFE_componentWillMount`. The old name has been deprecated. In a future major version of React, only the new name will work.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using the deprecated lifecycle name
+
+If your codebase still references `componentWillMount`, you should rename it to `UNSAFE_componentWillMount` to stay compatible with future React versions. Eventually, consider migrating side effects to `componentDidMount` or function components with `useEffect`.
 
 ```tsx
+// Problem: Using the deprecated componentWillMount name
 import React from "react";
 
 interface MyComponentProps {
@@ -51,9 +54,8 @@ class MyComponent extends React.Component<MyComponentProps> {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: Use UNSAFE_componentWillMount instead of the old name
 import React from "react";
 
 interface MyComponentProps {

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props/no-component-will-receive-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props/no-component-will-receive-props.mdx
@@ -33,13 +33,16 @@ react-x/no-component-will-receive-props
 
 This API was renamed from `componentWillReceiveProps` to `UNSAFE_componentWillReceiveProps`. The old name has been deprecated. In a future major version of React, only the new name will work.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using the legacy lifecycle method name in class components
+
+React has renamed `componentWillReceiveProps` to `UNSAFE_componentWillReceiveProps`. The old name will no longer work in future versions.
 
 ```tsx
 import React from "react";
 
+// Problem: Continuing to use the deprecated componentWillReceiveProps
 class MyComponent extends React.Component {
   componentWillReceiveProps() {
     // ...
@@ -47,11 +50,10 @@ class MyComponent extends React.Component {
 }
 ```
 
-### Valid
-
 ```tsx
 import React from "react";
 
+// Recommended: Use UNSAFE_componentWillReceiveProps instead
 class MyComponent extends React.Component {
   UNSAFE_componentWillReceiveProps() {
     // ...

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-update/no-component-will-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-update/no-component-will-update.mdx
@@ -33,13 +33,16 @@ react-x/no-component-will-update
 
 This API was renamed from `componentWillUpdate` to `UNSAFE_componentWillUpdate`. The old name is deprecated. In a future major version of React, only the new name will work.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using the legacy lifecycle method name in class components
+
+React has renamed `componentWillUpdate` to `UNSAFE_componentWillUpdate`. The old name will no longer work in future versions.
 
 ```tsx
 import React from "react";
 
+// Problem: Continuing to use the deprecated componentWillUpdate
 class MyComponent extends React.Component {
   componentWillUpdate() {
     // ...
@@ -47,11 +50,10 @@ class MyComponent extends React.Component {
 }
 ```
 
-### Valid
-
 ```tsx
 import React from "react";
 
+// Recommended: Use UNSAFE_componentWillUpdate instead
 class MyComponent extends React.Component {
   UNSAFE_componentWillUpdate() {
     // ...

--- a/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.mdx
@@ -37,13 +37,16 @@ In React 19, you can render `<Context>` as a provider instead of `<Context.Provi
   This rule works best in codebases that follow the [`naming-convention/context-name`](./naming-convention-context-name) rule.
 </Callout>
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using a Context Provider in React 19
+
+Starting from React 19, Context itself can be used directly as a provider, so you no longer need to write `.Provider`.
 
 ```tsx
 import ThemeContext from "./ThemeContext";
 
+// Problem: Continuing to use the legacy `<Context.Provider>` syntax
 function App({ children }) {
   return (
     <ThemeContext.Provider value="light">
@@ -53,11 +56,10 @@ function App({ children }) {
 }
 ```
 
-### Valid
-
 ```tsx
 import ThemeContext from "./ThemeContext";
 
+// Recommended: Use `<Context>` directly as a provider
 function App({ children }) {
   return (
     <ThemeContext value="dark">

--- a/plugins/eslint-plugin-react-x/src/rules/no-create-ref/no-create-ref.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-create-ref/no-create-ref.mdx
@@ -29,13 +29,16 @@ react-x/no-create-ref
 
 `createRef()` is a legacy API that is not recommended for use in new code. Instead, prefer using `useRef()` with function components.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using createRef in function components
+
+In function components, prefer the Hook `useRef` over `createRef`, which was designed for class components.
 
 ```tsx
 import React, { createRef } from "react";
 
+// Problem: Using createRef in a function component
 function MyComponent() {
   const ref = React.createRef<HTMLDivElement>();
   //          ^^^ [Deprecated] Use 'useRef' instead.
@@ -44,11 +47,10 @@ function MyComponent() {
 }
 ```
 
-### Valid
-
 ```tsx
 import React, { useRef } from "react";
 
+// Recommended: Use useRef in function components
 function MyComponent() {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -56,9 +58,14 @@ function MyComponent() {
 }
 ```
 
+### Using createRef in class components
+
+`createRef` can still be used in class components, which is the intended use of this API.
+
 ```tsx
 import React, { createRef } from "react";
 
+// OK: Using createRef in a class component is the intended use
 class MyComponent extends React.Component {
   inputRef = createRef();
   // ...

--- a/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.mdx
@@ -31,9 +31,11 @@ Never mutate `this.state` directly, as calling `setState()` afterward may replac
 
 The only place it's acceptable to assign `this.state` is in a class component's `constructor`.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Mutating this.state directly in an event handler
+
+Mutating `this.state` directly does not trigger a re-render, and a subsequent `setState` may overwrite the change.
 
 ```tsx
 import React from "react";
@@ -44,6 +46,7 @@ interface MyComponentState {
   foo: string;
 }
 
+// Problem: Assigning to this.state directly
 class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
   state = {
     foo: "bar",
@@ -64,8 +67,6 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 }
 ```
 
-### Valid
-
 ```tsx
 import React from "react";
 
@@ -75,6 +76,7 @@ interface MyComponentState {
   foo: string;
 }
 
+// Recommended: Update state via setState
 class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
   state = {
     foo: "bar",

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
@@ -27,11 +27,14 @@ react-x/no-duplicate-key
 
 React uses keys to identify elements in an array. If two elements have the same key, React will not be able to distinguish them. This can lead to issues with state and rendering.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Returning sibling elements with duplicate keys in an array
+
+When multiple elements in an array use the same `key`, React cannot distinguish them correctly.
 
 ```tsx
+// Problem: Duplicate keys on sibling elements in an array
 function MyComponent () {
   return [
     <li key="1">Item 1</li>
@@ -42,6 +45,21 @@ function MyComponent () {
 ```
 
 ```tsx
+// Recommended: Assign a unique key to each sibling element
+function MyComponent () {
+  return [
+    <li key="1">Item 1</li>
+    <li key="2">Item 2</li>
+  ]
+};
+```
+
+### Writing sibling elements with duplicate keys in JSX
+
+Sibling elements written directly in JSX with the same key will also cause React identification issues.
+
+```tsx
+// Problem: Duplicate keys on sibling elements in JSX
 function MyComponent() {
   return (
     <ul>
@@ -54,28 +72,7 @@ function MyComponent() {
 ```
 
 ```tsx
-function MyComponent() {
-  return (
-    <ul>
-      {["a", "b"].map((id) => <li key="1">{id}</li>)}
-    </ul>
-  );
-  //                                     ^^^ The 'key' prop must be unique to its sibling elements.
-}
-```
-
-### Valid
-
-```tsx
-function MyComponent () {
-  return [
-    <li key="1">Item 1</li>
-    <li key="2">Item 2</li>
-  ]
-};
-```
-
-```tsx
+// Recommended: Ensure keys are unique among sibling elements
 function MyComponent() {
   return (
     <ul>
@@ -86,7 +83,24 @@ function MyComponent() {
 }
 ```
 
+### Using a fixed key value in a map loop
+
+Using a fixed string as a key in loops like `map` causes every iteration to produce elements with the same key.
+
 ```tsx
+// Problem: All elements in a map loop use the same key
+function MyComponent() {
+  return (
+    <ul>
+      {["a", "b"].map((id) => <li key="1">{id}</li>)}
+      //                                     ^^^ The 'key' prop must be unique to its sibling elements.
+    </ul>
+  );
+}
+```
+
+```tsx
+// Recommended: Use a unique identifier from the data as the key
 function MyComponent() {
   return (
     <ul>

--- a/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.mdx
@@ -35,17 +35,31 @@ In React 19, `forwardRef` is no longer necessary. Pass `ref` as a prop instead.
 
 `forwardRef` will be deprecated in a future release. Learn more [here](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Wrapping function components with forwardRef
+
+Starting from React 19, you can pass `ref` as a regular prop directly, without using `forwardRef`.
 
 ```tsx
 import React, { forwardRef } from "react";
 
+// Problem: Using forwardRef to pass ref
 const MyInput = forwardRef(function MyInput(props, ref) {
   return <input ref={ref} {...props} />;
 });
 ```
+
+```tsx
+// Recommended: Receive ref as a regular prop
+function MyInput({ ref, ...props }) {
+  return <input ref={ref} {...props} />;
+}
+```
+
+### Using typed React.forwardRef
+
+Even with TypeScript generics, `forwardRef` can be replaced with a simpler props-based approach.
 
 ```tsx
 import React from "react";
@@ -55,6 +69,7 @@ interface MyInputProps {
   onChange: (value: string) => void;
 }
 
+// Problem: Using React.forwardRef with generic parameters
 const MyInput = React.forwardRef<MyInputProps, HTMLInputElement>(
   function MyInput({ value, onChange }, ref) {
     return (
@@ -68,14 +83,6 @@ const MyInput = React.forwardRef<MyInputProps, HTMLInputElement>(
 );
 ```
 
-### Valid
-
-```tsx
-function MyInput({ ref, ...props }) {
-  return <input ref={ref} {...props} />;
-}
-```
-
 ```tsx
 import React from "react";
 
@@ -84,6 +91,7 @@ interface MyInputProps {
   onChange: (value: string) => void;
 }
 
+// Recommended: Declare ref directly in the props type
 function MyInput({
   ref,
   value,

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
@@ -32,49 +32,61 @@ The following cases are **allowed** and will not be reported:
 1. The `children` property originates from React's own type definitions (ex: `React.DOMAttributes.children`, `React.PropsWithChildren.children`), such as when spreading `React.ComponentProps<"div">`, `React.HTMLAttributes<T>`, `React.PropsWithChildren<T>`, or similar React-provided types.
 2. The `children` property's **type** is a React-defined children type alias, such as `React.ReactNode`, `React.ReactElement`, `React.ReactPortal`, or `JSX.Element`, even if the property is declared in a user-defined type.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Implicitly passing children via the spread operator
+
+Spreading an object that contains `children` directly onto a component makes the source of `children` unclear.
 
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; children: string };
 
+// Problem: Implicitly passing children when spreading an object
 function MyComponent() {
   return <div {...someValues} />;
   //          ^^^ This spread attribute implicitly passes the 'children' prop to a component, this could lead to unexpected behavior. If you intend to pass the 'children' prop, use 'children={value}'.
 }
 ```
 
-### Valid
-
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; children: string };
 
+// Recommended: Explicitly destructure and pass children
 function MyComponent() {
   const { children, ...rest } = someValues;
-  //      ^^^ Dropping the 'children' prop from the spread attributes to prevent implicitly passing it to the component.
   return <div {...rest}>{children}</div>;
+  //      ^^^ Dropping the 'children' prop from the spread attributes to prevent implicitly passing it to the component.
 }
 ```
+
+### children type is a React built-in type
+
+When the `children` type is a React built-in children type alias, spreading is allowed.
 
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; children: React.ReactNode };
 
+// OK: children type is React.ReactNode, which is a React built-in type alias
 function MyComponent() {
   return <div {...someValues} data-slot="my-component" />;
   //          ^^^ The 'children' property is typed as React.ReactNode, which is a React-defined type alias. Allowed.
 }
 ```
 
+### Spreading React built-in component props
+
+When spreading props from React built-in types (such as `React.ComponentProps`), the `children` originates from React's type definitions and is allowed.
+
 ```tsx
 import React from "react";
 
+// OK: props come from React.ComponentProps, children originates from React.DOMAttributes
 function PaginationItem({ ...props }: React.ComponentProps<"li">) {
   return <li data-slot="pagination-item" {...props} />;
   //                                     ^^^ The 'children' property originates from React.DOMAttributes.children. Allowed.

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.mdx
@@ -34,49 +34,61 @@ The following cases are **allowed** and will not be reported:
 1. The `key` property originates from React's own type definitions (ex: `React.Attributes.key`), such as when spreading `React.ComponentProps<"div">`, `React.HTMLAttributes<T>`, or similar React-provided types.
 2. The `key` property's **type** is `React.Key`, even if the property is declared in a user-defined type.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Implicitly passing key via the spread operator
+
+Spreading an object that contains `key` directly onto a component makes the source and purpose of `key` unclear.
 
 ```tsx
 import React from "react";
 
 declare let someValues: { foo: string; bar: string; key: string };
 
+// Problem: Implicitly passing key when spreading an object
 function MyComponent() {
   return <div {...someValues} />;
   //          ^^^ This spread attribute implicitly passes the 'key' prop to a component, this could lead to unexpected behavior. If you intend to pass the 'key' prop, use 'key={value}'.
 }
 ```
 
-### Valid
-
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; key: string };
 
+// Recommended: Explicitly destructure and pass key
 function MyComponent() {
   const { key, ...rest } = someValues;
-  //      ^^^ Dropping the 'key' prop from the spread attributes to prevent implicitly passing it to the component.
   return <div key={key} {...rest} />;
+  //      ^^^ Dropping the 'key' prop from the spread attributes to prevent implicitly passing it to the component.
 }
 ```
+
+### key type is React.Key
+
+When the `key` type is the React built-in `React.Key`, spreading is allowed.
 
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; key: React.Key };
 
+// OK: key type is React.Key, which is a React built-in type
 function MyComponent() {
   return <div {...someValues} data-slot="pagination-item" />;
   //          ^^^ The 'key' property is typed as React.Key, which is a React-defined type alias. Allowed.
 }
 ```
 
+### Spreading React built-in component props
+
+When spreading props from React built-in types (such as `React.ComponentProps`), the `key` originates from React's type definitions and is allowed.
+
 ```tsx
 import React from "react";
 
+// OK: props come from React.ComponentProps, key originates from React.Attributes
 function PaginationItem({ ...props }: React.ComponentProps<"li">) {
   return <li data-slot="pagination-item" {...props} />;
   //                                     ^^^ The 'key' property originates from React.Attributes.key. Allowed.

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
@@ -32,49 +32,61 @@ The following cases are **allowed** and will not be reported:
 1. The `ref` property originates from React's own type definitions (ex: `React.ClassAttributes.ref`), such as when spreading `React.ComponentProps<"div">`, `React.HTMLAttributes<T>`, or similar React-provided types.
 2. The `ref` property's **type** is a React-defined ref type alias, such as `React.Ref`, `React.RefObject`, `React.RefCallback`, or `React.LegacyRef`, even if the property is declared in a user-defined type.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Implicitly passing ref via the spread operator
+
+Spreading an object that contains `ref` directly onto a component makes the source and target of `ref` unclear.
 
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; ref: null };
 
+// Problem: Implicitly passing ref when spreading an object
 function MyComponent() {
   return <div {...someValues} />;
   //          ^^^ This spread attribute implicitly passes the 'ref' prop to a component, this could lead to unexpected behavior. If you intend to pass the 'ref' prop, use 'ref={value}'.
 }
 ```
 
-### Valid
-
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; ref: null };
 
+// Recommended: Explicitly destructure and pass ref
 function MyComponent() {
   const { ref, ...rest } = someValues;
-  //      ^^^ Dropping the 'ref' prop from the spread attributes to prevent implicitly passing it to the component.
   return <div ref={ref} {...rest} />;
+  //      ^^^ Dropping the 'ref' prop from the spread attributes to prevent implicitly passing it to the component.
 }
 ```
+
+### ref type is a React built-in ref type
+
+When the `ref` type is a React built-in ref type alias, spreading is allowed.
 
 ```tsx
 import React from "react";
 
 declare let someValues: { id: string; className: string; ref: React.Ref<HTMLDivElement> };
 
+// OK: ref type is React.Ref, which is a React built-in type alias
 function MyComponent() {
   return <div {...someValues} data-slot="pagination-item" />;
   //          ^^^ The 'ref' property is typed as React.Ref, which is a React-defined type alias. Allowed.
 }
 ```
 
+### Spreading React built-in component props
+
+When spreading props from React built-in types (such as `React.ComponentProps`), the `ref` originates from React's type definitions and is allowed.
+
 ```tsx
 import React from "react";
 
+// OK: props come from React.ComponentProps, ref originates from React.ClassAttributes
 function PaginationItem({ ...props }: React.ComponentProps<"li">) {
   return <li data-slot="pagination-item" {...props} />;
   //                                     ^^^ The 'ref' property originates from React.ClassAttributes.ref. Allowed.

--- a/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.mdx
@@ -28,11 +28,12 @@ react-x/no-leaked-conditional-rendering
 
 Using the `&&` operator to render an element conditionally in JSX can cause unexpected values to be rendered or even crash the rendering.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using a number directly as a condition
 
 ```tsx
+// Problem: When count is 0, 0 will be rendered directly on the page
 interface MyComponentProps {
   count: number;
 }
@@ -44,6 +45,20 @@ function MyComponent({ count }: MyComponentProps) {
 ```
 
 ```tsx
+// Recommended: Use a comparison expression or ternary operator to ensure only boolean evaluation results are rendered
+interface MyComponentProps {
+  count: number;
+}
+
+function MyComponent({ count }: MyComponentProps) {
+  return <div>{count > 0 && <span>There are {count} results</span>}</div>;
+}
+```
+
+### Using array length as a condition
+
+```tsx
+// Problem: When items.length is 0, 0 may leak into the DOM
 interface MyComponentProps {
   items: string[];
 }
@@ -55,77 +70,7 @@ function MyComponent({ items }: MyComponentProps) {
 ```
 
 ```tsx
-interface MyComponentProps {
-  items: string[];
-}
-
-function MyComponent({ items }: MyComponentProps) {
-  return <div>{items[0] && <List items={items} />}</div>;
-  //           ^^^ Potential leaked value 'items[0]' that might cause unintentionally rendered values or rendering crashes.
-}
-```
-
-```tsx
-interface MyComponentProps {
-  numberA: number;
-  numberB: number;
-}
-
-function MyComponent({ numberA, numberB }: MyComponentProps) {
-  return (
-    <div>{(numberA || numberB) && <Results>{numberA + numberB}</Results>}</div>
-    //    ^^^ Potential leaked value '(numberA || numberB)' that might cause unintentionally rendered values or rendering crashes.
-  );
-}
-```
-
-### Valid
-
-```tsx
-interface MyComponentProps {
-  items: string[];
-}
-
-function MyComponent({ items }: MyComponentProps) {
-  return <div>{items}</div>;
-}
-```
-
-```tsx
-interface MyComponentProps {
-  customTitle: string;
-}
-
-const defaultTitle = "Default Title";
-
-// An OR condition is considered valid since it's assumed to be a way to render some fallback if the first value is falsy, not to render something conditionally.
-function MyComponent({ customTitle }: MyComponentProps) {
-  return <div>{customTitle || defaultTitle}</div>;
-}
-```
-
-```tsx
-interface MyComponentProps {
-  items: string[];
-}
-
-function MyComponent({ items }: MyComponentProps) {
-  return <div>There are {items.length} items</div>;
-}
-```
-
-```tsx
-interface MyComponentProps {
-  items: string[];
-  count: number;
-}
-
-function MyComponent({ items, count }: MyComponentProps) {
-  return <div>{!count && "No results found"}</div>;
-}
-```
-
-```tsx
+// Recommended: Use !!, Boolean(), or a comparison expression to avoid leaking
 interface MyComponentProps {
   items: string[];
 }
@@ -172,6 +117,89 @@ interface MyComponentProps {
 
 function MyComponent({ items }: MyComponentProps) {
   return <div>{items.length ? <List items={items} /> : <EmptyList />}</div>;
+}
+```
+
+### Using an array element as a condition
+
+```tsx
+// Problem: When items\[0] is an empty string or 0, that value may be rendered unexpectedly
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent({ items }: MyComponentProps) {
+  return <div>{items[0] && <List items={items} />}</div>;
+  //           ^^^ Potential leaked value 'items[0]' that might cause unintentionally rendered values or rendering crashes.
+}
+```
+
+### Using a logical OR expression as a condition
+
+```tsx
+// Problem: (numberA || numberB) may return 0 or another falsy value and leak onto the page
+interface MyComponentProps {
+  numberA: number;
+  numberB: number;
+}
+
+function MyComponent({ numberA, numberB }: MyComponentProps) {
+  return (
+    <div>{(numberA || numberB) && <Results>{numberA + numberB}</Results>}</div>
+    //    ^^^ Potential leaked value '(numberA || numberB)' that might cause unintentionally rendered values or rendering crashes.
+  );
+}
+```
+
+### Rendering arrays or strings directly
+
+```tsx
+// OK: Directly rendering values known to be React nodes does not require conditional checks
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent({ items }: MyComponentProps) {
+  return <div>{items}</div>;
+}
+```
+
+```tsx
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent({ items }: MyComponentProps) {
+  return <div>There are {items.length} items</div>;
+}
+```
+
+### Using a default value fallback
+
+```tsx
+// OK: Using `||` to provide a fallback value is a common default-value pattern, not conditional rendering
+interface MyComponentProps {
+  customTitle: string;
+}
+
+const defaultTitle = "Default Title";
+
+function MyComponent({ customTitle }: MyComponentProps) {
+  return <div>{customTitle || defaultTitle}</div>;
+}
+```
+
+### Using negation for conditional rendering
+
+```tsx
+// OK: When the condition expression explicitly produces a boolean result, no value will leak
+interface MyComponentProps {
+  items: string[];
+  count: number;
+}
+
+function MyComponent({ items, count }: MyComponentProps) {
+  return <div>{!count && "No results found"}</div>;
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name/no-missing-component-display-name.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name/no-missing-component-display-name.mdx
@@ -19,11 +19,12 @@ react-x/no-missing-component-display-name
 
 When defining a React component, if you specify its component name in a way that React can't infer its `displayName`, it will show up as an `anonymous` component in DevTools, which makes debugging more difficult.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Wrapping an anonymous arrow function with React.memo
 
 ```tsx
+// Problem: React cannot infer displayName from an anonymous arrow function; it will show as anonymous in DevTools
 import React from "react";
 
 const Button = React.memo(() => <div />);
@@ -31,24 +32,7 @@ const Button = React.memo(() => <div />);
 ```
 
 ```tsx
-import React from "react";
-
-const Button = React.forwardRef(() => <div />);
-//                              ^^^ Add missing 'displayName' for component.
-```
-
-(Not supported yet)
-
-```tsx
-import React from "react";
-
-export default () => <div />;
-//             ^^^ Add missing 'displayName' for component.
-```
-
-### Valid
-
-```tsx
+// Recommended: Use a named function or manually add displayName after assignment
 import React from "react";
 
 const Button = React.memo(function Button() {
@@ -63,7 +47,18 @@ const Button = React.memo(() => <div />);
 Button.displayName = "Button";
 ```
 
+### Wrapping an anonymous arrow function with React.forwardRef
+
 ```tsx
+// Problem: When forwardRef wraps an anonymous function, React cannot automatically infer the component name
+import React from "react";
+
+const Button = React.forwardRef(() => <div />);
+//                              ^^^ Add missing 'displayName' for component.
+```
+
+```tsx
+// Recommended: Use a named function or manually set the displayName property
 import React from "react";
 
 const Button = React.forwardRef(function Button() {
@@ -78,7 +73,18 @@ const Button = React.forwardRef(() => <div />);
 Button.displayName = "Button";
 ```
 
+### Default exporting an anonymous arrow function
+
 ```tsx
+// Problem: When default-exporting an anonymous function, the component has no recognizable name in DevTools
+import React from "react";
+
+export default () => <div />;
+//             ^^^ Add missing 'displayName' for component.
+```
+
+```tsx
+// Recommended: Change the default export to a named function declaration
 import React from "react";
 
 export default function Button() {

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.mdx
@@ -23,19 +23,21 @@ react-x/no-missing-context-display-name
 
 Context `displayName` property is used by React DevTools to identify the context in the component tree. Without it, debugging becomes difficult as contexts appear as "Context" or "Context.Provider" without any distinguishing information.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Creating a Context without setting displayName
 
 ```tsx
+// Problem: Different contexts cannot be distinguished in React DevTools, making debugging difficult
 import React from "react";
 
 const MyContext = React.createContext();
 ```
 
-### Valid
+### Creating a Context and adding displayName
 
 ```tsx
+// Recommended: Assign displayName immediately after creating the Context so it can be identified in DevTools
 import React from "react";
 
 const MyContext = React.createContext();

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.mdx
@@ -29,11 +29,12 @@ react-x/no-missing-key
 
 React needs keys to identify items in the list. If you don’t specify a key, React will use the array index as a key, which often leads to subtle and confusing bugs.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Missing key in list rendering
 
 ```tsx
+// Problem: When a key is missing, React uses the array index as the default key, which can lead to state mismatch or performance issues
 interface MyComponentProps {
   items: { id: number; name: string }[];
 }
@@ -47,9 +48,10 @@ function MyComponent({ items }: MyComponentProps) {
 }
 ```
 
-### Valid
+### Using a unique key in list rendering
 
 ```tsx
+// Recommended: Provide a stable and unique key for each item in the list to help React correctly track element identity
 interface MyComponentProps {
   items: { id: number; name: string }[];
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.mdx
@@ -37,11 +37,12 @@ react-x/no-misused-capture-owner-stack
 2. Conditionally accessed within an `if (process.env.NODE_ENV !== 'production') { ... }` block to prevent execution in production environments.
 3. Called inside a React-controlled function (**not implemented yet**).
 
-## Common Violations
+## Examples
 
-### Invalid
+### Directly importing captureOwnerStack as a named import
 
 ```tsx
+// Problem: Named imports may cause errors when bundled for production; use a namespace import instead
 // Failing: Using a named import directly
 import { captureOwnerStack } from "react";
 //       ^^^ Don't use named imports of `captureOwnerStack` in files that are bundled for development and production. Use a namespace import instead.
@@ -52,7 +53,10 @@ if (process.env.NODE_ENV !== "production") {
 }
 ```
 
+### Calling directly without an environment check
+
 ```tsx
+// Problem: captureOwnerStack is only available in development builds; calling it directly in production will cause errors
 // Failing: Missing environment check
 import * as React from "react";
 
@@ -61,9 +65,10 @@ const ownerStack = React.captureOwnerStack();
 console.log(ownerStack);
 ```
 
-### Valid
+### Correctly using a namespace import with an environment check
 
 ```tsx
+// Recommended: Import via a namespace and call inside a non-production environment block
 // Passing: Correct namespace import with environment check
 import * as React from "react";
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/no-nested-component-definitions.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/no-nested-component-definitions.mdx
@@ -38,11 +38,12 @@ When a component is defined inside another component:
 
 Instead, define every component at the top level.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Nesting a child component definition inside another component
 
 ```tsx
+// Problem: Profile is recreated on every render of Gallery, causing child component state loss and preventing memo optimization
 function Gallery() {
   // 🔴 Never define a component inside another component!
   function Profile() {
@@ -52,9 +53,10 @@ function Gallery() {
 }
 ```
 
-### Valid
+### Defining components at the top level of the module and passing data via props
 
 ```tsx
+// Recommended: Define all components at the top level; pass data via props when needed
 // ✅ Declare components at the top level
 function Gallery() {
   // ...

--- a/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations/no-nested-lazy-component-declarations.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations/no-nested-lazy-component-declarations.mdx
@@ -36,27 +36,27 @@ When a component is defined inside another component:
 - It defeats props memoization and optimization techniques
 - It creates new function references on every render
 
-## Common Violations
+## Examples
 
-### Invalid
+### Declaring lazy components inside a component
 
 ```tsx
+// Problem: Declaring MarkdownPreview inside Editor causes the lazy component to be recreated on every render, resetting its state unexpectedly
 import { lazy } from "react";
 
 function Editor() {
-  // 🔴 Bad: This will cause all state to be reset on re-renders
   const MarkdownPreview = lazy(() => import("./MarkdownPreview.js"));
   //    ^^^ Do not declare lazy components inside other components. Instead, always declare them at the top level of your module.
   // ...
 }
 ```
 
-### Valid
+### Declaring lazy components at the module level
 
 ```tsx
+// Recommended: Declare lazy components at the module level to keep references stable and state persistent
 import { lazy } from "react";
 
-// ✅ Good: Declare lazy components outside of your components
 const MarkdownPreview = lazy(() => import("./MarkdownPreview.js"));
 
 function Editor() {

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.mdx
@@ -29,11 +29,12 @@ react-x/no-set-state-in-component-did-mount
 
 Updating the state after a component mounts will trigger a second `render()` call and can lead to property/layout thrashing.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Calling setState directly in componentDidMount
 
 ```tsx
+// Problem: Calling setState directly in componentDidMount triggers an extra render and can cause performance issues and layout thrashing
 import React from "react";
 
 interface MyComponentProps {}

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.mdx
@@ -29,11 +29,12 @@ react-x/no-set-state-in-component-did-update
 
 Updating the state after a component mounts will trigger a second `render()` call and can lead to property/layout thrashing.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Calling setState directly in componentDidUpdate
 
 ```tsx
+// Problem: Calling setState directly in componentDidUpdate triggers another render and can easily cause infinite loops or layout thrashing
 import React from "react";
 
 interface MyComponentProps {}

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.mdx
@@ -29,11 +29,12 @@ react-x/no-set-state-in-component-will-update
 
 Updating the state after a component mounts will trigger a second `render()` call and can lead to property/layout thrashing.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Calling setState directly in componentWillUpdate
 
 ```tsx
+// Problem: Calling setState directly in componentWillUpdate triggers another render and can easily cause infinite loops or layout thrashing
 import React from "react";
 
 interface MyComponentProps {}

--- a/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/no-unnecessary-use-prefix.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/no-unnecessary-use-prefix.mdx
@@ -26,48 +26,56 @@ react-x/no-unnecessary-use-prefix
 
 ## Rule Details
 
-If your function doesn’t call any Hooks, avoid the `use` prefix. Instead, write it as a regular function without the `use` prefix. For example, `useSorted` below doesn’t call Hooks, so call it `getSorted` instead:
+If your function doesn't call any Hooks, avoid the `use` prefix and write it as a regular function. This allows the function to be called anywhere, including in conditions. You should only use the `use` prefix when the function calls at least one Hook inside it.
+
+Technically, React does not enforce this. In principle, you could make a Hook that doesn't call other Hooks, but this is often confusing and limiting. However, there may be rare cases where it is helpful, such as when you plan to add Hook calls in the future. In that case, naming it with the `use` prefix makes sense so that components won't be able to call it conditionally once Hooks are added. If you don't plan to use Hooks inside it (now or later), don't make it a Hook.
+
+## Examples
+
+### Using the `use` prefix without calling any Hooks
+
+Functions with the `use` prefix are treated as Hooks and must follow Hook rules (for example, they cannot be called conditionally). If a function doesn't call any Hooks, remove the `use` prefix and make it a regular function.
 
 ```tsx
-// 🔴 Avoid: A Hook that doesn't use Hooks
+// Problem: The function doesn't call any Hooks but uses the use prefix
 function useSorted(items) {
   return items.slice().sort();
 }
 ```
 
 ```tsx
-// ✅ Good: A regular function that doesn't use Hooks
+// Recommended: Convert it to a regular function so it can be called anywhere
 function getSorted(items) {
   return items.slice().sort();
 }
 ```
 
-This ensures that your code can call this regular function anywhere, including in conditions:
+As a regular function, it can safely be called inside conditional statements:
 
 ```tsx
+// OK: Regular functions allow conditional calls
 function List({ items, shouldSort }) {
   let displayedItems = items;
   if (shouldSort) {
-    // ✅ It's OK to call getSorted() conditionally because it's not a Hook
     displayedItems = getSorted(items);
   }
   // ...
 }
 ```
 
-You should give the `use` prefix to a function (and thus make it a Hook) if it uses at least one Hook inside it:
+### Not using Hooks now, but planning to add them later
+
+If a function doesn't currently call any Hooks but you plan to add Hook calls later, you can keep the `use` prefix. It's recommended to add a TODO comment explaining your intent to avoid false positives.
 
 ```tsx
-// ✅ Good: A Hook that uses other Hooks
+// Problem: No Hooks are used and there is no comment explaining future plans
 function useAuth() {
-  return useContext(Auth);
+  return TEST_USER;
 }
 ```
 
-Technically, this isn’t enforced by React. In principle, you could make a Hook that doesn’t call other Hooks. This is often confusing and limiting, so it's best to avoid that pattern. However, there may be rare cases where it is helpful. For example, maybe your function doesn’t use any Hooks right now but you plan to add some Hook calls to it in the future. Then it makes sense to name it with the `use` prefix:
-
 ```tsx
-// ✅ Good: A Hook that will likely use some other Hooks later
+// Recommended: Add an explicit TODO explaining it will be replaced with a Hook later
 function useAuth() {
   // TODO: Replace with this line when authentication is implemented:
   // return useContext(Auth);
@@ -75,48 +83,23 @@ function useAuth() {
 }
 ```
 
-Then components won’t be able to call it conditionally. This will become important when you actually add Hook calls inside. If you don’t plan to use Hooks inside it (now or later), don’t make it a Hook.
+### The function does call other Hooks
 
-## Common Violations
-
-### Invalid
+When a function calls Hooks internally, using the `use` prefix is correct and necessary.
 
 ```tsx
-function useSorted(items) {
-  return items.slice().sort();
-}
-```
-
-```tsx
-// No 'TODO' and 'useContext()' comments inside function body
-function useAuth() {
-  return TEST_USER;
-}
-```
-
-### Valid
-
-```tsx
-function getSorted(items) {
-  return items.slice().sort();
-}
-```
-
-```tsx
+// Recommended: Uses useContext, which follows Hook naming conventions
 function useAuth() {
   return useContext(Auth);
 }
 ```
 
-```tsx
-function useAuth() {
-  // TODO: Replace with this line when authentication is implemented:
-  // return useContext(Auth);
-  return TEST_USER;
-}
-```
+### MDX component factory functions
+
+Some framework conventions (such as MDX) require factory functions with the `use` prefix. These functions are acceptable even if they don't call any Hooks.
 
 ```tsx
+// OK: Component mapping function that follows MDX conventions
 export function useMDXComponents(components) {
   return {
     ...components,

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount/no-unsafe-component-will-mount.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount/no-unsafe-component-will-mount.mdx
@@ -27,13 +27,16 @@ react-x/no-unsafe-component-will-mount
 
 ## Rule Details
 
-Using unsafe lifecycle methods like `UNSAFE_componentWillMount` makes your component's behavior less predictable and more likely to cause bugs.
+Using unsafe lifecycle methods like `UNSAFE_componentWillMount` makes your component's behavior less predictable and more likely to cause bugs. Consider using `constructor` or `componentDidMount` instead.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `UNSAFE_componentWillMount` in class components
+
+`UNSAFE_componentWillMount` is a deprecated lifecycle method and may be removed in a future version of React. Initialization logic should go in the `constructor`, and side effects should go in `componentDidMount`.
 
 ```tsx
+// Problem: Uses an unsafe lifecycle method
 import React from "react";
 
 class MyComponent extends React.Component {

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props/no-unsafe-component-will-receive-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props/no-unsafe-component-will-receive-props.mdx
@@ -27,13 +27,16 @@ react-x/no-unsafe-component-will-receive-props
 
 ## Rule Details
 
-Using unsafe lifecycle methods like `UNSAFE_componentWillReceiveProps` makes your component's behavior less predictable and more likely to cause bugs.
+Using unsafe lifecycle methods like `UNSAFE_componentWillReceiveProps` makes your component's behavior less predictable and more likely to cause bugs. Consider using `getDerivedStateFromProps` or `componentDidUpdate` instead.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `UNSAFE_componentWillReceiveProps` in class components
+
+`UNSAFE_componentWillReceiveProps` is a deprecated lifecycle method. If you need to update state when props change, use the static method `getDerivedStateFromProps`; if you need to perform side effects, use `componentDidUpdate`.
 
 ```tsx
+// Problem: Uses an unsafe lifecycle method
 import React from "react";
 
 class MyComponent extends React.Component {

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update/no-unsafe-component-will-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update/no-unsafe-component-will-update.mdx
@@ -27,13 +27,16 @@ react-x/no-unsafe-component-will-update
 
 ## Rule Details
 
-Using unsafe lifecycle methods like `UNSAFE_componentWillUpdate` makes your component's behavior less predictable and is more likely to cause bugs.
+Using unsafe lifecycle methods like `UNSAFE_componentWillUpdate` makes your component's behavior less predictable and is more likely to cause bugs. Consider using `componentDidUpdate` instead.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using `UNSAFE_componentWillUpdate` in class components
+
+`UNSAFE_componentWillUpdate` is a deprecated lifecycle method. If you need to perform side effects or DOM operations after an update, use `componentDidUpdate`.
 
 ```tsx
+// Problem: Uses an unsafe lifecycle method
 import React from "react";
 
 class MyComponent extends React.Component {

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.mdx
@@ -25,11 +25,14 @@ react-x/no-unstable-context-value
 
 React will re-render all consumers of a context whenever the context value changes, and if the value is not stable this can lead to unnecessary re-renders.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Creating a new object as the Context value on every render
+
+JavaScript objects and functions get a new reference every time they are recreated. If you pass an object literal directly in JSX, the Provider will think the value has changed on every render, causing all consumers to re-render unnecessarily.
 
 ```tsx
+// Problem: Object literals create a new reference on every render
 import React from "react";
 
 const MyContext = React.createContext({});
@@ -45,9 +48,8 @@ function MyComponentProvider() {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: Lift the value to module scope or use useMemo to keep the reference stable
 import React, { useMemo } from "react";
 
 const MyContext = React.createContext({});
@@ -63,7 +65,12 @@ function MyComponentProvider() {
 }
 ```
 
+### Using the React 19 `use memo` directive
+
+In React 19, if a component uses the `"use memo"` directive, the compiler automatically keeps object references stable, so passing object literals directly is acceptable.
+
 ```tsx
+// OK: With the use memo directive, the compiler automatically optimizes references
 import React from "react";
 
 const MyContext = React.createContext({});

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.mdx
@@ -33,11 +33,14 @@ This harms performance, as it means that React will have to re-evaluate hooks an
 
 To fix the violations, the easiest way is to use a referencing variable in module scope instead of using the literal values.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Using array literals as default props
+
+Array literals `[]` create a new reference every time, causing Hooks or memoized components that depend on the reference to recompute frequently.
 
 ```tsx
+// Problem: Array literal as a default prop creates a new reference on every render
 interface MyComponentProps {
   items: string[];
 }
@@ -49,42 +52,7 @@ function MyComponent({ items = [] }: MyComponentProps) {
 ```
 
 ```tsx
-interface MyComponentProps {
-  items: Record<string, string>;
-}
-
-function MyComponent({ items = {} }: MyComponentProps) {
-  //                           ^^^ An 'Object literal' as a default prop. This could lead to a potential infinite render loop in React. Use a variable instead of 'Object literal'.
-  return null;
-}
-```
-
-```tsx
-interface MyComponentProps {
-  onClick: () => void;
-}
-
-function MyComponent({ onClick = () => {} }: MyComponentProps) {
-  //                             ^^^ An 'arrow function expression' as a default prop. This could lead to a potential infinite render loop in React. Use a variable instead of 'arrow function expression'.
-  return null;
-}
-```
-
-```tsx
-interface MyComponentProps {
-  items: string[];
-}
-
-function MyComponent(props: MyComponentProps) {
-  const { items = [] } = props;
-  //              ^^^ An 'Array literal' as a default prop. This could lead to a potential infinite render loop in React. Use a variable instead of 'Array literal'.
-  return null;
-}
-```
-
-### Valid
-
-```tsx
+// Recommended: Use a stable module-level variable instead of a literal
 import React from "react";
 
 const emptyArray: string[] = [];
@@ -98,7 +66,24 @@ function MyComponent({ items = emptyArray }: MyComponentProps) {
 }
 ```
 
+### Using object literals as default props
+
+Object literals `{}` also create a new reference on every render, causing unnecessary re-render overhead.
+
 ```tsx
+// Problem: Object literal as a default prop
+interface MyComponentProps {
+  items: Record<string, string>;
+}
+
+function MyComponent({ items = {} }: MyComponentProps) {
+  //                           ^^^ An 'Object literal' as a default prop. This could lead to a potential infinite render loop in React. Use a variable instead of 'Object literal'.
+  return null;
+}
+```
+
+```tsx
+// Recommended: Use a stable module-level object variable
 import React from "react";
 
 const emptyObject = {};
@@ -112,7 +97,24 @@ function MyComponent({ items = emptyObject }: MyComponentProps) {
 }
 ```
 
+### Using arrow functions as default props
+
+Arrow function expressions generate a new function reference on every render, breaking memo optimizations for child components.
+
 ```tsx
+// Problem: Arrow function as a default prop
+interface MyComponentProps {
+  onClick: () => void;
+}
+
+function MyComponent({ onClick = () => {} }: MyComponentProps) {
+  //                             ^^^ An 'arrow function expression' as a default prop. This could lead to a potential infinite render loop in React. Use a variable instead of 'arrow function expression'.
+  return null;
+}
+```
+
+```tsx
+// Recommended: Use a stable module-level function reference
 import React from "react";
 
 const noop = () => {};
@@ -126,7 +128,25 @@ function MyComponent({ onClick = noop }: MyComponentProps) {
 }
 ```
 
+### Using unstable default values in destructured props
+
+Even when assigning default values after destructuring `props`, using literals still causes the same reference instability problem.
+
 ```tsx
+// Problem: Using an array literal after destructuring
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent(props: MyComponentProps) {
+  const { items = [] } = props;
+  //              ^^^ An 'Array literal' as a default prop. This could lead to a potential infinite render loop in React. Use a variable instead of 'Array literal'.
+  return null;
+}
+```
+
+```tsx
+// Recommended: Use a stable module-level variable
 import React from "react";
 
 const emptyArray: string[] = [];
@@ -142,7 +162,12 @@ function MyComponent(props: MyComponentProps) {
 }
 ```
 
+### Using primitive types as default props
+
+Primitive types (number, string, boolean, etc.) are compared by value and don't have reference instability issues, so they can be inlined directly.
+
 ```tsx
+// OK: Primitive default props are safe
 interface MyComponentProps {
   num: number;
   str: string;
@@ -155,13 +180,18 @@ function MyComponent({ num = 3, str = "foo", bool = true }: MyComponentProps) {
 }
 ```
 
+### Using the `use memo` directive
+
+In React 19, if a component uses the `"use memo"` directive, the compiler automatically optimizes reference stability for default props, so literal default values are acceptable.
+
 ```tsx
-"use memo";
+// OK: The use memo directive automatically optimizes references
 interface MyComponentProps {
   items: string[];
 }
 
 function MyComponent({ items = [] }: MyComponentProps) {
+  "use memo";
   return null;
 }
 ```

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
@@ -27,11 +27,14 @@ This rule warns about class component methods and properties that are defined bu
 
 Note that `shouldComponentUpdate` is considered unused when defined in a class extending `PureComponent`, since `PureComponent` implements its own `shouldComponentUpdate` with shallow prop and state comparison.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Class component methods defined but never used
+
+Defining a method in a class component that is never called (including in lifecycles, render, or other methods) increases maintenance overhead and causes confusion.
 
 ```tsx
+// Problem: handleClick is never called
 import React from "react";
 
 class MyComponent extends React.Component {
@@ -42,9 +45,12 @@ class MyComponent extends React.Component {
 }
 ```
 
-### Valid
+### Class component members called by other methods or lifecycles
+
+If a method is explicitly called in a lifecycle (such as componentDidMount) or by other members, it is not considered unused.
 
 ```tsx
+// OK: action is called in componentDidMount
 import React from "react";
 
 class MyComponent extends React.Component {

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.mdx
@@ -36,12 +36,14 @@ This is the TypeScript-only version of [`eslint-plugin-react/no-unused-prop-type
 - doesn't support the legacy propTypes syntax
 - combines the used props of one type definition declared by multiple components
 
-## Common Violations
+## Examples
 
-### Invalid
+### Props defined but not used inside the component body
+
+Declaring a field in a type or interface but not reading or using it in the component function causes the type definition to be inconsistent with the actual implementation.
 
 ```tsx
-// 'onClick' is defined in 'ButtonProps' but never used in the 'Button' component.
+// Problem: onClick is defined in ButtonProps but never used
 type ButtonProps = {
   children: React.ReactNode;
   onClick: () => void;
@@ -53,21 +55,7 @@ function Button({ children }: ButtonProps) {
 ```
 
 ```tsx
-// 'avatarUrl' is defined in 'UserProfileProps' but never used in the 'UserProfile' component.
-interface UserProfileProps {
-  username: string;
-  avatarUrl: string;
-}
-
-function UserProfile({ username }: UserProfileProps) {
-  return <div>{username}</div>;
-}
-```
-
-### Valid
-
-```tsx
-// All props are used.
+// Recommended: actually use all declared props in the component
 type ButtonProps = {
   children: React.ReactNode;
   onClick: () => void;
@@ -82,9 +70,28 @@ function Button({ children, onClick }: ButtonProps) {
 }
 ```
 
+### Fields declared in an interface but missed during destructuring
+
+Even if props are destructured, missing some fields from the interface is considered unused.
+
 ```tsx
-// 'className' is passed to the underlying <p> element with the rest of the props.
-// '...rest' is considered a use of all props that are not destructured.
+// Problem: avatarUrl is defined in UserProfileProps but never used
+interface UserProfileProps {
+  username: string;
+  avatarUrl: string;
+}
+
+function UserProfile({ username }: UserProfileProps) {
+  return <div>{username}</div>;
+}
+```
+
+### Passing all props through to child elements via the spread operator
+
+Using the `...rest` spread operator passes through all props that are not explicitly destructured, so these props are considered used.
+
+```tsx
+// OK: ...rest is considered to use all non-destructured props
 interface TextProps extends React.HTMLAttributes<HTMLParagraphElement> {
   children: React.ReactNode;
   className?: string;
@@ -95,8 +102,12 @@ function Text({ children, ...rest }: TextProps) {
 }
 ```
 
+### Multiple components sharing the same props type definition
+
+When a type/interface is shared by multiple components, as long as each field is used in at least one component, it will not be reported as unused.
+
 ```tsx
-// Both components use props from the same type definition.
+// OK: userId and theme are used in different components respectively
 interface ProfileProps {
   userId: string; // Used by ProfilePage
   theme: "light" | "dark"; // Used by ProfileAvatar

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.mdx
@@ -27,11 +27,14 @@ react-x/no-unused-state
 
 This rule warns about state variables declared via `useState` (or similar state hooks) that are defined but never read, or only read inside an effect or effect dependency array. State that is only used in effects often indicates missing logic in the render output or a state value that can be derived from props instead.
 
-## Common Violations
+## Examples
 
-### Invalid
+### State declared but never read in the component
+
+If only `useState` is called and the setter is destructured, but the state value itself is never read, this state has no actual effect on rendering.
 
 ```tsx
+// Problem: data is declared but never read
 import { useState } from "react";
 
 function Component() {
@@ -41,6 +44,21 @@ function Component() {
 ```
 
 ```tsx
+// Recommended: remove the state if it is not needed; otherwise use it in JSX
+import { useState } from "react";
+
+function Component() {
+  const [data, setData] = useState(0);
+  return <div>{data}</div>;
+}
+```
+
+### State only read in an effect
+
+If a state value is only used inside `useEffect` (including the dependency array), it often means it could be computed directly during rendering, or does not need to exist as state at all.
+
+```tsx
+// Problem: data is only read in an effect
 import { useEffect, useState } from "react";
 
 function Component() {
@@ -53,30 +71,7 @@ function Component() {
 ```
 
 ```tsx
-import { useEffect, useState } from "react";
-
-function Form({ firstName, lastName }) {
-  // 🔴 Avoid: redundant state and unnecessary Effect
-  const [fullName, setFullName] = useState("");
-  useEffect(() => {
-    setFullName(firstName + " " + lastName);
-  }, [firstName, lastName]);
-  // ...
-}
-```
-
-### Valid
-
-```tsx
-import { useState } from "react";
-
-function Component() {
-  const [data, setData] = useState(0);
-  return <div>{data}</div>;
-}
-```
-
-```tsx
+// Recommended: move the logic into rendering or compute directly from props
 import { useCallback, useState } from "react";
 
 function Component() {
@@ -88,9 +83,26 @@ function Component() {
 }
 ```
 
+### Simulating computed properties with state and effects
+
+When a state value can be fully computed from props, using `useState` + `useEffect` is redundant. It adds unnecessary code and introduces extra render cycles.
+
 ```tsx
+// Problem: fullName can be fully computed from props
+import { useEffect, useState } from "react";
+
 function Form({ firstName, lastName }) {
-  // ✅ Good: calculated during rendering
+  const [fullName, setFullName] = useState("");
+  useEffect(() => {
+    setFullName(firstName + " " + lastName);
+  }, [firstName, lastName]);
+  // ...
+}
+```
+
+```tsx
+// Recommended: compute directly during rendering
+function Form({ firstName, lastName }) {
   const fullName = firstName + " " + lastName;
   // ...
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.mdx
@@ -35,11 +35,14 @@ In React 19, `use` is preferred over `useContext` because it is more flexible.
 
 In addition, enable the [`naming-convention/context-name`](./naming-convention-context-name) rule to enforce consistent naming conventions for contexts.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Still using useContext in React 19
+
+React 19 introduced the more general `use` API, which can replace `useContext` and supports being called in conditional statements and loops. New code should prefer `use`.
 
 ```tsx
+// Problem: use should be preferred over useContext in React 19
 import { useContext } from "react";
 
 function Button() {
@@ -48,9 +51,8 @@ function Button() {
 }
 ```
 
-### Valid
-
 ```tsx
+// Recommended: use the React 19 use API
 import { use } from "react";
 
 function Button() {

--- a/plugins/eslint-plugin-react-x/src/rules/purity/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added spec documentation (`purity.spec.md`) documenting algorithms, validation rules, edge cases, and examples.
-- Added IMPL vs SPEC diff document (`purity.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`purity.spec.diff.md`) for tracking deviations from the React Compiler specification.
 
 ### Changed
 

--- a/plugins/eslint-plugin-react-x/src/rules/purity/purity.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/purity.mdx
@@ -7,13 +7,13 @@ description: Validates that components and hooks are pure by checking that they 
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 
-**Full Name in [`eslint-plugin-react-x@rc`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/purity
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin@rc`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/purity
@@ -33,8 +33,6 @@ react-x/purity
 
 React components must be pure functions — given the same props, they should always return the same JSX. When components use functions like `Math.random()` or `Date.now()` during render, they produce different output each time, breaking React's assumptions and causing bugs like hydration mismatches, incorrect memoization, and unpredictable behavior.
 
-## Common Violations
-
 In general, any API that returns a different value for the same inputs violates this rule. Usual examples include:
 
 - `Math.random()`
@@ -42,36 +40,32 @@ In general, any API that returns a different value for the same inputs violates 
 - `crypto.randomUUID()` / `crypto.getRandomValues()`
 - `performance.now()`
 
-### Invalid
+## Examples
+
+### Generating random values during render
+
+Random values change on every render, making the component's output unpredictable. This breaks memoization and can cause hydration mismatches in server-rendered apps.
 
 ```tsx
-// ❌ Math.random() in render
+// Problem: produces a different value on every render
 function Component() {
-  const id = Math.random(); // Different every render
+  const id = Math.random(); // different on every render
+  //         ^^^ Do not call 'Math.random()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
   return <div key={id}>Content</div>;
 }
 ```
 
 ```tsx
-// ❌ Date.now() for values
+// Problem: calling crypto.randomUUID() directly during render
 function Component() {
-  const timestamp = Date.now(); // Changes every render
-  return <div>Created at: {timestamp}</div>;
+  const id = crypto.randomUUID(); // different on every render
+  //         ^^^ Do not call 'crypto.randomUUID()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
+  return <div id={id}>Content</div>;
 }
 ```
 
 ```tsx
-// ❌ new Date() in render
-function Component() {
-  const date = new Date(); // Different every render
-  return <div>{date.toISOString()}</div>;
-}
-```
-
-### Valid
-
-```tsx
-// ✅ Stable IDs from initial state
+// Recommended: use lazy initialization to ensure a stable value
 function Component() {
   const [id] = useState(() => crypto.randomUUID());
   return <div key={id}>Content</div>;
@@ -79,7 +73,77 @@ function Component() {
 ```
 
 ```tsx
-// ✅ Impure calls in event handlers
+// Problem: useMemo cannot make an impure call pure
+function Component() {
+  const value = useMemo(() => Math.random(), []);
+  //                  ^^^ Do not call 'Math.random()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
+  return <div>{value}</div>;
+}
+```
+
+### Using time-based values during render
+
+Time-based values change constantly. Using them directly in render makes the component impure and causes unnecessary re-renders or hydration issues.
+
+```tsx
+// Problem: time-based value changes on every render
+function Component() {
+  const timestamp = Date.now(); // constantly changing
+  //                ^^^ Do not call 'Date.now()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
+  return <div>Created at: {timestamp}</div>;
+}
+```
+
+```tsx
+// Problem: new Date() is also impure
+function Component() {
+  const date = new Date(); // new time on every render
+  //           ^^^ Do not call 'new Date()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
+  return <div>{date.toISOString()}</div>;
+}
+```
+
+```tsx
+// Recommended: use time-based values in effects or event handlers
+function Component() {
+  useEffect(() => {
+    const timestamp = Date.now();
+    console.log(timestamp);
+  }, []);
+  return <div>Content</div>;
+}
+```
+
+### Using time-based values in custom hooks
+
+Custom hooks are also part of the render phase, so impure calls inside them are flagged just like in components.
+
+```tsx
+// Problem: impure call inside a custom hook
+function useTimestamp() {
+  const t = Date.now(); // called during render
+  //        ^^^ Do not call 'Date.now()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
+  return t;
+}
+```
+
+```tsx
+// Recommended: move impure logic into an effect
+function useTimestamp() {
+  const [timestamp, setTimestamp] = useState(() => Date.now());
+  useEffect(() => {
+    setTimestamp(Date.now());
+  }, []);
+  return timestamp;
+}
+```
+
+### Impure calls in event handlers and effects
+
+Event handlers and effects run outside of React's render cycle, so impure functions are perfectly acceptable there.
+
+```tsx
+// Recommended: use random numbers in event handlers
 function Component() {
   return (
     <button onClick={() => console.log(Math.random())}>
@@ -90,7 +154,7 @@ function Component() {
 ```
 
 ```tsx
-// ✅ Impure calls inside effects
+// Recommended: use timestamps in effects
 function Component() {
   useEffect(() => {
     const timestamp = Date.now();
@@ -100,23 +164,21 @@ function Component() {
 }
 ```
 
-## Troubleshooting
+### Showing the current time
 
-### I need to show the current time
-
-Calling `Date.now()` during render makes your component impure:
+Calling `Date.now()` directly in JSX produces a different value on every render and makes the component impure.
 
 ```tsx
-// ❌ Wrong: Time changes every render
+// Problem: time changes on every render
 function Clock() {
   return <div>Current time: {Date.now()}</div>;
 }
 ```
 
-Instead, move the impure function outside of render:
+When you need to display a constantly updating value like the current time, use state and an effect rather than calling `Date.now()` directly in render.
 
 ```tsx
-// ✅ Correct: Initialize in state, update in effect
+// Recommended: manage time with state and effects
 function Clock() {
   const [time, setTime] = useState(() => Date.now());
   useEffect(() => {
@@ -126,100 +188,6 @@ function Clock() {
     return () => clearInterval(interval);
   }, []);
   return <div>Current time: {time}</div>;
-}
-```
-
-### I need a unique ID
-
-Calling `crypto.randomUUID()` or `Math.random()` during render produces a different value on every render:
-
-```tsx
-// ❌ Wrong: ID changes every render
-function Component() {
-  const id = crypto.randomUUID();
-  return <div id={id}>Content</div>;
-}
-```
-
-Instead, wrap the call in a state initializer so it only runs once:
-
-```tsx
-// ✅ Correct: ID is stable across renders
-function Component() {
-  const [id] = useState(() => crypto.randomUUID());
-  return <div id={id}>Content</div>;
-}
-```
-
-## Common Violations
-
-### Invalid
-
-```tsx
-function Component() {
-  const id = Math.random();
-  //         ^^^ Do not call 'Math.random()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
-  return <div key={id}>Content</div>;
-}
-```
-
-```tsx
-function Component() {
-  const timestamp = Date.now();
-  //                ^^^ Do not call 'Date.now()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
-  return <div>Created at: {timestamp}</div>;
-}
-```
-
-```tsx
-function Component() {
-  const date = new Date();
-  //           ^^^ Do not call 'new Date()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
-  return <div>{date.toISOString()}</div>;
-}
-```
-
-```tsx
-function useTimestamp() {
-  const t = Date.now();
-  //        ^^^ Do not call 'Date.now()' during render. Components and hooks must be pure. Move this call into an event handler, effect, or state initializer.
-  return t;
-}
-```
-
-### Valid
-
-```tsx
-function Component() {
-  const [id] = useState(() => crypto.randomUUID());
-  return <div key={id}>Content</div>;
-}
-```
-
-```tsx
-function Component() {
-  return (
-    <button onClick={() => console.log(Math.random())}>
-      Roll
-    </button>
-  );
-}
-```
-
-```tsx
-function Component() {
-  useEffect(() => {
-    const timestamp = Date.now();
-    console.log(timestamp);
-  }, []);
-  return <div>Content</div>;
-}
-```
-
-```tsx
-function Component() {
-  const value = useMemo(() => Math.random(), []);
-  return <div>{value}</div>;
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/purity/purity.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/purity.spec.diff.md
@@ -1,4 +1,4 @@
-# purity IMPL vs. SPEC Report
+# purity IMPL–SPEC Diff Report
 
 **IMPL**: `purity.ts` (ESLint rule)\
 **SPEC**: `purity.spec.md` (React Compiler `ValidateNoImpureValuesInRender`)
@@ -84,7 +84,7 @@ The SPEC does not use message IDs but has a single error category:
 
 - `ImpureValues` — "Cannot access impure value during render".
 
-Error message text is conceptually aligned but structurally different due to single vs. dual reporting.
+Error message text is conceptually aligned but structurally different due to single-location rather than dual-location reporting.
 
 ---
 

--- a/plugins/eslint-plugin-react-x/src/rules/refs/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added spec documentation (`refs.spec.md`) documenting algorithms, validation rules, edge cases, and examples.
-- Added IMPL vs SPEC diff document (`refs.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`refs.spec.diff.md`) for tracking deviations from the React Compiler specification.
 
 ### Changed
 

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.mdx
@@ -7,13 +7,13 @@ description: Validates correct usage of refs by checking that 'ref.current' is n
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 
-**Full Name in [`eslint-plugin-react-x@rc`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/refs
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin@rc`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/refs
@@ -51,140 +51,73 @@ The lint only applies these rules to values it knows are refs. A value is inferr
 
 Once something is marked as a ref, the lint surfaces violations when `ref.current` is accessed directly in the render phase of a component or hook body (i.e. not inside effects, event handlers, callbacks, or other nested functions).
 
-## Common Violations
+## Examples
 
-- Reading `ref.current` during render
-- Updating `refs` during render
-- Using `refs` for values that should be state
+### Reading `ref.current` during render
 
-### Invalid
+Refs are not guaranteed to be initialized during render. Reading them in the component body may return `null` or a stale value from a previous render cycle.
 
 ```tsx
-// ❌ Reading ref during render
+// Problem: reading ref during render
 function Component() {
   const ref = useRef(0);
-  const value = ref.current; // Don't read during render
-  return <div>{value}</div>;
-}
-```
-
-```tsx
-// ❌ Modifying ref during render
-function Component({ value }) {
-  const ref = useRef(null);
-  ref.current = value; // Don't modify during render
-  return <div />;
-}
-```
-
-### Valid
-
-```tsx
-// ✅ Read ref in effects/handlers
-function Component() {
-  const ref = useRef(null);
-  useEffect(() => {
-    if (ref.current) {
-      console.log(ref.current.offsetWidth); // OK in effect
-    }
-  });
-  return <div ref={ref} />;
-}
-```
-
-```tsx
-// ✅ Use state for UI values
-function Component() {
-  const [count, setCount] = useState(0);
-  return (
-    <button onClick={() => setCount(count + 1)}>
-      {count}
-    </button>
-  );
-}
-```
-
-```tsx
-// ✅ Lazy initialization of ref value
-function Component() {
-  const ref = useRef(null);
-  // Initialize only once on first use
-  if (ref.current === null) {
-    ref.current = expensiveComputation(); // OK - lazy initialization
-  }
-  const handleClick = () => {
-    console.log(ref.current); // Use the initialized value
-  };
-  return <button onClick={handleClick}>Click</button>;
-}
-```
-
-## Troubleshooting
-
-### The lint flagged my plain object with `.current`
-
-The name heuristic intentionally treats `ref.current` and `fooRef.current` as real refs. If you're modeling a custom container object, pick a different name (for example, `box`) or move the mutable value into state. Renaming avoids the lint because the compiler stops inferring it as a ref.
-
-### I need to read a ref value in JSX
-
-Refs are meant for values that don't affect rendering output. If you need to display a value in JSX, use state instead:
-
-```tsx
-// ❌ Wrong: Reading ref in JSX
-function Component() {
-  const ref = useRef(0);
-  return <div>{ref.current}</div>;
-}
-```
-
-```tsx
-// ✅ Correct: Use state for rendered values
-function Component() {
-  const [count, setCount] = useState(0);
-  return <div>{count}</div>;
-}
-```
-
-### Invalid
-
-```tsx
-function Component() {
-  const ref = useRef(0);
-  const value = ref.current;
+  const value = ref.current; // read during render
   //            ^^^ Do not read 'ref.current' during render. Refs are not available during rendering and their values may be stale or inconsistent. Move this read into an effect or event handler.
   return <div>{value}</div>;
 }
 ```
 
 ```tsx
+// Recommended: use state to display values
+function Component() {
+  const [count, setCount] = useState(0);
+  return <div>{count}</div>;
+}
+```
+
+### Reading `ref.current` in custom hooks
+
+Custom hooks follow the same rules as components. Reading `ref.current` during the execution of a custom hook is still part of the render phase.
+
+```tsx
+// Problem: reading ref.current inside a custom hook during render
+function useMyHook() {
+  const ref = useRef(0);
+  const value = ref.current;
+  //            ^^^ Do not read 'ref.current' during render. Refs are not available during rendering and their values may be stale or inconsistent. Move this read into an effect or event handler.
+  return value;
+}
+```
+
+```tsx
+// Recommended: pass the ref to a component and read it in an effect
+function Component() {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (ref.current) {
+      console.log(ref.current.offsetWidth);
+    }
+  }, []);
+  return <div ref={ref} />;
+}
+```
+
+### Modifying `ref.current` during render
+
+Writing to a ref during render is a side effect. React may invoke your component multiple times before committing, so the ref write may happen more often than you expect.
+
+```tsx
+// Problem: modifying ref during render
 function Component({ value }) {
   const ref = useRef(null);
-  ref.current = value;
+  ref.current = value; // modified during render
   // ^^^ Do not write to 'ref.current' during render. Refs should only be mutated in effects or event handlers. Move this write into an effect or event handler.
   return <div />;
 }
 ```
 
 ```tsx
-function Component() {
-  const ref = useRef(0);
-  return <div>{ref.current}</div>;
-  //          ^^^ Do not read 'ref.current' during render.
-}
-```
-
-```tsx
-function useMyHook() {
-  const ref = useRef(0);
-  const value = ref.current;
-  //            ^^^ Do not read 'ref.current' during render.
-  return value;
-}
-```
-
-### Valid
-
-```tsx
+// Recommended: modify refs in effects or event handlers
 function Component() {
   const ref = useRef(null);
   useEffect(() => {
@@ -197,26 +130,7 @@ function Component() {
 ```
 
 ```tsx
-function Component() {
-  const ref = useRef(null);
-  const handleClick = () => {
-    console.log(ref.current);
-  };
-  return <button onClick={handleClick}>Click</button>;
-}
-```
-
-```tsx
-function Component() {
-  const ref = useRef(null);
-  if (ref.current === null) {
-    ref.current = expensiveComputation();
-  }
-  return <div />;
-}
-```
-
-```tsx
+// Recommended: use useLayoutEffect when you need to measure DOM nodes before paint
 function Component() {
   const ref = useRef(null);
   useLayoutEffect(() => {
@@ -225,6 +139,51 @@ function Component() {
   return <div ref={ref} />;
 }
 ```
+
+### Lazy initialization of ref value
+
+There is one exception: lazy initialization of a ref value on first access is a common and safe pattern, as long as it only runs once.
+
+```tsx
+// OK: lazy initialization of ref value
+function Component() {
+  const ref = useRef(null);
+  if (ref.current === null) {
+    ref.current = expensiveComputation(); // lazy initialization
+  }
+  const handleClick = () => {
+    console.log(ref.current);
+  };
+  return <button onClick={handleClick}>Click</button>;
+}
+```
+
+### Using refs for rendered values
+
+If a value affects what is shown on screen, it should be state, not a ref. Refs are meant for values that don't affect rendering output.
+
+```tsx
+// Problem: using a ref to store a value that needs to be displayed in JSX
+function Component() {
+  const ref = useRef(0);
+  return <div>{ref.current}</div>;
+  //          ^^^ Do not read 'ref.current' during render.
+}
+```
+
+```tsx
+// Recommended: use state to store rendered values
+function Component() {
+  const [count, setCount] = useState(0);
+  return <div>{count}</div>;
+}
+```
+
+## Troubleshooting
+
+### The lint flagged my plain object with `.current`
+
+The name heuristic intentionally treats `ref.current` and `fooRef.current` as real refs. If you're modeling a custom container object, pick a different name (for example, `box`) or move the mutable value into state. Renaming avoids the lint because the compiler stops inferring it as a ref.
 
 ## Resources
 

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.spec.diff.md
@@ -1,4 +1,4 @@
-# refs IMPL vs. SPEC Report
+# refs IMPL–SPEC Diff Report
 
 **IMPL**: `refs.ts` + `lib.ts` (ESLint rule)\
 **SPEC**: `refs.spec.md` (React Compiler `ValidateNoRefAccessInRender`)

--- a/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks/rules-of-hooks.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks/rules-of-hooks.mdx
@@ -3,13 +3,13 @@ title: rules-of-hooks
 description: Enforces the Rules of Hooks.
 ---
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/rules-of-hooks
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/rules-of-hooks
@@ -33,38 +33,70 @@ react-x/rules-of-hooks
 
 React relies on the order in which hooks are called to correctly preserve state between renders. Each time your component renders, React expects the exact same hooks to be called in the exact same order. When hooks are called conditionally or in loops, React loses track of which state corresponds to which hook call, leading to bugs like state mismatches and "Rendered fewer/more hooks than expected" errors.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Calling hooks conditionally
+
+Hooks must be called in the exact same order on every render. Placing a hook inside an `if` statement breaks this contract because the hook may be skipped on some renders.
 
 ```tsx
-// ❌ Hook in condition
+// Problem: calling hook conditionally
 function MyComponent({ isLoggedIn }) {
   if (isLoggedIn) {
     const [user, setUser] = useState(null);
-    //    ^^^ React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+    //    ^^^ React Hook "useState" is called conditionally.
   }
 }
 ```
 
 ```tsx
-// ❌ Hook after early return
+// Recommended: call hooks unconditionally and handle conditions inside
+function MyComponent({ isLoggedIn }) {
+  useEffect(() => {
+    if (isLoggedIn) {
+      fetchUserData();
+    }
+  }, [isLoggedIn]);
+}
+```
+
+### Hooks after early return
+
+An early return before a hook call also makes the hook conditional — it won't run on renders that hit the return statement.
+
+```tsx
+// Problem: early return causes conditional hook execution
 function MyComponent({ data }) {
   if (!data) return <Loading />;
 
   const [processed, setProcessed] = useState(data);
-  //    ^^^ React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.
+  //    ^^^ React Hook "useState" is called conditionally.
 }
 ```
 
 ```tsx
-// ❌ Hook in callback
+// Recommended: move hooks to the top of the component and handle conditions in JSX
+function MyComponent({ data }) {
+  const [processed, setProcessed] = useState(data);
+
+  if (!data) return <Loading />;
+
+  return <div>{processed}</div>;
+}
+```
+
+### Hooks inside callbacks or loops
+
+Hooks must be called at the top level of a React function component or custom hook. Calling them inside callbacks, loops, or nested functions means they won't be called in a predictable order.
+
+```tsx
+// Problem: calling hook inside a callback
 function MyComponent() {
   return (
     <button
       onClick={() => {
         const [clicked, setClicked] = useState(false);
-        //    ^^^ React Hook "useState" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.
+        //    ^^^ React Hook "useState" cannot be called inside a callback.
       }}
     />
   );
@@ -72,31 +104,79 @@ function MyComponent() {
 ```
 
 ```tsx
-// ❌ Hook in loop
+// Problem: calling hook inside a loop
 function MyComponent({ items }) {
   for (const item of items) {
     const [selected, setSelected] = useState(false);
-    //    ^^^ React Hook "useState" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.
+    //    ^^^ React Hook "useState" may be executed more than once.
   }
 }
 ```
 
 ```tsx
-// ❌ `use` in try/catch
+// Recommended: call hooks at the top level of the component and use state updater functions in callbacks
+function MyComponent() {
+  const [clicked, setClicked] = useState(false);
+  return <button onClick={() => setClicked(true)}>Click</button>;
+}
+```
+
+### `use` in try/catch blocks
+
+The `use` hook cannot be called from inside a `try` block because React needs to be able to suspend the component, and try/catch interferes with React's internal exception handling for Suspense.
+
+```tsx
+// Problem: calling use inside a try block
 function MyComponent({ promise }) {
   try {
     const data = use(promise);
-    //           ^^^ React Hook "use" cannot be called from a try block. Call it outside of the try block.
+    //           ^^^ React Hook "use" cannot be called from a try block.
   } catch (e) {
     // error handling
   }
 }
 ```
 
-### Valid
+```tsx
+// Recommended: call use outside the try block
+function MyComponent({ promise }) {
+  const data = use(promise);
+  // ...
+}
+```
+
+### Conditionally initializing state
+
+You may be tempted to call `useState` inside a condition when you want different initial values for different scenarios. This breaks the Rules of Hooks because the number of hook calls changes between renders.
 
 ```tsx
-// ✅ Hooks at top level
+// Problem: conditionally initializing state
+function MyComponent({ userType, adminPerms, userPerms }) {
+  if (userType === "admin") {
+    const [permissions, setPermissions] = useState(adminPerms);
+    //    ^^^ React Hook "useState" is called conditionally.
+  } else {
+    const [permissions, setPermissions] = useState(userPerms);
+    //    ^^^ React Hook "useState" is called conditionally.
+  }
+}
+```
+
+```tsx
+// Recommended: call useState unconditionally and set the initial value conditionally
+function MyComponent({ userType, adminPerms, userPerms }) {
+  const [permissions, setPermissions] = useState(
+    userType === "admin" ? adminPerms : userPerms,
+  );
+}
+```
+
+### Hooks at top level
+
+When all hooks are called unconditionally at the top level, React can reliably match each hook call to its corresponding state across renders.
+
+```tsx
+// Recommended: call hooks unconditionally at the top level in a fixed order
 function MyComponent({ isSpecial, shouldFetch, fetchPromise }) {
   const [count, setCount] = useState(0);
   const [name, setName] = useState("");
@@ -106,7 +186,6 @@ function MyComponent({ isSpecial, shouldFetch, fetchPromise }) {
   }
 
   if (shouldFetch) {
-    // ✅ `use` can be conditional
     const data = use(fetchPromise);
     return <div>{data}</div>;
   }
@@ -120,7 +199,7 @@ function MyComponent({ isSpecial, shouldFetch, fetchPromise }) {
 ```
 
 ```tsx
-// ✅ Custom hook calling other hooks at top level
+// Recommended: custom hooks should also call other hooks at the top level
 function useUserData(userId) {
   const [user, setUser] = useState(null);
 
@@ -129,62 +208,6 @@ function useUserData(userId) {
   }, [userId]);
 
   return user;
-}
-```
-
-## Troubleshooting
-
-### I want to fetch data based on some condition
-
-You're trying to conditionally call `useEffect`:
-
-```tsx
-// ❌ Conditional hook
-function MyComponent({ isLoggedIn }) {
-  if (isLoggedIn) {
-    useEffect(() => {
-      fetchUserData();
-    }, []);
-  }
-}
-```
-
-Call the hook unconditionally, and check the condition inside:
-
-```tsx
-// ✅ Condition inside hook
-function MyComponent({ isLoggedIn }) {
-  useEffect(() => {
-    if (isLoggedIn) {
-      fetchUserData();
-    }
-  }, [isLoggedIn]);
-}
-```
-
-### I need different state for different scenarios
-
-You're trying to conditionally initialize state:
-
-```tsx
-// ❌ Conditional state
-function MyComponent({ userType, adminPerms, userPerms }) {
-  if (userType === "admin") {
-    const [permissions, setPermissions] = useState(adminPerms);
-  } else {
-    const [permissions, setPermissions] = useState(userPerms);
-  }
-}
-```
-
-Always call `useState` unconditionally, and set the initial value conditionally:
-
-```tsx
-// ✅ Conditional initial value
-function MyComponent({ userType, adminPerms, userPerms }) {
-  const [permissions, setPermissions] = useState(
-    userType === "admin" ? adminPerms : userPerms,
-  );
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Improved validation accuracy with enhanced detection logic.
-- Added IMPL vs SPEC diff document (`set-state-in-effect.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`set-state-in-effect.spec.diff.md`) for tracking deviations from the React Compiler specification.
 - Extracted rule helpers into co-located `lib.ts` module.
 
 ## [5.5.3-beta.1] - 2026-04-26

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.mdx
@@ -3,13 +3,13 @@ title: set-state-in-effect
 description: Validates against setting state synchronously in an effect, which can lead to re-renders that degrade performance.
 ---
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/set-state-in-effect
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/set-state-in-effect
@@ -27,7 +27,7 @@ react-x/set-state-in-effect
 
 ## Rule Details
 
-Setting state immediately inside an effect forces React to restart the entire render cycle. When you update state in an effect, React must re-render your component, apply changes to the DOM, and then run effects again. This creates an extra render pass that could have been avoided by transforming data directly during render or deriving state from props. Transform data at the top level of your component instead. This code will naturally re-run when props or state change without triggering additional render cycles.
+Setting state immediately inside an effect forces React to restart the entire render cycle. When you update state in an effect, React must re-render your component, apply changes to the DOM, and then run effects again. This creates an extra render pass that could have been avoided by transforming data directly during render or deriving state from props.
 
 Synchronous `setState` calls in effects trigger immediate re-renders before the browser can paint, causing performance issues and visual jank. React has to render twice: once to apply the state update, then again after effects run. This double rendering is wasteful when the same result could be achieved with a single render.
 
@@ -35,130 +35,25 @@ Synchronous `setState` calls in effects trigger immediate re-renders before the 
 
 In many cases, you may also not need an effect at all. Please see [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect) for more information.
 
-### Common Violations
+## Examples
 
-This rule catches several patterns where synchronous `setState` is used unnecessarily:
+### Transforming data in effects instead of render
 
-- Transforming data in effects instead of render
-- Deriving state from props in effects
-- Setting loading state synchronously
-
-### What is allowed?
-
-The rule does not flag indirect calls, such as:
-
-- Inside event handlers.
-- Inside `async` functions.
-- Inside `setTimeout`, `setInterval`, `Promise.then`, etc.
-
-### Known Limitations
-
-- It doesn’t check `set` calls in `useEffect` cleanup functions.
-
-  ```tsx {2}
-  useEffect(() => {
-    return () => {
-      setFullName(firstName + " " + lastName); // ❌ Direct call
-    };
-  }, [firstName, lastName]);
-  ```
-
-- It doesn’t detect `set` calls in `async` functions that are called before the `await` statement.
-
-  ```tsx {2}
-  useEffect(() => {
-    const fetchData = async () => {
-      setFullName(data.name); // ❌ Direct call
-    };
-    fetchData();
-  }, []);
-  ```
-
-### Valid
-
-The following example from the [React Docs](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect) demonstrates that `setState` in an effect is fine if the value comes from a ref, since it cannot be calculated during rendering:
+When data can be derived directly from props, putting it in state inside an effect creates an unnecessary render cycle.
 
 ```tsx
-import { useLayoutEffect, useRef, useState } from "react";
-
-function Tooltip() {
-  const ref = useRef(null);
-  const [tooltipHeight, setTooltipHeight] = useState(0);
-
-  useLayoutEffect(() => {
-    const { height } = ref.current.getBoundingClientRect();
-    setTooltipHeight(height);
-  }, []);
-  // ...
-}
-```
-
-The following cases are common valid use cases because they do not call the `set` function directly in `useEffect`:
-
-```tsx
-import { useEffect, useState } from "react";
-
-export default function Counter() {
-  const [count, setCount] = useState(0);
+// Problem: transforming data in an effect
+function Component({ rawData }) {
+  const [processed, setProcessed] = useState([]);
 
   useEffect(() => {
-    const handler = () => setCount((c) => c + 1);
-    window.addEventListener("click", handler);
-    return () => window.removeEventListener("click", handler);
-  }, []);
-
-  return <h1>{count}</h1>;
+    setProcessed(rawData.map(transform)); // extra render, should compute directly during rendering
+  }, [rawData]);
 }
 ```
 
 ```tsx
-import { useEffect, useState } from "react";
-
-export default function Counter() {
-  const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    const intervalId = setInterval(() => {
-      setCount((c) => c + 1);
-    }, 1000);
-    return () => clearInterval(intervalId);
-  }, []);
-
-  return <h1>{count}</h1>;
-}
-```
-
-```tsx
-import { useEffect, useState } from "react";
-
-export default function RemoteContent() {
-  const [content, setContent] = useState("");
-
-  useEffect(() => {
-    let discarded = false;
-    fetch("https://eslint-react.xyz/content")
-      .then((resp) => resp.text())
-      .then((text) => {
-        if (discarded) return;
-        setContent(text);
-      });
-    return () => {
-      discarded = true;
-    };
-  }, []);
-
-  return <h1>{count}</h1>;
-}
-```
-
-<Callout title="TIP">
-  If you need to fetch remote data within the component, consider using libraries like [TanStack Query](https://tanstack.com/query/v3/) or [SWR](https://swr.vercel.app/). They handle caching, re-fetching, and state management for you, making your code cleaner and more efficient.
-</Callout>
-
-```tsx
-import { useMemo, useState } from "react";
-
-// ✅ Calculate during render
+// Recommended: compute directly during rendering
 function Component({ rawData }) {
   const processed = useMemo(() => rawData.map(transform), [rawData]);
   // ...
@@ -166,106 +61,19 @@ function Component({ rawData }) {
 ```
 
 ```tsx
-// ✅ Calculate during render
+// Recommended: simple computations can be done directly during rendering
 function Component({ selectedId, items }) {
   const selected = items.find((i) => i.id === selectedId);
   return <div>{selected?.name}</div>;
 }
 ```
 
-```tsx
-import { useState } from "react";
+### Deriving state from props in effects
 
-export default function ProfilePage({ userId }) {
-  return <Profile userId={userId} key={userId} />;
-}
-
-function Profile({ userId }) {
-  // ✅ This and any other state below will reset on key change automatically
-  const [comment, setComment] = useState("");
-  // ...
-}
-```
+Synchronously setting state based on props in an effect is a common anti-pattern that causes extra renders.
 
 ```tsx
-import { useState } from "react";
-
-function List({ items }) {
-  const [isReverse, setIsReverse] = useState(false);
-  const [selection, setSelection] = useState(null);
-
-  // Better: Adjust the state while rendering
-  const [prevItems, setPrevItems] = useState(items);
-  if (items !== prevItems) {
-    setPrevItems(items);
-    setSelection(null);
-  }
-  // ...
-}
-```
-
-```tsx
-import { useState } from "react";
-
-function List({ items }) {
-  const [isReverse, setIsReverse] = useState(false);
-  const [selectedId, setSelectedId] = useState(null);
-  // ✅ Best: Calculate everything during rendering
-  const selection = items.find((item) => item.id === selectedId) ?? null;
-  // ...
-}
-```
-
-## Common Violations
-
-### Invalid
-
-The following examples are derived from the [React Docs: `set-state-in-effect`](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect) and the [React Docs: You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect):
-
-```tsx
-import { useEffect, useState } from "react";
-
-// ❌ Synchronous setState in effect
-function Component({ data }) {
-  const [items, setItems] = useState([]);
-
-  useEffect(() => {
-    setItems(data); // Extra render, use initial state instead
-  }, [data]);
-}
-```
-
-```tsx
-import { useEffect, useState } from "react";
-
-// ❌ Setting loading state synchronously
-function Component() {
-  const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    setLoading(true); // Synchronous, causes extra render
-    fetchData().then(() => setLoading(false));
-  }, []);
-}
-```
-
-```tsx
-import { useEffect, useState } from "react";
-
-// ❌ Transforming data in effect
-function Component({ rawData }) {
-  const [processed, setProcessed] = useState([]);
-
-  useEffect(() => {
-    setProcessed(rawData.map(transform)); // Should derive in render
-  }, [rawData]);
-}
-```
-
-```tsx
-import { useEffect, useState } from "react";
-
-// ❌ Deriving state from props
+// Problem: setting state based on props in an effect
 function Component({ selectedId, items }) {
   const [selected, setSelected] = useState(null);
 
@@ -276,31 +84,135 @@ function Component({ selectedId, items }) {
 ```
 
 ```tsx
-import { useEffect, useState } from "react";
-
-export default function ProfilePage({ userId }) {
-  const [comment, setComment] = useState("");
-
-  // 🔴 Avoid: Resetting state on prop change in an Effect
-  useEffect(() => {
-    setComment("");
-  }, [userId]);
+// Recommended: derive values during rendering
+function Component({ selectedId, items }) {
+  const selection = items.find((item) => item.id === selectedId) ?? null;
   // ...
 }
 ```
 
+### Resetting state on prop changes
+
+Using an effect to reset state when a prop changes causes an extra render. Instead, use the `key` prop to reset state automatically.
+
 ```tsx
-import { useEffect, useState } from "react";
+// Problem: resetting state in an effect
+function ProfilePage({ userId }) {
+  const [comment, setComment] = useState("");
 
-function List({ items }) {
-  const [isReverse, setIsReverse] = useState(false);
-  const [selection, setSelection] = useState(null);
-
-  // 🔴 Avoid: Adjusting state on prop change in an Effect
   useEffect(() => {
-    setSelection(null);
-  }, [items]);
-  // ...
+    setComment(""); // extra render
+  }, [userId]);
+}
+```
+
+```tsx
+// Recommended: use the key prop to reset state automatically
+function ProfilePage({ userId }) {
+  return <Profile userId={userId} key={userId} />;
+}
+
+function Profile({ userId }) {
+  const [comment, setComment] = useState("");
+  // automatically resets when key changes
+}
+```
+
+### Setting synchronous loading state
+
+Toggling a loading flag synchronously at the start of an effect causes an immediate re-render before any actual work begins.
+
+```tsx
+// Problem: setting loading state synchronously
+function Component() {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true); // synchronously triggers extra render
+    fetchData().then(() => setLoading(false));
+  }, []);
+}
+```
+
+```tsx
+// Recommended: initialize loading state to true so no synchronous setState is needed
+function Component() {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchData().then(() => setLoading(false));
+  }, []);
+}
+```
+
+### Indirect setState calls are allowed
+
+The rule does not flag indirect calls, such as inside event handlers, async functions, or timers. These run outside of the synchronous effect execution and do not cause the same immediate re-render problem.
+
+```tsx
+// OK: setState in an event handler
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const handler = () => setCount((c) => c + 1);
+    window.addEventListener("click", handler);
+    return () => window.removeEventListener("click", handler);
+  }, []);
+}
+```
+
+```tsx
+// OK: setState in an async function
+function RemoteContent() {
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    let discarded = false;
+    fetch("https://eslint-react.xyz/content")
+      .then((resp) => resp.text())
+      .then((text) => {
+        if (discarded) return;
+        setContent(text); // allowed in async callback
+      });
+    return () => {
+      discarded = true;
+    };
+  }, []);
+}
+```
+
+## Known Limitations
+
+### Cleanup functions
+
+The rule does not check `set` calls inside `useEffect` cleanup functions.
+
+```tsx
+// Note: setState in a cleanup function is not flagged
+function Component({ firstName, lastName }) {
+  useEffect(() => {
+    return () => {
+      setFullName(firstName + " " + lastName); // not detected
+    };
+  }, [firstName, lastName]);
+}
+```
+
+### Async functions before await
+
+The rule does not detect `set` calls in `async` functions that are called before the first `await` statement.
+
+```tsx
+// Note: setState before await in an async function is not flagged
+function Component({ data }) {
+  useEffect(() => {
+    const fetchData = async () => {
+      setFullName(data.name); // not detected
+      await syncToServer(data);
+    };
+    fetchData();
+  }, [data]);
 }
 ```
 
@@ -315,7 +227,7 @@ Custom state and effect hooks can also be configured via shared ESLint settings,
   "settings": {
     "react-x": {
       "additionalStateHooks": "/^(useMyState|useCustomState)$/u",
-      "additionalEffectHooks": "/^(useMyEffect|useCustomEffect)$/u",
+      "additionalEffectHooks": "/^(useMyEffect|useCustomEffect)$/u"
     }
   }
 }

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.diff.md
@@ -1,4 +1,4 @@
-# set-state-in-effect IMPL vs. SPEC Report
+# set-state-in-effect IMPL–SPEC Diff Report
 
 **IMPL**: `set-state-in-effect.ts` + `lib.ts` (ESLint rule)\
 **SPEC**: `46-validateNoSetStateInEffects.md` (React Compiler `ValidateNoSetStateInEffects`)

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added spec documentation (`set-state-in-render.spec.md`) documenting algorithms, validation rules, edge cases, and examples.
-- Added IMPL vs SPEC diff document (`set-state-in-render.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`set-state-in-render.spec.diff.md`) for tracking deviations from the React Compiler specification.
 
 ### Changed
 

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.mdx
@@ -7,13 +7,13 @@ description: Validates against unconditionally setting state during render, whic
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/set-state-in-render
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/set-state-in-render
@@ -37,31 +37,31 @@ react-x/set-state-in-render
 
 Calling `setState` during render unconditionally triggers another render before the current one finishes. This creates an infinite loop that crashes your app.
 
-## Common Violations
+## Examples
 
-### Invalid
+### Unconditional setState in render
+
+Calling a state setter directly in the component body, without any guard condition, will trigger a re-render immediately, leading to an infinite loop.
 
 ```tsx
-// ❌ Unconditional setState directly in render
+// Problem: unconditionally calling setState during render
 function Component({ value }) {
   const [count, setCount] = useState(0);
-  setCount(value); // Infinite loop!
+  setCount(value); // infinite loop!
   return <div>{count}</div>;
 }
 ```
 
-### Valid
-
 ```tsx
-// ✅ Derive during render
+// Recommended: derive values directly during rendering
 function Component({ items }) {
-  const sorted = [...items].sort(); // Just calculate it in render
+  const sorted = [...items].sort();
   return <ul>{sorted.map(/*...*/)}</ul>;
 }
 ```
 
 ```tsx
-// ✅ Set state in event handler
+// Recommended: set state in event handlers
 function Component() {
   const [count, setCount] = useState(0);
   return (
@@ -72,23 +72,65 @@ function Component() {
 }
 ```
 
+### Deriving values from props
+
+If you only need to transform props before displaying them, compute the value directly during rendering instead of copying it into state.
+
 ```tsx
-// ✅ Derive from props instead of setting state
+// Recommended: derive values directly during rendering
 function Component({ user }) {
-  const name = user?.name || '';
-  const email = user?.email || '';
+  const name = user?.name || "";
+  const email = user?.email || "";
   return <div>{name}</div>;
 }
 ```
 
+### Syncing state to a prop
+
+A common mistake is trying to "fix" state after it renders. For example, clamping a counter to a `max` prop during render causes an infinite loop as soon as the value exceeds the limit.
+
 ```tsx
-// ✅ Conditionally derive state from props and state from previous renders
+// Problem: adjusting state during render
+function Counter({ max }) {
+  const [count, setCount] = useState(0);
+
+  if (count > max) {
+    setCount(max); // triggers infinite loop when exceeding max
+  }
+
+  return (
+    <button onClick={() => setCount(count + 1)}>
+      {count}
+    </button>
+  );
+}
+```
+
+```tsx
+// Recommended: limit the value when updating
+function Counter({ max }) {
+  const [count, setCount] = useState(0);
+
+  const increment = () => {
+    setCount(current => Math.min(current + 1, max));
+  };
+
+  return <button onClick={increment}>{count}</button>;
+}
+```
+
+### Conditional state updates during render
+
+In rare cases, you may need to adjust state based on information from previous renders. This is valid only when guarded by a condition that prevents infinite loops.
+
+```tsx
+// OK: conditionally updating state based on information from the previous render
 function Component({ items }) {
   const [isReverse, setIsReverse] = useState(false);
   const [selection, setSelection] = useState(null);
 
   const [prevItems, setPrevItems] = useState(items);
-  if (items !== prevItems) { // This condition makes it valid
+  if (items !== prevItems) { // condition prevents infinite loop
     setPrevItems(items);
     setSelection(null);
   }
@@ -96,111 +138,12 @@ function Component({ items }) {
 }
 ```
 
-## Troubleshooting
-
-### I want to sync state to a prop
-
-A common problem is trying to "fix" state after it renders. Suppose you want to keep a counter from exceeding a `max` prop:
-
 ```tsx
-// ❌ Wrong: clamps during render
-function Counter({ max }) {
-  const [count, setCount] = useState(0);
-
-  if (count > max) {
-    setCount(max);
-  }
-
-  return (
-    <button onClick={() => setCount(count + 1)}>
-      {count}
-    </button>
-  );
-}
-```
-
-As soon as `count` exceeds `max`, an infinite loop is triggered.
-
-Instead, it's often better to move this logic to the event (the place where the state is first set). For example, you can enforce the maximum at the moment you update state:
-
-```tsx
-// ✅ Clamp when updating
-function Counter({ max }) {
-  const [count, setCount] = useState(0);
-
-  const increment = () => {
-    setCount(current => Math.min(current + 1, max));
-  };
-
-  return <button onClick={increment}>{count}</button>;
-}
-```
-
-Now the setter only runs in response to the click, React finishes the render normally, and `count` never crosses `max`.
-
-In rare cases, you may need to adjust state based on information from previous renders. For those, follow the pattern of [setting state conditionally](https://react.dev/reference/react/useState#storing-information-from-previous-renders).
-
-## Common Violations
-
-### Invalid
-
-```tsx
-import { useState } from "react";
-
-function Component({ value }) {
-  const [count, setCount] = useState(0);
-  // 🔴 Unconditional setState directly in render
-  setCount(value);
-  return <div>{count}</div>;
-}
-```
-
-### Valid
-
-```tsx
-import { useState } from "react";
-
-function Component() {
-  const [count, setCount] = useState(0);
-  // ✅ Set state in event handler
-  return (
-    <button onClick={() => setCount(count + 1)}>
-      {count}
-    </button>
-  );
-}
-```
-
-### Valid (Event Handler)
-
-```tsx
-import { useState } from "react";
-
-function Counter({ max }) {
-  const [count, setCount] = useState(0);
-  // ✅ Clamp when updating
-  const increment = () => {
-    setCount(current => Math.min(current + 1, max));
-  };
-  return <button onClick={increment}>{count}</button>;
-}
-```
-
-### Valid (Conditional State Update)
-
-```tsx
-import { useState } from "react";
-
+// Recommended: compute directly during rendering whenever possible
 function Component({ items }) {
   const [isReverse, setIsReverse] = useState(false);
-  const [selection, setSelection] = useState(null);
-
-  // ✅ Conditionally derive state from props and state from previous renders
-  const [prevItems, setPrevItems] = useState(items);
-  if (items !== prevItems) {
-    setPrevItems(items);
-    setSelection(null);
-  }
+  const [selectedId, setSelectedId] = useState(null);
+  const selection = items.find((item) => item.id === selectedId) ?? null;
   // ...
 }
 ```
@@ -215,7 +158,7 @@ Custom state hooks can also be configured via shared ESLint settings, which appl
 {
   "settings": {
     "react-x": {
-      "additionalStateHooks": "(useMyState|useCustomState)",
+      "additionalStateHooks": "(useMyState|useCustomState)"
     }
   }
 }

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.spec.diff.md
@@ -1,4 +1,4 @@
-# set-state-in-render IMPL vs. SPEC Report
+# set-state-in-render IMPL–SPEC Diff Report
 
 **IMPL**: `set-state-in-render.ts` + `lib.ts` (ESLint rule)\
 **SPEC**: `set-state-in-render.spec.md` (React Compiler `ValidateNoSetStateInRender`)
@@ -30,7 +30,7 @@ The IMPL operates on the ESLint AST. It detects `setState` calls by tracing vari
 
 ---
 
-## 3. Conditional vs. Unconditional Execution
+## 3. Conditional and Unconditional Execution
 
 The SPEC uses `computeUnconditionalBlocks` (post-dominator tree) to determine exactly which code blocks always execute. A `setState` call is only flagged if it resides in an unconditional block.
 

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added IMPL vs SPEC diff document (`static-components.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`static-components.spec.diff.md`) for tracking deviations from the React Compiler specification.
 
 ### Changed
 

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.mdx
@@ -43,32 +43,21 @@ If you find yourself wanting to define components inside other components to acc
 
 ## Examples
 
-### Invalid
+### Nesting component definitions
+
+Defining a component inside another component causes it to be recreated on every parent render. React treats each definition as a distinct component type, causing the child to unmount and remount every time.
 
 ```tsx
+// Problem: defining a component inside another component
 function Parent() {
-  // 🔴 Never define a component inside another component!
   const Child = () => <div />;
 
-  return <Child />; // State resets every render
+  return <Child />; // resets state on every render
 }
 ```
 
 ```tsx
-function Parent({ type }) {
-  // 🔴 Dynamically creating components during render
-  const Component = type === "button"
-    ? () => <button>Click</button>
-    : () => <div>Text</div>;
-
-  return <Component />;
-}
-```
-
-### Valid
-
-```tsx
-// ✅ Declare components at the top level
+// Recommended: declare components at the top level
 function Parent() {
   return <Child />;
 }
@@ -78,7 +67,65 @@ function Child() {
 }
 ```
 
-When a child component needs data from a parent, [pass it by props](https://react.dev/learn/passing-props-to-a-component) instead of nesting definitions.
+### Dynamically creating component types
+
+Creating different component types based on props or state during render has the same problem — React cannot reconcile between different component types.
+
+```tsx
+// Problem: dynamically creating components based on props
+function Parent({ type }) {
+  const Component = type === "button"
+    ? () => <button>Click</button>
+    : () => <div>Text</div>;
+
+  return <Component />;
+}
+```
+
+```tsx
+// Recommended: pass props instead of dynamically creating components
+function Parent({ type }) {
+  return type === "button"
+    ? <Button>Click</Button>
+    : <TextBox>Text</TextBox>;
+}
+
+function Button({ children }) {
+  return <button>{children}</button>;
+}
+
+function TextBox({ children }) {
+  return <div>{children}</div>;
+}
+```
+
+### Accessing parent variables in nested components
+
+A common motivation for nesting components is to capture local variables from the parent scope. This should be solved with props instead.
+
+```tsx
+// Problem: nesting components to access parent variables
+function Parent({ items }) {
+  const ItemList = () => (
+    <ul>{items.map(item => <li key={item.id}>{item.name}</li>)}</ul>
+  );
+
+  return <ItemList />;
+}
+```
+
+```tsx
+// Recommended: pass data via props
+function Parent({ items }) {
+  return <ItemList items={items} />;
+}
+
+function ItemList({ items }) {
+  return (
+    <ul>{items.map(item => <li key={item.id}>{item.name}</li>)}</ul>
+  );
+}
+```
 
 ## Resources
 

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.diff.md
@@ -1,4 +1,4 @@
-# static-components IMPL vs. SPEC Report
+# static-components IMPL–SPEC Diff Report
 
 **IMPL**: `static-components.ts` + `lib.ts` (ESLint rule)\
 **SPEC**: `static-components.spec.md` (React Compiler `ValidateStaticComponents`)

--- a/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.mdx
@@ -3,13 +3,13 @@ title: unsupported-syntax
 description: Validates against syntax that React Compiler does not support.
 ---
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/unsupported-syntax
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/unsupported-syntax
@@ -35,39 +35,69 @@ This rule checks for the following unsupported patterns:
 - **`with` statements** — Dynamically changes scope, preventing static analysis.
 - **IIFEs in JSX** — Immediately-invoked function expressions within JSX elements or fragments will not be optimized by React Compiler.
 
-### Invalid
+## Examples
+
+### Using `eval` in components
+
+`eval` executes code dynamically at runtime, making it impossible for any static analysis tool to understand what variables are accessed or modified.
 
 ```tsx
-// ❌ Using eval in component
+// Problem: using eval in a component
 function Component({ code }) {
-  const result = eval(code); // Can't be analyzed
+  const result = eval(code); // cannot be statically analyzed
+  //             ^^^ Do not use 'eval' inside components or hooks. 'eval' cannot be statically analyzed and is not supported by React Compiler.
   return <div>{result}</div>;
 }
 ```
 
 ```tsx
-// ❌ Using with statement
+// Recommended: use analyzable property access
+function Component({ propName, props }) {
+  const value = props[propName]; // statically analyzable
+  return <div>{value}</div>;
+}
+```
+
+```tsx
+// Recommended: using eval outside components and hooks is fine
+function notAComponent() {
+  const result = eval("1 + 2");
+  return result;
+}
+```
+
+### Using `with` statements
+
+The `with` statement dynamically modifies the scope chain at runtime. Static analysis tools cannot predict which identifiers refer to which objects inside a `with` block.
+
+```tsx
+// Problem: using with in a component
 function Component() {
-  with (Math) { // Changes scope dynamically
+  with (Math) { // dynamically changes scope
+  // ^^^ Do not use 'with' statements inside components or hooks. 'with' changes scope dynamically and is not supported by React Compiler.
     return <div>{sin(PI / 2)}</div>;
   }
 }
 ```
 
 ```tsx
-// ❌ Dynamic property access with eval
-function Component({ propName }) {
-  const value = eval(`props.${propName}`);
-  return <div>{value}</div>;
+// Recommended: use standard method calls
+function Component() {
+  return <div>{Math.sin(Math.PI / 2)}</div>;
 }
 ```
 
+### IIFEs in JSX
+
+Immediately-invoked function expressions inside JSX prevent the compiler from analyzing the component's output structure at build time.
+
 ```tsx
-// ❌ IIFE in JSX
+// Problem: using IIFE in JSX
 function MyComponent() {
   return (
     <SomeJsx>
       {(() => {
+      // ^^^ Avoid using immediately-invoked function expressions in JSX. IIFEs will not be optimized by React Compiler.
         const filteredThings = things.filter(callback);
 
         if (filteredThings.length === 0) {
@@ -81,33 +111,8 @@ function MyComponent() {
 }
 ```
 
-### Valid
-
 ```tsx
-// ✅ Use normal property access
-function Component({ propName, props }) {
-  const value = props[propName]; // Analyzable
-  return <div>{value}</div>;
-}
-```
-
-```tsx
-// ✅ Use standard Math methods
-function Component() {
-  return <div>{Math.sin(Math.PI / 2)}</div>;
-}
-```
-
-```tsx
-// ✅ eval outside of components and hooks is fine
-function notAComponent() {
-  const result = eval("1 + 2");
-  return result;
-}
-```
-
-```tsx
-// ✅ Extract IIFE logic into a variable before JSX
+// Recommended: extract logic into variables outside JSX
 function MyComponent() {
   const thingsList = (() => {
     const filteredThings = things.filter(callback);
@@ -128,7 +133,7 @@ function MyComponent() {
 ```
 
 ```tsx
-// ✅ Use useMemo instead of IIFE
+// Recommended: use useMemo instead of IIFE
 function MyComponent() {
   const thingsList = useMemo(() => {
     const filteredThings = things.filter(callback);
@@ -148,31 +153,29 @@ function MyComponent() {
 }
 ```
 
-## Troubleshooting
-
-### I need to evaluate dynamic code
-
-You might need to evaluate user-provided code:
-
 ```tsx
-// ❌ Wrong: eval in component
-function Calculator({ expression }) {
-  const result = eval(expression); // Unsafe and unoptimizable
-  return <div>Result: {result}</div>;
+// Recommended: use ternary or logical expressions
+function MyComponent() {
+  return (
+    <div>
+      {loading ? <Spinner /> : error ? <Error /> : <Content />}
+    </div>
+  );
 }
 ```
 
-Use a safe expression parser instead:
+### Evaluating dynamic expressions safely
+
+If you need to evaluate user-provided code, use a safe expression parser instead of `eval`.
 
 ```tsx
-// ✅ Better: Use a safe parser
-import { evaluate } from 'mathjs'; // or similar library
+// Recommended: use a safe parsing library
+import { evaluate } from 'mathjs';
 
 function Calculator({ expression }) {
   const [result, setResult] = useState(null);
   const calculate = () => {
     try {
-      // Safe mathematical expression evaluation
       setResult(evaluate(expression));
     } catch (error) {
       setResult('Invalid expression');
@@ -188,152 +191,6 @@ function Calculator({ expression }) {
 ```
 
 > **Note:** Never use `eval` with user input — it's a security risk. Use dedicated parsing libraries for specific use cases like mathematical expressions, JSON parsing, or template evaluation.
-
-### I need conditional rendering logic in JSX
-
-You might be using an IIFE in JSX to handle complex conditional rendering:
-
-```tsx
-// ❌ Wrong: IIFE in JSX
-function MyComponent() {
-  return (
-    <div>
-      {(() => {
-        if (loading) return <Spinner />;
-        if (error) return <Error />;
-        return <Content />;
-      })()}
-    </div>
-  );
-}
-```
-
-Extract the logic into a variable before the return statement, or use a helper component:
-
-```tsx
-// ✅ Better: Extract into a variable
-function MyComponent() {
-  const content = (() => {
-    if (loading) return <Spinner />;
-    if (error) return <Error />;
-    return <Content />;
-  })();
-
-  return <div>{content}</div>;
-}
-```
-
-```tsx
-// ✅ Even better: Use ternary or logical expressions
-function MyComponent() {
-  return (
-    <div>
-      {loading ? <Spinner /> : error ? <Error /> : <Content />}
-    </div>
-  );
-}
-```
-
-## Common Violations
-
-### Invalid
-
-```tsx
-function Component({ code }) {
-  const result = eval(code);
-  //             ^^^ Do not use 'eval' inside components or hooks. 'eval' cannot be statically analyzed and is not supported by React Compiler.
-  return <div>{result}</div>;
-}
-```
-
-```tsx
-function Component() {
-  with (Math) {
-  // ^^^ Do not use 'with' statements inside components or hooks. 'with' changes scope dynamically and is not supported by React Compiler.
-    return <div>{sin(PI / 2)}</div>;
-  }
-}
-```
-
-```tsx
-function useMyHook(code) {
-  const result = eval(code);
-  //             ^^^ Do not use 'eval' inside components or hooks. 'eval' cannot be statically analyzed and is not supported by React Compiler.
-  return result;
-}
-```
-
-```tsx
-function MyComponent() {
-  return (
-    <SomeJsx>
-      {(() => {
-      // ^^^ Avoid using immediately-invoked function expressions in JSX. IIFEs will not be optimized by React Compiler.
-        const filteredThings = things.filter(callback);
-
-        if (filteredThings.length === 0) {
-          return <Empty />;
-        }
-
-        return filteredThings.map((thing) => <Thing key={thing.id} data={thing} />);
-      })()}
-    </SomeJsx>
-  );
-}
-```
-
-### Valid
-
-```tsx
-function Component({ propName, props }) {
-  const value = props[propName];
-  return <div>{value}</div>;
-}
-```
-
-```tsx
-function Component() {
-  return <div>{Math.sin(Math.PI / 2)}</div>;
-}
-```
-
-```tsx
-function Component() {
-  const handleClick = () => {
-    eval("something");
-  };
-  return <button onClick={handleClick}>Click</button>;
-}
-```
-
-```tsx
-function Component() {
-  useEffect(() => {
-    eval("something");
-  }, []);
-  return <div>Content</div>;
-}
-```
-
-```tsx
-function MyComponent() {
-  const thingsList = useMemo(() => {
-    const filteredThings = things.filter(callback);
-
-    if (filteredThings.length === 0) {
-      return <Empty />;
-    }
-
-    return filteredThings.map((thing) => <Thing key={thing.id} data={thing} />);
-  }, [things, callback]);
-
-  return (
-    <SomeJsx>
-      {thingsList}
-    </SomeJsx>
-  );
-}
-```
 
 ## Resources
 

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added IMPL vs SPEC diff document (`use-memo.spec.diff.md`) for tracking deviations from the React Compiler specification.
+- Added IMPL–SPEC diff document (`use-memo.spec.diff.md`) for tracking deviations from the React Compiler specification.
 
 ### Changed
 

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.mdx
@@ -3,13 +3,13 @@ title: use-memo
 description: Validates that 'useMemo' is called with a callback that returns a value.
 ---
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/use-memo
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/use-memo
@@ -35,25 +35,38 @@ This rule ensures that `useMemo()` callbacks follow React's requirements. It che
 4. Callbacks should return a value (useMemo is for computing values, not side effects)
 5. The result of useMemo should be used (not discarded)
 
-## Common Violations
+## Examples
 
-### Invalid
+### useMemo callback receiving parameters
 
-#### Callback with parameters
+`useMemo` callbacks do not accept any parameters. All required data should be captured via closure.
 
 ```tsx
+// Problem: callback receives parameter c
 import { useMemo } from "react";
 
 function Component({ a, b }) {
   const x = useMemo((c) => a + c, [a]);
-  //                 ^^ Callbacks with parameters are not supported
   return <div>{x}</div>;
 }
 ```
 
-#### Async or generator callback
+```tsx
+// Recommended: use external variables directly via closure
+import { useMemo } from "react";
+
+function Component({ a, b }) {
+  const x = useMemo(() => a + b, [a, b]);
+  return <div>{x}</div>;
+}
+```
+
+### Using async or generator functions in useMemo
+
+`useMemo` is for synchronous value computation and does not support async or generator functions.
 
 ```tsx
+// Problem: using an async callback
 import { useMemo } from "react";
 
 function Component({ a }) {
@@ -65,9 +78,12 @@ function Component({ a }) {
 }
 ```
 
-#### Reassigning outer variables
+### Reassigning external variables in a useMemo callback
+
+`useMemo` callbacks must be pure functions and should not modify variables in the outer scope.
 
 ```tsx
+// Problem: callback reassigns external variable x
 import { useMemo } from "react";
 
 function Component() {
@@ -81,23 +97,50 @@ function Component() {
 }
 ```
 
-#### No return value
+```tsx
+// Recommended: only read external variables, do not modify them
+import { useMemo } from "react";
+
+function Component({ a, b }) {
+  const sum = useMemo(() => a + b, [a, b]);
+  return <div>{sum}</div>;
+}
+```
+
+### useMemo callback without a return value
+
+The purpose of `useMemo` is to cache computed results, so the callback must explicitly return a value.
 
 ```tsx
+// Problem: callback has no return, result is always undefined
 import { useMemo } from "react";
 
 function Component({ data }) {
   const processed = useMemo(() => {
     data.forEach((item) => console.log(item));
-    // Missing return! Callback must return a value.
   }, [data]);
-  return <div>{processed}</div>; // Always undefined
+  return <div>{processed}</div>;
 }
 ```
 
-#### Result not assigned
+```tsx
+// Recommended: return the computed value
+import { useMemo } from "react";
+
+function Component({ data }) {
+  const processed = useMemo(() => {
+    return data.map((item) => item * 2);
+  }, [data]);
+  return <div>{processed}</div>;
+}
+```
+
+### Calling useMemo but not using its return value
+
+If the result of `useMemo` is not assigned or used, caching is pointless.
 
 ```tsx
+// Problem: useMemo return value is discarded
 import { useMemo } from "react";
 
 function Component({ user }) {
@@ -109,11 +152,22 @@ function Component({ user }) {
 }
 ```
 
-### Valid
+```tsx
+// Recommended: assign the result to a variable and use it in JSX
+import { useMemo } from "react";
 
-#### Returns a computed value
+function Component({ items }) {
+  const sorted = useMemo(() => [...items].sort(), [items]);
+  return <div>{sorted.join(", ")}</div>;
+}
+```
+
+### Correctly returning computed values
+
+When the callback correctly returns a synchronous computed value, `useMemo` works as expected.
 
 ```tsx
+// OK: returning a mapped array
 import { useMemo } from "react";
 
 function Component({ data }) {
@@ -124,25 +178,17 @@ function Component({ data }) {
 }
 ```
 
-#### Arrow function with concise body
+### Using concise arrow functions
+
+Using arrow functions with implicit return makes `useMemo` callbacks more concise.
 
 ```tsx
+// OK: concise arrow function directly returns the computed result
 import { useMemo } from "react";
 
 function Component({ items }) {
   const sorted = useMemo(() => [...items].sort(), [items]);
   return <div>{sorted.join(", ")}</div>;
-}
-```
-
-#### Reads outer variables without reassigning
-
-```tsx
-import { useMemo } from "react";
-
-function Component({ a, b }) {
-  const sum = useMemo(() => a + b, [a, b]);
-  return <div>{sum}</div>;
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.diff.md
@@ -1,4 +1,4 @@
-# use-memo IMPL vs. SPEC Report
+# use-memo IMPL–SPEC Diff Report
 
 **IMPL**: `use-memo.ts` (ESLint rule)\
 **SPEC**: `use-memo.spec.md` (React Compiler `ValidateUseMemo.ts`)

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.md
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.md
@@ -208,7 +208,7 @@ function hasNonVoidReturn(func: HIRFunction): boolean {
 
 ## Edge Cases
 
-### React.useMemo vs useMemo
+### React.useMemo and useMemo
 
 The pass handles both import styles:
 

--- a/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.mdx
@@ -3,13 +3,13 @@ title: use-state
 description: Enforces correct usage of 'useState', including destructuring, symmetric naming of the value and setter, and wrapping expensive initializers in a lazy initializer function.
 ---
 
-**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x)**
+**Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
 
 ```plain copy
 react-x/use-state
 ```
 
-**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin)**
+**Full Name in [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin/v/latest)**
 
 ```plain copy
 @eslint-react/use-state
@@ -39,14 +39,14 @@ This rule covers three concerns:
 
 > Lazy initialization behavior was previously a standalone `prefer-use-state-lazy-initialization` rule. That rule has been merged into `use-state` and removed.
 
-## Common Violations
+## Examples
 
-### Assignment (Destructuring)
+### Not destructuring the useState return value
 
-#### Invalid
+`useState` must return a `[value, setter]` array pattern. Assigning directly to a single variable prevents calling the setter to update state.
 
 ```tsx
-// ❌ Not destructured (enforceAssignment: true)
+// Problem: not destructured into a [value, setter] pair
 import { useState } from "react";
 
 function Counter() {
@@ -56,10 +56,10 @@ function Counter() {
 }
 ```
 
-#### Valid
+If only the state value is needed and not the setter, you can destructure just the value:
 
 ```tsx
-// ✅ Only value destructured — setter omitted
+// OK: destructure only the value, omitting the setter
 import { useState } from "react";
 
 function Component() {
@@ -68,12 +68,12 @@ function Component() {
 }
 ```
 
-### Setter Naming (Symmetry)
+### Setter name does not follow the symmetric naming convention
 
-#### Invalid
+The setter name should be `set` followed by the capitalized state variable name, for example `count` corresponds to `setCount`. Snake\_case names also allow symmetric forms.
 
 ```tsx
-// ❌ Setter name does not match value name
+// Problem: setter name is not symmetric with the state name
 import { useState } from "react";
 
 function Counter() {
@@ -84,7 +84,7 @@ function Counter() {
 ```
 
 ```tsx
-// ❌ Setter prefix is correct but capitalization is wrong
+// Problem: correct prefix but case mismatch
 import { useState } from "react";
 
 function Counter() {
@@ -93,10 +93,8 @@ function Counter() {
 }
 ```
 
-#### Valid
-
 ```tsx
-// ✅ Symmetric camelCase naming
+// Recommended: use symmetric camelCase naming
 import { useState } from "react";
 
 function Counter() {
@@ -106,7 +104,7 @@ function Counter() {
 ```
 
 ```tsx
-// ✅ Snake_case value and setter
+// OK: symmetric snake_case naming
 import { useState } from "react";
 
 function Counter() {
@@ -115,8 +113,12 @@ function Counter() {
 }
 ```
 
+### Using complex objects as state with plain identifiers
+
+The state value itself must be a plain identifier and cannot be a destructuring pattern. However, storing objects or arrays as the state value is completely allowed.
+
 ```tsx
-// ✅ Object state stored under a plain identifier
+// OK: object state stored under a plain identifier
 import { useState } from "react";
 
 function Form() {
@@ -125,12 +127,12 @@ function Form() {
 }
 ```
 
-### Lazy Initialization
+### Passing a function call directly as the initial value
 
-#### Invalid
+If the initial value needs to be computed by a function, passing the function call directly causes it to re-execute on every render. It should be wrapped in a lazy initializer function.
 
 ```tsx
-// ❌ Function call passed directly as initial state (enforceLazyInitialization: true)
+// Problem: generateTodos is called on every render
 import { useState } from "react";
 
 function MyComponent() {
@@ -142,10 +144,8 @@ function MyComponent() {
 declare function generateTodos(): string[];
 ```
 
-#### Valid
-
 ```tsx
-// ✅ Lazy initializer wrapping an expensive function call
+// Recommended: use a lazy initializer function that only runs on the first render
 import { useState } from "react";
 
 function MyComponent() {
@@ -156,8 +156,10 @@ function MyComponent() {
 declare function generateTodos(): string[];
 ```
 
+React's `use()` Hook is safe as an initial value because it has special handling semantics:
+
 ```tsx
-// ✅ use() calls are always allowed as initial state
+// OK: use() calls as the initial value are always allowed
 import { useState, use } from "react";
 
 function Component({ promise }) {

--- a/plugins/eslint-plugin/README.md
+++ b/plugins/eslint-plugin/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/npm/l/@eslint-react/core?style=flat&colorA=333333&colorB=000000)](https://github.com/Rel1cx/eslint-react/blob/main/LICENSE)
 [![Build with](https://img.shields.io/badge/built_with-tsdown@0.22.0-000000?style=flat)](https://tsdown.dev)
 
-4-7x faster, composable ESLint rules for React and friends.
+Performant, composable ESLint rules for React and friends.
 
 ## Table of Contents
 
@@ -25,7 +25,6 @@
   - [TypeScript Specialized](#typescript-specialized)
   - [Other](#other)
 - [Rules](#rules)
-- [Benchmark](#benchmark)
 - [FAQ](#faq)
 - [Migration](#migration)
 - [Changelog](#changelog)
@@ -38,7 +37,7 @@
 
 - **Modern**: First-class support for **TypeScript**, **React 19**, and more.
 - **Flexible**: Fully customizable rule severity levels, allowing you to **enforce** or **relax** rules as needed.
-- **Performant**: Built with performance in mind, optimized for large codebases, [**4-7x faster**](https://github.com/Rel1cx/eslint-react-benchmark) than other ESLint plugins.
+- **Performant**: Built with performance in mind, optimized for large codebases, code editor responsiveness, and CI pipelines.
 - **Context-aware linting**: Rules that understand the context of your code and [project configuration](https://eslint-react.xyz/docs/configuration/configure-project-config) to provide more **accurate** linting.
 
 ## Public Packages
@@ -188,18 +187,14 @@ export default defineConfig(
 
 [Rules ↗](https://eslint-react.xyz/docs/rules)
 
-## Benchmark
-
-[Benchmark Results ↗](https://github.com/Rel1cx/eslint-react-benchmark)
-
 ## FAQ
 
 [Frequently Asked Questions ↗](https://eslint-react.xyz/docs/faq)
 
 ## Migration
 
-- [Migrating from eslint-plugin-react ↗](https://beta.eslint-react.xyz/docs/migrating-from-eslint-plugin-react)
-- [Migrating from eslint-plugin-react-hooks ↗](https://beta.eslint-react.xyz/docs/migrating-from-eslint-plugin-react-hooks)
+- [Migrating from eslint-plugin-react ↗](https://eslint-react.xyz/docs/migrating-from-eslint-plugin-react)
+- [Migrating from eslint-plugin-react-hooks ↗](https://eslint-react.xyz/docs/migrating-from-eslint-plugin-react-hooks)
 
 ## Changelog
 


### PR DESCRIPTION
Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Restructures rule documentation across all plugins (react-x, react-dom, react-jsx, react-web-api, react-naming-convention, react-debug, react-rsc) from the old `Common Violations / Invalid / Valid` format to the new `Examples / scenario-based / Troubleshooting / Further Reading` format. Also updates npmx.dev links to include `/v/latest` and normalizes IMPL–SPEC diff document references.