### PR TITLE
docs: improve eslint-plugin-react-x rule documentation

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.mdx
@@ -121,6 +121,37 @@ function Component() {
 }
 ```
 
+## Troubleshooting
+
+### Why is the linter telling me not to wrap `use` in `try`/`catch`?
+
+The `use` hook doesn't throw errors in the traditional sense — it suspends component execution. When `use` encounters a pending promise, it suspends the component and lets React show a fallback. Only Suspense and Error Boundaries can handle these cases. The linter warns against `try`/`catch` around `use` to prevent confusion as the `catch` block would never run.
+
+```tsx
+// Problem: try/catch around `use` hook
+function Component({ promise }) {
+  try {
+    const data = use(promise); // Won't catch — `use` suspends, not throws
+    return <div>{data}</div>;
+  } catch (error) {
+    return <div>Failed to load</div>; // Unreachable
+  }
+}
+```
+
+```tsx
+// Recommended: Use an Error Boundary with Suspense
+function App() {
+  return (
+    <ErrorBoundary fallback={<div>Failed to load</div>}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <DataComponent promise={fetchData()} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.ts)

--- a/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps/exhaustive-deps.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/exhaustive-deps/exhaustive-deps.mdx
@@ -1,6 +1,6 @@
 ---
 title: exhaustive-deps
-description: Verifies the list of dependencies for Hooks like 'useEffect' and similar.
+description: Verifies that dependency arrays for React hooks contain all necessary dependencies.
 ---
 
 **Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
@@ -250,6 +250,7 @@ Custom effect hooks can also be configured via shared ESLint settings, which app
 ## Further Reading
 
 - [React Docs: Removing Effect Dependencies](https://react.dev/learn/removing-effect-dependencies)
+- [React Docs: Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
 - [React Docs: `useEffect`](https://react.dev/reference/react/useEffect)
 - [React Docs: `useCallback`](https://react.dev/reference/react/useCallback)
 - [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)

--- a/plugins/eslint-plugin-react-x/src/rules/globals/globals.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/globals/globals.mdx
@@ -132,4 +132,5 @@ function Component({ id }) {
 ## Further Reading
 
 - [React Docs: Keeping Components Pure](https://react.dev/learn/keeping-components-pure)
+- [React Docs: Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)
 - [React Docs: `globals` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/globals)

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
@@ -251,4 +251,5 @@ Custom state hooks can also be configured via shared ESLint settings, which appl
 
 - [React Docs: Updating Objects in State](https://react.dev/learn/updating-objects-in-state)
 - [React Docs: Updating Arrays in State](https://react.dev/learn/updating-arrays-in-state)
+- [React Docs: Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)
 - [React Docs: `immutability` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/immutability)

--- a/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.mdx
@@ -31,6 +31,29 @@ Using `this.state` inside `setState` calls might result in errors when two state
 
 ## Examples
 
+### Reading this.state inside setState may return a stale value
+
+React batches state updates. When you read `this.state` immediately after calling `setState`, it still holds the old value. This demonstrates why the updater function is safer.
+
+```tsx
+// Problem: this.state is not updated immediately after setState
+import React from "react";
+
+class MyComponent extends React.Component {
+  state = { name: "Taylor" };
+
+  handleClick = () => {
+    console.log(this.state.name); // "Taylor"
+    this.setState({ name: "Robin" });
+    console.log(this.state.name); // Still "Taylor"!
+  };
+
+  render() {
+    return <button onClick={this.handleClick}>Change name</button>;
+  }
+}
+```
+
 ### Incrementing state based on the previous value
 
 When multiple `setState` calls are batched together, reading `this.state` directly may give you a stale value. The updater function receives the latest state as an argument, ensuring correctness even with batching.
@@ -89,3 +112,8 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.spec.ts)
 - [Rule Changelog](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/CHANGELOG.md)
+
+## Further Reading
+
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
+- [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.mdx
@@ -77,3 +77,5 @@ function MyComponent({ items }: MyComponentProps) {
 ## Further Reading
 
 - [React Docs: Why does React need keys?](https://react.dev/learn/rendering-lists#why-does-react-need-keys)
+- [React Docs: Rendering Lists](https://react.dev/learn/rendering-lists)
+- [React Docs: `Fragment`](https://react.dev/reference/react/Fragment)

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.mdx
@@ -35,6 +35,26 @@ Using `Children` is uncommon and can lead to fragile code. [See common alternati
 
 Relying on `Children.count` makes your component tightly coupled to React's internal children representation. Instead, let the parent decide what to render or use standard JavaScript patterns.
 
+For example, if you need to know how many items to display, you can accept an array as a prop directly and use `.length`:
+
+```tsx
+// Recommended: accept data as an array prop
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent({ items }: MyComponentProps) {
+  return (
+    <>
+      <h1>Total rows: {items.length}</h1>
+      {items.map((item) => (
+        <div key={item}>{item}</div>
+      ))}
+    </>
+  );
+}
+```
+
 ```tsx
 // Problem: Using Children.count to determine the number of children
 import React, { Children } from "react";

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.mdx
@@ -35,6 +35,28 @@ Using `Children` is uncommon and can lead to fragile code. [See common alternati
 
 Using `Children.forEach` to walk through and transform children is brittle because it relies on React's internal children structure. Prefer letting the parent handle iteration with standard array methods or restructuring your component API.
 
+For example, if you need to interleave separators between children, let the parent pass an array directly and use `.map()`:
+
+```tsx
+// Recommended: accept data as an array prop and use standard JS methods
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent({ items }: MyComponentProps) {
+  return (
+    <>
+      {items.map((item, index) => (
+        <div key={item}>
+          {item}
+          {index < items.length - 1 && <hr />}
+        </div>
+      ))}
+    </>
+  );
+}
+```
+
 ```tsx
 // Problem: Using Children.forEach to iterate over and transform children
 import React, { Children } from "react";

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.mdx
@@ -35,6 +35,27 @@ Using `Children` is uncommon and can lead to fragile code. [See common alternati
 
 Using `Children.map` to wrap children assumes a specific React internals structure that may break. Instead, accept an array of data or let the parent map over items directly.
 
+For example, if you need to wrap items in a styled container, accept an array of data as a prop and map over it:
+
+```tsx
+// Recommended: accept data as an array prop and map over it
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent({ items }: MyComponentProps) {
+  return (
+    <div className="RowList">
+      {items.map((item) => (
+        <div className="Row" key={item}>
+          {item}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
 ```tsx
 // Problem: Using Children.map to wrap each child in a styled container
 import React, { Children } from "react";

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.mdx
@@ -35,6 +35,21 @@ Using `Children` is uncommon and can lead to fragile code. [See common alternati
 
 Using `Children.only` to assert that a component receives exactly one child is fragile. If you need to restrict children, consider documenting the prop type or using a different API design.
 
+For example, if your component needs exactly one child element, you can type the prop as a single `ReactElement` instead of `React.ReactNode`:
+
+```tsx
+// Recommended: type the children prop to enforce a single child at compile time
+import { type ReactElement } from "react";
+
+interface MyComponentProps {
+  children: ReactElement;
+}
+
+function MyComponent({ children }: MyComponentProps) {
+  return <div>{children}</div>;
+}
+```
+
 ```tsx
 // Problem: Using Children.only to enforce a single child
 import React, { Children } from "react";

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.mdx
@@ -35,6 +35,26 @@ Using `Children.toArray` is uncommon and can lead to fragile code. [See common a
 
 Using `Children.toArray` to turn children into an array assumes internal React details that may change. If you need to reorder or filter items, accept structured data as props instead.
 
+For example, if you need to reverse a list, let the parent pass an array prop and use standard array methods:
+
+```tsx
+// Recommended: accept data as an array prop and manipulate it directly
+interface MyComponentProps {
+  items: string[];
+}
+
+function MyComponent({ items }: MyComponentProps) {
+  const reversed = [...items].reverse();
+  return (
+    <>
+      {reversed.map((item) => (
+        <div key={item}>{item}</div>
+      ))}
+    </>
+  );
+}
+```
+
 ```tsx
 // Problem: Using Children.toArray to convert children into an array for manipulation
 import React, { Children } from "react";

--- a/plugins/eslint-plugin-react-x/src/rules/no-class-component/no-class-component.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-class-component/no-class-component.mdx
@@ -96,4 +96,6 @@ class ErrorBoundary extends Component<ErrorBoundaryProps> {
 
 ## Further Reading
 
+- [React Docs: `react/experimental-classes` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/react-experimental-classes)
 - [Legacy React APIs: `Component`](https://react.dev/reference/react/Component)
+- [React Docs: Alternatives to class components](https://react.dev/reference/react/Component#alternatives)

--- a/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.mdx
@@ -48,6 +48,62 @@ const clonedElement = cloneElement(
 console.log(clonedElement); // <Row title="Cabbage" isHighlighted={true}>Goodbye</Row>
 ```
 
+### Wrapping children with injected props
+
+Using `cloneElement` inside `Children.map` hides which props a child receives and breaks encapsulation. Prefer passing data explicitly via render props or by restructuring your component API.
+
+```tsx
+// Problem: Using cloneElement to inject props into each child
+import { Children, cloneElement, useState } from "react";
+
+function List({ children }) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  return (
+    <div className="List">
+      {Children.map(children, (child, index) =>
+        cloneElement(child, {
+          isHighlighted: index === selectedIndex,
+        }),
+      )}
+      <button onClick={() => setSelectedIndex((i) => (i + 1) % Children.count(children))}>
+        Next
+      </button>
+    </div>
+  );
+}
+```
+
+```tsx
+// Recommended: Pass isHighlighted explicitly via render props
+import { useState } from "react";
+
+function List({ items, renderItem }) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  return (
+    <div className="List">
+      {items.map((item, index) => {
+        const isHighlighted = index === selectedIndex;
+        return renderItem(item, isHighlighted);
+      })}
+      <button onClick={() => setSelectedIndex((i) => (i + 1) % items.length)}>
+        Next
+      </button>
+    </div>
+  );
+}
+
+function App() {
+  return (
+    <List
+      items={products}
+      renderItem={(product, isHighlighted) => (
+        <Row key={product.id} title={product.title} isHighlighted={isHighlighted} />
+      )}
+    />
+  );
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.ts)
@@ -57,3 +113,4 @@ console.log(clonedElement); // <Row title="Cabbage" isHighlighted={true}>Goodbye
 ## Further Reading
 
 - [Legacy React APIs: `cloneElement`](https://react.dev/reference/react/cloneElement)
+- [React Docs: `cloneElement` Alternatives](https://react.dev/reference/react/cloneElement#alternatives)

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount/no-component-will-mount.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount/no-component-will-mount.mdx
@@ -77,4 +77,7 @@ class MyComponent extends React.Component<MyComponentProps> {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentWillMount`](https://react.dev/reference/react/Component#componentwillmount)
+- [React Docs: `UNSAFE_componentWillMount`](https://react.dev/reference/react/Component#unsafe_componentwillmount)
+- [React Docs: Updating to Async Rendering](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props/no-component-will-receive-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props/no-component-will-receive-props.mdx
@@ -69,4 +69,8 @@ class MyComponent extends React.Component {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentWillReceiveProps`](https://react.dev/reference/react/Component#componentwillreceiveprops)
+- [React Docs: `UNSAFE_componentWillReceiveProps`](https://react.dev/reference/react/Component#unsafe_componentwillreceiveprops)
+- [React Docs: You Probably Don't Need Derived State](https://legacy.reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html)
+- [React Docs: Updating to Async Rendering](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-update/no-component-will-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-update/no-component-will-update.mdx
@@ -69,4 +69,7 @@ class MyComponent extends React.Component {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentWillUpdate`](https://react.dev/reference/react/Component#componentwillupdate)
+- [React Docs: `UNSAFE_componentWillUpdate`](https://react.dev/reference/react/Component#unsafe_componentwillupdate)
+- [React Docs: Updating to Async Rendering](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

--- a/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.mdx
@@ -69,6 +69,42 @@ function App({ children }) {
 }
 ```
 
+### Nesting multiple context providers
+
+When multiple contexts are provided to the same subtree, the legacy `.Provider` syntax adds unnecessary noise. React 19 allows each context to be used directly.
+
+```tsx
+// Problem: Nested legacy providers
+import ThemeContext from "./ThemeContext";
+import AuthContext from "./AuthContext";
+
+function App({ children }) {
+  return (
+    <ThemeContext.Provider value="dark">
+      <AuthContext.Provider value={currentUser}>
+        {children}
+      </AuthContext.Provider>
+    </ThemeContext.Provider>
+  );
+}
+```
+
+```tsx
+// Recommended: Use contexts directly as providers
+import ThemeContext from "./ThemeContext";
+import AuthContext from "./AuthContext";
+
+function App({ children }) {
+  return (
+    <ThemeContext value="dark">
+      <AuthContext value={currentUser}>
+        {children}
+      </AuthContext>
+    </ThemeContext>
+  );
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.ts)
@@ -78,3 +114,4 @@ function App({ children }) {
 ## Further Reading
 
 - [React Docs: Blog: `<Context>` as a provider](https://react.dev/blog/2024/12/05/react-19#context-as-a-provider)
+- [React Docs: `createContext`](https://react.dev/reference/react/createContext)

--- a/plugins/eslint-plugin-react-x/src/rules/no-create-ref/no-create-ref.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-create-ref/no-create-ref.mdx
@@ -72,6 +72,50 @@ class MyComponent extends React.Component {
 }
 ```
 
+### Migrating from createRef to useRef
+
+When migrating a class component to a function component, replace `createRef` with `useRef`.
+
+```tsx
+// Problem: createRef inside a function component creates a new ref on every render
+import { createRef } from "react";
+
+function Form() {
+  const inputRef = createRef(); // Does not persist across renders
+
+  function handleClick() {
+    inputRef.current.focus();
+  }
+
+  return (
+    <>
+      <input ref={inputRef} />
+      <button onClick={handleClick}>Focus the input</button>
+    </>
+  );
+}
+```
+
+```tsx
+// Recommended: useRef persists the same ref object across renders
+import { useRef } from "react";
+
+function Form() {
+  const inputRef = useRef(null);
+
+  function handleClick() {
+    inputRef.current.focus();
+  }
+
+  return (
+    <>
+      <input ref={inputRef} />
+      <button onClick={handleClick}>Focus the input</button>
+    </>
+  );
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-create-ref/no-create-ref.ts)
@@ -80,4 +124,6 @@ class MyComponent extends React.Component {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `createRef`](https://react.dev/reference/react/createRef)
+- [React Docs: `useRef`](https://react.dev/reference/react/useRef)

--- a/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.mdx
@@ -96,8 +96,55 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 }
 ```
 
+### Mutating state in function components
+
+Directly mutating a state object or array in a function component does not trigger a re-render and breaks React's state management.
+
+```tsx
+// Problem: Mutating a state object directly instead of using the setter
+import { useState } from "react";
+
+function UserProfile() {
+  const [user, setUser] = useState({ name: "Taylor", age: 25 });
+
+  function handleClick() {
+    user.age = user.age + 1; // Mutates state directly — won't re-render!
+  }
+
+  return (
+    <button onClick={handleClick}>
+      {user.name} is {user.age} years old
+    </button>
+  );
+}
+```
+
+```tsx
+// Recommended: Always use the setter function with a new object
+import { useState } from "react";
+
+function UserProfile() {
+  const [user, setUser] = useState({ name: "Taylor", age: 25 });
+
+  function handleClick() {
+    setUser({ ...user, age: user.age + 1 });
+  }
+
+  return (
+    <button onClick={handleClick}>
+      {user.name} is {user.age} years old
+    </button>
+  );
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.spec.ts)
 - [Rule Changelog](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/CHANGELOG.md)
+
+## Further Reading
+
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
+- [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
@@ -107,6 +107,42 @@ function MyComponent() {
 }
 ```
 
+### Duplicate keys when rendering multiple lists side by side
+
+When two or more lists are rendered as siblings under the same parent element, using array indices as keys can produce duplicate key values.
+
+```tsx
+// Problem: Two lists rendered side by side both use index keys
+function App({ activeItems, archivedItems }) {
+  return (
+    <div>
+      {activeItems.map((item, index) => (
+        <div key={index}>{item.name}</div>
+      ))}
+      {archivedItems.map((item, index) => (
+        <div key={index}>{item.name}</div>
+      ))}
+    </div>
+  );
+}
+```
+
+```tsx
+// Recommended: Use unique identifiers from the data
+function App({ activeItems, archivedItems }) {
+  return (
+    <div>
+      {activeItems.map((item) => (
+        <div key={item.id}>{item.name}</div>
+      ))}
+      {archivedItems.map((item) => (
+        <div key={item.id}>{item.name}</div>
+      ))}
+    </div>
+  );
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts)
@@ -116,3 +152,5 @@ function MyComponent() {
 ## Further Reading
 
 - [React Docs: Why does React need keys?](https://react.dev/learn/rendering-lists#why-does-react-need-keys)
+- [React Docs: Rendering Lists](https://react.dev/learn/rendering-lists)
+- [React Docs: `Fragment`](https://react.dev/reference/react/Fragment)

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
@@ -94,3 +94,7 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.spec.ts)
 - [Rule Changelog](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/CHANGELOG.md)
+
+## Further Reading
+
+- [React Docs: Passing Props to a Component](https://react.dev/learn/passing-props-to-a-component)

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
@@ -94,3 +94,7 @@ function PaginationItem({ ...props }: React.ComponentProps<"li">) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.spec.ts)
 - [Rule Changelog](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/CHANGELOG.md)
+
+## Further Reading
+
+- [React Docs: Manipulating the DOM with Refs](https://react.dev/learn/manipulating-the-dom-with-refs)

--- a/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.mdx
@@ -212,3 +212,4 @@ function MyComponent({ items, count }: MyComponentProps) {
 ## Further Reading
 
 - [React Docs: Conditional Rendering](https://react.dev/learn/conditional-rendering)
+- [React Docs: Rendering Lists](https://react.dev/learn/rendering-lists)

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.mdx
@@ -53,4 +53,5 @@ MyContext.displayName = "MyContext";
 ## Further Reading
 
 - [React Docs: `displayName`](https://react.dev/reference/react/Component#displayname)
+- [React Docs: `createContext`](https://react.dev/reference/react/createContext)
 - [React Docs: Context](https://react.dev/learn/passing-data-deeply-with-context)

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.mdx
@@ -65,6 +65,36 @@ function MyComponent({ items }: MyComponentProps) {
 }
 ```
 
+### Missing key when returning multiple elements per iteration
+
+When you map over data and return multiple sibling elements, wrapping them in `<></>` loses the ability to assign a key. You must use the explicit `Fragment` syntax.
+
+```tsx
+// Problem: Fragment shorthand (<>) does not support keys
+function Blog({ posts }) {
+  return posts.map((post) => (
+    <>
+      <PostTitle title={post.title} />
+      <PostBody body={post.body} />
+    </>
+  ));
+}
+```
+
+```tsx
+// Recommended: Use explicit Fragment with a key
+import { Fragment } from "react";
+
+function Blog({ posts }) {
+  return posts.map((post) => (
+    <Fragment key={post.id}>
+      <PostTitle title={post.title} />
+      <PostBody body={post.body} />
+    </Fragment>
+  ));
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts)
@@ -74,3 +104,5 @@ function MyComponent({ items }: MyComponentProps) {
 ## Further Reading
 
 - [React Docs: Why does React need keys?](https://react.dev/learn/rendering-lists#why-does-react-need-keys)
+- [React Docs: Rendering Lists](https://react.dev/learn/rendering-lists)
+- [React Docs: `Fragment`](https://react.dev/reference/react/Fragment)

--- a/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.mdx
@@ -89,3 +89,4 @@ if (process.env.NODE_ENV !== "production") {
 - [React Docs: `captureOwnerStack`](https://react.dev/reference/react/captureOwnerStack)
   - [The owner stack is `null`](https://react.dev/reference/react/captureOwnerStack#the-owner-stack-is-null)
   - [`captureOwnerStack` is not available](https://react.dev/reference/react/captureOwnerStack#captureownerstack-is-not-available)
+- [React Compiler: Gating](https://react.dev/reference/react-compiler/gating)

--- a/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/no-nested-component-definitions.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/no-nested-component-definitions.mdx
@@ -36,6 +36,8 @@ When a component is defined inside another component:
 - It defeats prop memoization and optimization techniques
 - It creates new function references on every render
 
+React is responsible for rendering components when necessary to optimize the user experience. It is declarative: you tell React what to render in your component's logic, and React will figure out how best to display it to your user. Components should only be used in JSX. Don't call them as regular functions — React should call them.
+
 Instead, define every component at the top level.
 
 ## Examples
@@ -68,6 +70,31 @@ function Profile() {
 
 When a child component needs data from a parent, [pass it by props](https://react.dev/learn/passing-props-to-a-component) instead of nesting definitions.
 
+### Calling components as regular functions
+
+Components should only be used in JSX. Don't call them as regular functions. React must decide when your component function is called during rendering. In React, you do this using JSX.
+
+```tsx
+// Problem: calling a component as a regular function
+function BlogPost() {
+  return <Layout>{Article()}</Layout>;
+  //                        ^^^ Never call component functions directly.
+}
+```
+
+```tsx
+// Recommended: use components in JSX
+function BlogPost() {
+  return (
+    <Layout>
+      <Article />
+    </Layout>
+  );
+}
+```
+
+If a component contains Hooks, calling it directly can easily violate the Rules of Hooks when called in a loop or conditionally. Letting React orchestrate rendering also allows components to participate in reconciliation, enables local state through Hooks, and allows React to skip over components that don't need re-rendering.
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/no-nested-component-definitions.ts)
@@ -77,4 +104,5 @@ When a child component needs data from a parent, [pass it by props](https://reac
 ## Further Reading
 
 - [React Docs: Nesting and organizing components](https://react.dev/learn/your-first-component#nesting-and-organizing-components)
+- [React Docs: React calls Components and Hooks](https://react.dev/reference/rules/react-calls-components-and-hooks)
 - [React Docs: `static-components` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components)

--- a/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations/no-nested-lazy-component-declarations.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations/no-nested-lazy-component-declarations.mdx
@@ -27,14 +27,16 @@ react-x/no-nested-lazy-component-declarations
 
 ## Rule Details
 
-Component definitions inside other components cause them to be recreated on every render, which can lead to performance issues and unexpected behavior.
+Lazy component declarations inside other components cause them to be recreated on every render, which can lead to performance issues and unexpected behavior.
 
-When a component is defined inside another component:
+When a lazy component is declared inside another component:
 
 - It gets recreated on every render of the parent component
 - It loses its internal state when the parent re-renders
 - It defeats props memoization and optimization techniques
 - It creates new function references on every render
+
+Just like regular components, lazy components should be declared at the top level of your module so that React can properly track their identity across renders. When a lazy component is recreated, React treats it as a different component type, causing the old one to unmount and the new one to mount — destroying all state and DOM nodes in the process.
 
 ## Examples
 
@@ -75,3 +77,4 @@ function Editor() {
 - [React Docs: `Lazy`](https://react.dev/reference/react/lazy)
   - [My lazy component’s state gets reset unexpectedly](https://react.dev/reference/react/lazy#my-lazy-components-state-gets-reset-unexpectedly)
 - [React Docs: Nesting and organizing components](https://react.dev/learn/your-first-component#nesting-and-organizing-components)
+- [React Docs: React calls Components and Hooks](https://react.dev/reference/rules/react-calls-components-and-hooks)

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.mdx
@@ -29,6 +29,8 @@ react-x/no-set-state-in-component-did-mount
 
 Updating the state after a component mounts will trigger a second `render()` call and can lead to property/layout thrashing.
 
+For class components, prefer setting the initial state in the constructor or via a class field initializer. If you need to perform side effects, consider using `useEffect` after migrating to function components.
+
 ## Examples
 
 ### Calling setState directly in componentDidMount
@@ -55,6 +57,38 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 }
 ```
 
+### Setting initial state correctly
+
+Set the initial state in the constructor or via a class field. Use `componentDidMount` only for side effects like subscriptions or data fetching, and only call `setState` inside callbacks (e.g., event handlers or network responses).
+
+```tsx
+// Recommended: Initialize state in the constructor or as a class field
+import React from "react";
+
+interface MyComponentProps {}
+
+interface MyComponentState {
+  name: string;
+}
+
+class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
+  state = {
+    name: "John",
+  };
+
+  componentDidMount() {
+    // Side effects like fetching data are fine here
+    fetchData().then((data) => {
+      this.setState({ name: data.name }); // OK inside a callback
+    });
+  }
+
+  render() {
+    return <div>Hello {this.state.name}</div>;
+  }
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.ts)
@@ -63,5 +97,6 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentDidMount`](https://react.dev/reference/react/Component#componentdidmount)
 - [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.mdx
@@ -27,7 +27,7 @@ react-x/no-set-state-in-component-did-update
 
 ## Rule Details
 
-Updating the state after a component mounts will trigger a second `render()` call and can lead to property/layout thrashing.
+Updating the state after a component updates will trigger an additional `render()` call and can lead to property/layout thrashing or infinite loops.
 
 ## Examples
 
@@ -55,6 +55,52 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 }
 ```
 
+### Responding to prop changes without extra state
+
+If you need to perform side effects when props change, do so conditionally and avoid synchronous `setState` calls that trigger additional renders.
+
+```tsx
+// Recommended: Perform conditional side effects without synchronous setState
+import React from "react";
+
+interface MyComponentProps {
+  roomId: string;
+}
+
+interface MyComponentState {
+  serverUrl: string;
+}
+
+class ChatRoom extends React.Component<MyComponentProps, MyComponentState> {
+  state = {
+    serverUrl: "https://localhost:1234",
+  };
+
+  componentDidUpdate(prevProps: MyComponentProps) {
+    if (this.props.roomId !== prevProps.roomId) {
+      this.destroyConnection();
+      this.setupConnection(); // Side effect, not setState
+    }
+  }
+
+  componentWillUnmount() {
+    this.destroyConnection();
+  }
+
+  setupConnection() {
+    /* ... */
+  }
+
+  destroyConnection() {
+    /* ... */
+  }
+
+  render() {
+    return <div>Room: {this.props.roomId}</div>;
+  }
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.ts)
@@ -63,5 +109,6 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentDidUpdate`](https://react.dev/reference/react/Component#componentdidupdate)
 - [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.mdx
@@ -27,7 +27,7 @@ react-x/no-set-state-in-component-will-update
 
 ## Rule Details
 
-Updating the state after a component mounts will trigger a second `render()` call and can lead to property/layout thrashing.
+Updating the state in `componentWillUpdate` is not allowed because the component is already about to re-render. It can lead to infinite loops and inconsistent state.
 
 ## Examples
 
@@ -55,6 +55,39 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 }
 ```
 
+### Preparing for an update without setState
+
+If you need to compute something before an update, store it in an instance variable or derive it during `render`. Never call `setState` in `componentWillUpdate` because the component is already about to re-render.
+
+```tsx
+// Recommended: Use instance variables or derive values during render
+import React from "react";
+
+interface MyComponentProps {
+  value: number;
+}
+
+interface MyComponentState {
+  prevValue: number;
+}
+
+class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
+  state = {
+    prevValue: 0,
+  };
+
+  componentWillUpdate(nextProps: MyComponentProps) {
+    // Store previous value in an instance variable, not state
+    this.previousValue = this.props.value;
+  }
+
+  render() {
+    const hasIncreased = this.props.value > this.state.prevValue;
+    return <div>Value increased: {hasIncreased ? "Yes" : "No"}</div>;
+  }
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.ts)
@@ -63,5 +96,6 @@ class MyComponent extends React.Component<MyComponentProps, MyComponentState> {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentWillUpdate`](https://react.dev/reference/react/Component#componentwillupdate)
 - [Legacy React APIs: `setState`](https://react.dev/reference/react/Component#setstate)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount/no-unsafe-component-will-mount.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount/no-unsafe-component-will-mount.mdx
@@ -46,6 +46,19 @@ class MyComponent extends React.Component {
 }
 ```
 
+```tsx
+// Recommended: initialize state in the constructor or as a class field, move side effects to componentDidMount
+import React from "react";
+
+class MyComponent extends React.Component {
+  state = { counter: 0 };
+
+  componentDidMount() {
+    // Side effects belong here
+  }
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount/no-unsafe-component-will-mount.ts)
@@ -54,4 +67,7 @@ class MyComponent extends React.Component {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentWillMount`](https://react.dev/reference/react/Component#componentwillmount)
+- [React Docs: `UNSAFE_componentWillMount`](https://react.dev/reference/react/Component#unsafe_componentwillmount)
+- [React Docs: Updating to Async Rendering](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props/no-unsafe-component-will-receive-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props/no-unsafe-component-will-receive-props.mdx
@@ -46,6 +46,28 @@ class MyComponent extends React.Component {
 }
 ```
 
+```tsx
+// Recommended: derive state with getDerivedStateFromProps or use componentDidUpdate for side effects
+import React from "react";
+
+class MyComponent extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    if (props.userID !== state.prevUserID) {
+      return {
+        prevUserID: props.userID,
+        email: props.defaultEmail,
+      };
+    }
+    return null;
+  }
+
+  state = {
+    email: this.props.defaultEmail,
+    prevUserID: this.props.userID,
+  };
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props/no-unsafe-component-will-receive-props.ts)
@@ -54,4 +76,8 @@ class MyComponent extends React.Component {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentWillReceiveProps`](https://react.dev/reference/react/Component#componentwillreceiveprops)
+- [React Docs: `UNSAFE_componentWillReceiveProps`](https://react.dev/reference/react/Component#unsafe_componentwillreceiveprops)
+- [React Docs: You Probably Don't Need Derived State](https://legacy.reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html)
+- [React Docs: Updating to Async Rendering](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update/no-unsafe-component-will-update.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update/no-unsafe-component-will-update.mdx
@@ -46,6 +46,19 @@ class MyComponent extends React.Component {
 }
 ```
 
+```tsx
+// Recommended: use componentDidUpdate for side effects after an update
+import React from "react";
+
+class MyComponent extends React.Component {
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.value !== prevProps.value) {
+      // Perform side effects here
+    }
+  }
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update/no-unsafe-component-will-update.ts)
@@ -54,4 +67,7 @@ class MyComponent extends React.Component {
 
 ## Further Reading
 
+- [React Docs: How to migrate to a function component](https://react.dev/reference/react/Component#alternatives)
 - [Legacy React APIs: `componentWillUpdate`](https://react.dev/reference/react/Component#componentwillupdate)
+- [React Docs: `UNSAFE_componentWillUpdate`](https://react.dev/reference/react/Component#unsafe_componentwillupdate)
+- [React Docs: Updating to Async Rendering](https://legacy.reactjs.org/blog/2018/03/27/update-on-async-rendering.html)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.mdx
@@ -100,4 +100,5 @@ This can be a large performance hit because not only will it cause the context p
 ## Further Reading
 
 - [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)
+- [React Docs: `createContext`](https://react.dev/reference/react/createContext)
 - [React Docs: Context](https://react.dev/learn/passing-data-deeply-with-context)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.mdx
@@ -219,3 +219,5 @@ Default: `[]`
 ## Further Reading
 
 - [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)
+- [React Docs: `memo`](https://react.dev/reference/react/memo)
+- [React Compiler: `compilationMode`](https://react.dev/reference/react-compiler/compilationMode)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
@@ -75,4 +75,5 @@ class MyComponent extends React.Component {
 
 ## Further Reading
 
+- [React Docs: `react/experimental-classes` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/react-experimental-classes)
 - [Legacy React APIs: `Component`](https://react.dev/reference/react/Component)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.mdx
@@ -129,3 +129,8 @@ function ProfileAvatar({ theme }: ProfileProps) {
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.spec.ts)
 - [Rule Changelog](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unused-props/CHANGELOG.md)
+
+## Further Reading
+
+- [React Docs: Passing Props to a Component](https://react.dev/learn/passing-props-to-a-component)
+- [React Docs: Thinking in React](https://react.dev/learn/thinking-in-react)

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.mdx
@@ -130,3 +130,7 @@ Custom state and effect hooks can also be configured via shared ESLint settings,
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.ts)
 - [Test Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.spec.ts)
 - [Rule Changelog](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-unused-state/CHANGELOG.md)
+
+## Further Reading
+
+- [React Docs: `useState`](https://react.dev/reference/react/useState)

--- a/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.mdx
@@ -61,6 +61,32 @@ function Button() {
 }
 ```
 
+### Calling context reads conditionally
+
+Unlike `useContext`, `use` can be called inside conditions and loops. This lets you read context only when needed.
+
+```tsx
+// Problem: useContext must be called at the top level, even when not needed
+import { useContext } from "react";
+
+function Toolbar({ showTooltip, tooltipContext }) {
+  const tooltip = useContext(tooltipContext); // Always called
+  if (!showTooltip) return null;
+  return <Tooltip content={tooltip} />;
+}
+```
+
+```tsx
+// Recommended: use can be called conditionally
+import { use } from "react";
+
+function Toolbar({ showTooltip, tooltipContext }) {
+  if (!showTooltip) return null;
+  const tooltip = use(tooltipContext); // Called only when needed
+  return <Tooltip content={tooltip} />;
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.ts)

--- a/plugins/eslint-plugin-react-x/src/rules/purity/purity.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/purity.mdx
@@ -200,4 +200,5 @@ function Clock() {
 ## Further Reading
 
 - [React Docs: Keeping Components Pure](https://react.dev/learn/keeping-components-pure)
+- [React Docs: Components and Hooks must be pure](https://react.dev/reference/rules/components-and-hooks-must-be-pure)
 - [React Docs: `purity` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/purity)

--- a/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks/rules-of-hooks.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/rules-of-hooks/rules-of-hooks.mdx
@@ -1,6 +1,6 @@
 ---
 title: rules-of-hooks
-description: Enforces the Rules of Hooks.
+description: Validates that components and hooks follow the Rules of Hooks.
 ---
 
 **Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
@@ -34,6 +34,39 @@ react-x/rules-of-hooks
 React relies on the order in which hooks are called to correctly preserve state between renders. Each time your component renders, React expects the exact same hooks to be called in the exact same order. When hooks are called conditionally or in loops, React loses track of which state corresponds to which hook call, leading to bugs like state mismatches and "Rendered fewer/more hooks than expected" errors.
 
 ## Examples
+
+### The `use` hook
+
+The `use` hook is different from other React hooks. You can call it conditionally and in loops:
+
+```tsx
+// ✅ `use` can be conditional
+function Component({ shouldFetch, fetchPromise }) {
+  if (shouldFetch) {
+    const data = use(fetchPromise);
+    return <div>{data}</div>;
+  }
+  return <div>Nothing to fetch</div>;
+}
+```
+
+```tsx
+// ✅ `use` can be in loops
+function Component({ promises }) {
+  const results = [];
+  for (const promise of promises) {
+    results.push(use(promise));
+  }
+  return <div>{results.join(", ")}</div>;
+}
+```
+
+However, `use` still has restrictions:
+
+- Can't be wrapped in try/catch
+- Must be called inside a component or hook
+
+Learn more: [`use` API Reference](https://react.dev/reference/react/use)
 
 ### Calling hooks conditionally
 

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.mdx
@@ -243,5 +243,6 @@ Custom state and effect hooks can also be configured via shared ESLint settings,
 
 - [React Docs: `useState`](https://react.dev/reference/react/useState)
 - [React Docs: `useEffect`](https://react.dev/reference/react/useEffect)
+- [React Docs: `useLayoutEffect`](https://react.dev/reference/react/useLayoutEffect)
 - [React Docs: You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)
 - [React Docs: `set-state-in-effect` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect)

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.mdx
@@ -173,4 +173,5 @@ Custom state hooks can also be configured via shared ESLint settings, which appl
 ## Further Reading
 
 - [React Docs: `useState`](https://react.dev/reference/react/useState)
+- [React Docs: Storing information from previous renders](https://react.dev/reference/react/useState#storing-information-from-previous-renders)
 - [React Docs: `set-state-in-render` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-render)

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.mdx
@@ -136,4 +136,5 @@ function ItemList({ items }) {
 ## Further Reading
 
 - [React Docs: Nesting and organizing components](https://react.dev/learn/your-first-component#nesting-and-organizing-components)
+- [React Docs: React calls Components and Hooks](https://react.dev/reference/rules/react-calls-components-and-hooks)
 - [React Docs: `static-components` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components)

--- a/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.mdx
@@ -198,3 +198,4 @@ function Calculator({ expression }) {
 ## Further Reading
 
 - [React Docs: `unsupported-syntax` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/unsupported-syntax)
+- [React Compiler: Directives](https://react.dev/reference/react-compiler/directives)

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.mdx
@@ -1,6 +1,6 @@
 ---
 title: use-memo
-description: Validates that 'useMemo' is called with a callback that returns a value.
+description: Validates that the `useMemo` hook is used with a return value.
 ---
 
 **Full Name in [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x/v/latest)**
@@ -192,6 +192,55 @@ function Component({ items }) {
 }
 ```
 
+## Troubleshooting
+
+### I need to run side effects when dependencies change
+
+You might try to use `useMemo` for side effects:
+
+```tsx
+// Problem: Side effects in useMemo
+function Component({ user }) {
+  // No return value, just side effect
+  useMemo(() => {
+    analytics.track("UserViewed", { userId: user.id });
+  }, [user.id]);
+
+  // Not assigned to a variable
+  useMemo(() => {
+    return analytics.track("UserViewed", { userId: user.id });
+  }, [user.id]);
+}
+```
+
+If the side effect needs to happen in response to user interaction, it's best to colocate the side effect with the event:
+
+```tsx
+// Recommended: Side effects in event handlers
+function Component({ user }) {
+  const handleClick = () => {
+    analytics.track("ButtonClicked", { userId: user.id });
+    // Other click logic...
+  };
+
+  return <button onClick={handleClick}>Click me</button>;
+}
+```
+
+If the side effect synchronizes React state with some external state (or vice versa), use `useEffect`:
+
+```tsx
+// Recommended: Synchronization in useEffect
+function Component({ theme }) {
+  useEffect(() => {
+    localStorage.setItem("preferredTheme", theme);
+    document.body.className = theme;
+  }, [theme]);
+
+  return <div>Current theme: {theme}</div>;
+}
+```
+
 ## Resources
 
 - [Rule Source](https://github.com/Rel1cx/eslint-react/tree/main/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts)
@@ -201,4 +250,5 @@ function Component({ items }) {
 ## Further Reading
 
 - [React Docs: `useMemo`](https://react.dev/reference/react/useMemo)
+- [React Docs: `use-memo` Lint Rule](https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo)
 - [React Compiler: `validateUseMemo`](https://github.com/facebook/react/tree/main/compiler/packages/babel-plugin-react-compiler/docs/passes/40-validateUseMemo.md)

--- a/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.mdx
@@ -224,4 +224,5 @@ Custom state hooks can also be configured via shared ESLint settings, which appl
 
 - [React Docs: `useState`](https://react.dev/reference/react/useState)
 - [React Docs: Avoiding recreating the initial state](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state)
+- [React Docs: Storing information from previous renders](https://react.dev/reference/react/useState#storing-information-from-previous-renders)
 - [React Docs: State naming conventions](https://react.dev/learn/state-a-components-memory#meet-your-first-hook)


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR'\''s title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This PR improves the MDX documentation for `eslint-plugin-react-x` rules by:

- Adding troubleshooting sections and practical examples for multiple rules (e.g., `error-boundaries`, `use-memo`, `rules-of-hooks`)
- Adding recommended alternatives to `Children.*` API usage in `no-children-*` rules
- Adding migration examples from class components to function components
- Adding Further Reading links to React official documentation across multiple rules
- Fixing an incorrect duplicate key example in `no-duplicate-key` that conflated unstable index keys with actual duplicate keys
- Fixing a function component state mutation example in `no-direct-mutation-state` that incorrectly demonstrated const reassignment instead of object mutation