### PR TITLE
docs: remove inline ESLint error annotations from examples

### DIFF
--- a/apps/website/content/docs/recipes/custom-rules-of-children.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-children.mdx
@@ -207,7 +207,6 @@ function MyComponent({ children }) {
   return (
     <div className="RowList">
       {Children.map(children, (child) => <div className="Row">{child}</div>)}
-      //      ^^^ Using 'Children.map' is uncommon and can lead to fragile code. Use alternatives instead.
     </div>
   );
 }

--- a/apps/website/content/docs/recipes/custom-rules-of-props.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-props.mdx
@@ -83,13 +83,11 @@ export default [
 ```tsx
 // Problem: duplicate props silently discard earlier values.
 <div id="a" id="b" />;
-//          ^^^ Prop `id` is specified more than once. Only the last one will take effect.
 ```
 
 ```tsx
 // Problem: duplicate props silently discard earlier values.
 <div onClick={handleA} onClick={handleB} />;
-//                      ^^^ Prop `onClick` is specified more than once. Only the last one will take effect.
 ```
 
 #### Unique props or conditional spreads
@@ -254,13 +252,11 @@ export default [
 ```tsx
 // Problem: spreading an object literal hides props from view.
 <MyComponent {...{ foo, bar, baz }} />;
-//            ^^^ Don't spread an object literal in JSX. Write each property as a separate prop instead.
 ```
 
 ```tsx
 // Problem: spreading an object literal hides props from view.
 <input {...{ disabled: true, readOnly: true }} />;
-//      ^^^ Don't spread an object literal in JSX. Write each property as a separate prop instead.
 ```
 
 #### Spreading variables or conditional expressions
@@ -350,13 +346,11 @@ export default [
 ```tsx
 // Problem: mixing controlled and uncontrolled props causes confusing bugs.
 <input value={name} defaultValue="World" />;
-//                  ^^^ 'value' and 'defaultValue' should not be used together. Use either controlled or uncontrolled mode, not both.
 ```
 
 ```tsx
 // Problem: mixing controlled and uncontrolled props causes confusing bugs.
 <input type="checkbox" checked={isChecked} defaultChecked />;
-//                                         ^^^ 'checked' and 'defaultChecked' should not be used together. Use either controlled or uncontrolled mode, not both.
 ```
 
 #### Using either controlled or uncontrolled mode

--- a/apps/website/content/docs/recipes/function-component-definition.mdx
+++ b/apps/website/content/docs/recipes/function-component-definition.mdx
@@ -100,7 +100,6 @@ export default [
 ```tsx
 // Problem: Function components must be defined with arrow functions.
 function MyComponent({ name }: { name: string }) {
-//      ^^^ Function components must be defined with arrow functions.
   return <div>Hello, {name}!</div>;
 }
 ```
@@ -108,7 +107,6 @@ function MyComponent({ name }: { name: string }) {
 ```tsx
 // Problem: Function components must be defined with arrow functions.
 const MyComponent = function({ name }: { name: string }) {
-//                  ^^^ Function components must be defined with arrow functions.
   return <div>Hello, {name}!</div>;
 };
 ```

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.mdx
@@ -47,7 +47,6 @@ interface MyComponentProps {
 function MyComponent({ children }: MyComponentProps) {
   // Problem: Children should always be actual children, not passed in as a prop.
   return <div children={children} />;
-  //          ^^^ Children should always be actual children, not passed in as a prop.
 }
 ```
 

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.mdx
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.mdx
@@ -38,7 +38,6 @@ If the `key` prop is before any spread props, it is passed as the `key` argument
 ```tsx
 // Problem: The 'key' prop must be placed before any spread props when using the new JSX transform.
 <div {...props} key="2" />;
-//              ^^^ The 'key' prop must be placed before any spread props when using the new JSX transform.
 ```
 
 ### Using `key` before or without spread props

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.mdx
@@ -40,7 +40,6 @@ class MyComponent extends Component {
   componentDidMount() {
     // Problem: An 'addEventListener' in 'componentDidMount' should have a corresponding 'removeEventListener' in the 'componentWillUnmount' method.
     document.addEventListener("click", this.handleClick);
-    //                                 ^^^ An 'addEventListener' in 'componentDidMount' should have a corresponding 'removeEventListener' in the 'componentWillUnmount' method.
   }
 
   handleClick() {
@@ -66,7 +65,6 @@ function MyComponent() {
 
     // Problem: An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
     document.addEventListener("click", handleClick);
-    //                                 ^^^ An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
   }, []);
 
   return null;
@@ -82,7 +80,6 @@ function MyComponent() {
   useEffect(() => {
     // Problem: An 'addEventListener' should not have an inline listener function.
     document.addEventListener("click", () => console.log("clicked"));
-    //                                 ^^^ An 'addEventListener' should not have an inline listener function.
   }, []);
 
   return null;
@@ -102,7 +99,6 @@ function MyComponent() {
 
     document.addEventListener("click", handleClick, { capture: true });
     // Problem: An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
-    //                                 ^^^ An 'addEventListener' in 'useEffect' should have a corresponding 'removeEventListener' in its cleanup function.
 
     return () => {
       // Problem: Options don't match — removeEventListener must use the same capture value
@@ -127,14 +123,12 @@ function MyComponent() {
 
     // Problem: The entries are not guaranteed to be the same as those in the effect cleanup function.
     for (const [name, handler] of Object.entries(handlers)) {
-      //                          ^^^ The entries are not guaranteed to be the same as those in the effect cleanup function.
       el.addEventListener(name, handler);
     }
 
     return () => {
       // Problem: The entries are not guaranteed to be the same as those in the effect setup function.
       for (const [name, handler] of Object.entries(handlers)) {
-        //                          ^^^ The entries are not guaranteed to be the same as those in the effect setup function.
         el.removeEventListener(name, handler);
       }
     };

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.mdx
@@ -55,7 +55,6 @@ function UserProfile({ id }: { id: string }) {
   useEffect(() => {
     // Problem: A 'fetch' started in 'useEffect' must be aborted in the cleanup function.
     fetch(`/api/user/${id}`)
-    // ^^^ A 'fetch' started in 'useEffect' must be aborted in the cleanup function.
       .then((r) => r.json())
       .then(setUser);
   }, [id]);

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.mdx
@@ -42,7 +42,6 @@ function MyComponent() {
   useEffect(() => {
     // Problem: A 'setInterval' created in 'useEffect' must be cleared in the cleanup function.
     const intervalId = setInterval(() => console.log(count), 1000);
-    //                 ^^^ A 'setInterval' created in 'useEffect' must be cleared in the cleanup function.
   }, []);
 
   return null;

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.mdx
@@ -43,7 +43,6 @@ function MyComponent() {
     if (!ref.current) return;
     // Problem: A 'ResizeObserver' in 'useEffect' should have a corresponding 'resizeObserver.disconnect()' in its cleanup function.
     const ro = new ResizeObserver(() => console.log("resize"));
-    //         ^^^ A 'ResizeObserver' in 'useEffect' should have a corresponding 'resizeObserver.disconnect()' in its cleanup function.
     ro.observe(ref.current);
   }, []);
 

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.mdx
@@ -42,7 +42,6 @@ function MyComponent() {
   useEffect(() => {
     // Problem: A 'setTimeout' created in 'useEffect' must be cleared in the cleanup function.
     const timeoutId = setTimeout(() => console.log(count), 1000);
-    //                ^^^ A 'setTimeout' created in 'useEffect' must be cleared in the cleanup function.
   }, []);
 
   return null;

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
@@ -39,7 +39,6 @@ function MyComponent () {
   return [
     <li key="1">Item 1</li>
     <li key="1">Item 2</li>
-    //  ^^^ The 'key' prop must be unique to its sibling elements.
   ]
 };
 ```
@@ -65,7 +64,6 @@ function MyComponent() {
     <ul>
       <li key="1">Item 1</li>
       <li key="1">Item 2</li>
-      {/* ^^^ The 'key' prop must be unique to its sibling elements. */}
     </ul>
   );
 }
@@ -93,7 +91,6 @@ function MyComponent() {
   return (
     <ul>
       {["a", "b"].map((id) => <li key="1">{id}</li>)}
-      //                                     ^^^ The 'key' prop must be unique to its sibling elements.
     </ul>
   );
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
@@ -46,7 +46,6 @@ declare let someValues: { id: string; className: string; children: string };
 // Problem: Implicitly passing children when spreading an object
 function MyComponent() {
   return <div {...someValues} />;
-  //          ^^^ This spread attribute implicitly passes the 'children' prop to a component, this could lead to unexpected behavior. If you intend to pass the 'children' prop, use 'children={value}'.
 }
 ```
 
@@ -59,7 +58,6 @@ declare let someValues: { id: string; className: string; children: string };
 function MyComponent() {
   const { children, ...rest } = someValues;
   return <div {...rest}>{children}</div>;
-  //      ^^^ Dropping the 'children' prop from the spread attributes to prevent implicitly passing it to the component.
 }
 ```
 
@@ -75,7 +73,6 @@ declare let someValues: { id: string; className: string; children: React.ReactNo
 // OK: children type is React.ReactNode, which is a React built-in type alias
 function MyComponent() {
   return <div {...someValues} data-slot="my-component" />;
-  //          ^^^ The 'children' property is typed as React.ReactNode, which is a React-defined type alias. Allowed.
 }
 ```
 
@@ -89,7 +86,6 @@ import React from "react";
 // OK: props come from React.ComponentProps, children originates from React.DOMAttributes
 function PaginationItem({ ...props }: React.ComponentProps<"li">) {
   return <li data-slot="pagination-item" {...props} />;
-  //                                     ^^^ The 'children' property originates from React.DOMAttributes.children. Allowed.
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.mdx
@@ -48,7 +48,6 @@ declare let someValues: { foo: string; bar: string; key: string };
 // Problem: Implicitly passing key when spreading an object
 function MyComponent() {
   return <div {...someValues} />;
-  //          ^^^ This spread attribute implicitly passes the 'key' prop to a component, this could lead to unexpected behavior. If you intend to pass the 'key' prop, use 'key={value}'.
 }
 ```
 
@@ -61,7 +60,6 @@ declare let someValues: { id: string; className: string; key: string };
 function MyComponent() {
   const { key, ...rest } = someValues;
   return <div key={key} {...rest} />;
-  //      ^^^ Dropping the 'key' prop from the spread attributes to prevent implicitly passing it to the component.
 }
 ```
 
@@ -77,7 +75,6 @@ declare let someValues: { id: string; className: string; key: React.Key };
 // OK: key type is React.Key, which is a React built-in type
 function MyComponent() {
   return <div {...someValues} data-slot="pagination-item" />;
-  //          ^^^ The 'key' property is typed as React.Key, which is a React-defined type alias. Allowed.
 }
 ```
 
@@ -91,7 +88,6 @@ import React from "react";
 // OK: props come from React.ComponentProps, key originates from React.Attributes
 function PaginationItem({ ...props }: React.ComponentProps<"li">) {
   return <li data-slot="pagination-item" {...props} />;
-  //                                     ^^^ The 'key' property originates from React.Attributes.key. Allowed.
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.spec.ts
@@ -356,7 +356,6 @@ ruleTesterWithTypes.run(RULE_NAME, rule, {
 
       function MyComponent() {
         return <div {...someValues} data-slot="pagination-item" />;
-        //          ^^^ Passing-through React internally defined keys are allowed.
       }
     `,
     tsx`

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
@@ -46,7 +46,6 @@ declare let someValues: { id: string; className: string; ref: null };
 // Problem: Implicitly passing ref when spreading an object
 function MyComponent() {
   return <div {...someValues} />;
-  //          ^^^ This spread attribute implicitly passes the 'ref' prop to a component, this could lead to unexpected behavior. If you intend to pass the 'ref' prop, use 'ref={value}'.
 }
 ```
 
@@ -59,7 +58,6 @@ declare let someValues: { id: string; className: string; ref: null };
 function MyComponent() {
   const { ref, ...rest } = someValues;
   return <div ref={ref} {...rest} />;
-  //      ^^^ Dropping the 'ref' prop from the spread attributes to prevent implicitly passing it to the component.
 }
 ```
 
@@ -75,7 +73,6 @@ declare let someValues: { id: string; className: string; ref: React.Ref<HTMLDivE
 // OK: ref type is React.Ref, which is a React built-in type alias
 function MyComponent() {
   return <div {...someValues} data-slot="pagination-item" />;
-  //          ^^^ The 'ref' property is typed as React.Ref, which is a React-defined type alias. Allowed.
 }
 ```
 
@@ -89,7 +86,6 @@ import React from "react";
 // OK: props come from React.ComponentProps, ref originates from React.ClassAttributes
 function PaginationItem({ ...props }: React.ComponentProps<"li">) {
   return <li data-slot="pagination-item" {...props} />;
-  //                                     ^^^ The 'ref' property originates from React.ClassAttributes.ref. Allowed.
 }
 ```
 

--- a/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.mdx
@@ -45,7 +45,6 @@ This rule checks for the following unsupported patterns:
 // Problem: using eval in a component
 function Component({ code }) {
   const result = eval(code); // cannot be statically analyzed
-  //             ^^^ Do not use 'eval' inside components or hooks. 'eval' cannot be statically analyzed and is not supported by React Compiler.
   return <div>{result}</div>;
 }
 ```
@@ -74,7 +73,6 @@ The `with` statement dynamically modifies the scope chain at runtime. Static ana
 // Problem: using with in a component
 function Component() {
   with (Math) { // dynamically changes scope
-  // ^^^ Do not use 'with' statements inside components or hooks. 'with' changes scope dynamically and is not supported by React Compiler.
     return <div>{sin(PI / 2)}</div>;
   }
 }
@@ -96,8 +94,7 @@ Immediately-invoked function expressions inside JSX prevent the compiler from an
 function MyComponent() {
   return (
     <SomeJsx>
-      {(() => {
-      // ^^^ Avoid using immediately-invoked function expressions in JSX. IIFEs will not be optimized by React Compiler.
+      {(() => { // Avoid using immediately-invoked function expressions in JSX. IIFEs will not be optimized by React Compiler.
         const filteredThings = things.filter(callback);
 
         if (filteredThings.length === 0) {


### PR DESCRIPTION
This PR removes inline \^^^\ ESLint error annotations from code examples across rule documentation and tests, making the snippets cleaner and easier to read.