### PR TITLE
test: add null-safety boundary tests for rules affected by PR #1792

### DIFF
--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.spec.ts
@@ -75,6 +75,26 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    // Boundary: JSXAttribute with empty expression container (resolveAttributeValue handles JSXEmptyExpression)
+    {
+      code: tsx`
+        function App() {
+          return <iframe sandbox={} />;
+        }
+      `,
+      errors: [{
+        messageId: "missingSandboxAttribute",
+        suggestions: [{
+          data: { value: "" },
+          messageId: "addSandboxAttribute",
+          output: tsx`
+            function App() {
+              return <iframe sandbox="" />;
+            }
+          `,
+        }],
+      }],
+    },
   ],
   valid: [
     "<a />;",

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.spec.ts
@@ -90,5 +90,28 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     "var foo = render(<div />, root)",
     "var foo = ReactDOM.renderder(<div />, root)",
+    // Boundary: ReactDOM.render in non-banned parent contexts (isReturnValueUsed parent traversal)
+    tsx`
+      function Component() {
+        ReactDOM.render(<div />, document.body);
+      }
+    `,
+    tsx`
+      function Component() {
+        if (condition) {
+          ReactDOM.render(<div />, document.body);
+        }
+      }
+    `,
+    tsx`
+      function Component() {
+        [ReactDOM.render(<div />, document.body)];
+      }
+    `,
+    tsx`
+      function Component() {
+        const result = condition && ReactDOM.render(<div />, document.body);
+      }
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.spec.ts
@@ -214,5 +214,10 @@ ruleTester.run(RULE_NAME, rule, {
       const props = { href: "javascript:void(0)" };
       <a {...props}></a>
     `,
+    // Boundary: JSXAttribute with no value (boolean shorthand)
+    "<a href>Link</a>",
+    // Boundary: JSXAttribute with empty expression container
+    "<a href={}>Link</a>",
+    "<div href={}></div>",
   ],
 });

--- a/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.spec.ts
@@ -279,5 +279,9 @@ ruleTester.run(RULE_NAME, rule, {
       const props = { style: "color: red;" };
       <div {...props} />
     `,
+    // Boundary: JSXAttribute with no value (boolean shorthand)
+    tsx`<div style />`,
+    // Boundary: JSXAttribute with empty expression container (resolveAttributeValue handles JSXEmptyExpression)
+    tsx`<div style={} />`,
   ],
 });

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.spec.ts
@@ -5,541 +5,586 @@ import { ruleTester } from "#/test";
 import rule, { RULE_NAME } from "./no-unknown-property";
 
 ruleTester.run(RULE_NAME, rule, {
-  invalid: [{
-    code: '<div hasOwnProperty="should not be allowed property"></div>;',
-    errors: [
-      {
-        data: {
-          name: "hasOwnProperty",
+  invalid: [
+    {
+      code: '<div hasOwnProperty="should not be allowed property"></div>;',
+      errors: [
+        {
+          data: {
+            name: "hasOwnProperty",
+          },
+          messageId: "unknownProp",
         },
-        messageId: "unknownProp",
-      },
-    ],
-  }, {
-    code: '<div abc="should not be allowed property"></div>;',
-    errors: [
-      {
-        data: {
-          name: "abc",
-        },
-        messageId: "unknownProp",
-      },
-    ],
-  }, {
-    code: '<div aria-fake="should not be allowed property"></div>;',
-    errors: [
-      {
-        data: {
-          name: "aria-fake",
-        },
-        messageId: "unknownProp",
-      },
-    ],
-  }, {
-    code: '<div someProp="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "someProp",
-        },
-        messageId: "unknownProp",
-      },
-    ],
-  }, {
-    code: '<div class="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "class",
-          standardName: "className",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div className="bar"></div>;',
-  }, {
-    code: '<div for="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "for",
-          standardName: "htmlFor",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div htmlFor="bar"></div>;',
-  }, {
-    code: '<div accept-charset="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "accept-charset",
-          standardName: "acceptCharset",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div acceptCharset="bar"></div>;',
-  }, {
-    code: '<div http-equiv="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "http-equiv",
-          standardName: "httpEquiv",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div httpEquiv="bar"></div>;',
-  }, {
-    code: '<div accesskey="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "accesskey",
-          standardName: "accessKey",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div accessKey="bar"></div>;',
-  }, {
-    code: '<div onclick="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "onclick",
-          standardName: "onClick",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div onClick="bar"></div>;',
-  }, {
-    code: '<div onmousedown="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "onmousedown",
-          standardName: "onMouseDown",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div onMouseDown="bar"></div>;',
-  }, {
-    code: '<div onMousedown="bar"></div>;',
-    errors: [
-      {
-        data: {
-          name: "onMousedown",
-          standardName: "onMouseDown",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<div onMouseDown="bar"></div>;',
-  }, {
-    code: '<use xlink:href="bar" />;',
-    errors: [
-      {
-        data: {
-          name: "xlink:href",
-          standardName: "xlinkHref",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<use xlinkHref="bar" />;',
-  }, {
-    code: '<rect clip-path="bar" />;',
-    errors: [
-      {
-        data: {
-          name: "clip-path",
-          standardName: "clipPath",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: '<rect clipPath="bar" />;',
-  }, {
-    code: "<script crossorigin nomodule />",
-    errors: [
-      {
-        data: {
-          name: "crossorigin",
-          standardName: "crossOrigin",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-      {
-        data: {
-          name: "nomodule",
-          standardName: "noModule",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: "<script crossOrigin noModule />",
-  }, {
-    code: "<div crossorigin />",
-    errors: [
-      {
-        data: {
-          name: "crossorigin",
-          standardName: "crossOrigin",
-        },
-        messageId: "unknownPropWithStandardName",
-      },
-    ],
-    output: "<div crossOrigin />",
-  }, {
-    code: "<div crossOrigin />",
-    errors: [
-      {
-        data: {
-          name: "crossOrigin",
-          allowedTags: "script, img, video, audio, link, image",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div as="audio" />',
-    errors: [
-      {
-        data: {
-          name: "as",
-          allowedTags: "link",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code:
-      "<div onAbort={this.abort} onDurationChange={this.durationChange} onEmptied={this.emptied} onEnded={this.end} onResize={this.resize} onError={this.error} />",
-    errors: [
-      {
-        data: {
-          name: "onAbort",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "onDurationChange",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "onEmptied",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "onEnded",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "onResize",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "onError",
-          allowedTags: "audio, video, img, link, source, script, picture, iframe",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: "<div onLoad={this.load} />",
-    errors: [
-      {
-        data: {
-          name: "onLoad",
-          allowedTags: "script, img, link, picture, iframe, object, source",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div fill="pink" />',
-    errors: [
-      {
-        data: {
-          name: "fill",
-          allowedTags:
-            "altGlyph, circle, ellipse, g, line, marker, mask, path, polygon, polyline, rect, svg, symbol, text, textPath, tref, tspan, use, animate, animateColor, animateMotion, animateTransform, set",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code:
-      "<div controls={this.controls} loop={true} muted={false} src={this.videoSrc} playsInline={true} allowFullScreen></div>",
-    errors: [
-      {
-        data: {
-          name: "controls",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "loop",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "muted",
-          allowedTags: "audio, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "playsInline",
-          allowedTags: "video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-      {
-        data: {
-          name: "allowFullScreen",
-          allowedTags: "iframe, video",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div download="foo" />',
-    errors: [
-      {
-        data: {
-          name: "download",
-          allowedTags: "a, area",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div imageSrcSet="someImageSrcSet" />',
-    errors: [
-      {
-        data: {
-          name: "imageSrcSet",
-          allowedTags: "link",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div imageSizes="someImageSizes" />',
-    errors: [
-      {
-        data: {
-          name: "imageSizes",
-          allowedTags: "link",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div data-xml-anything="invalid" />',
-    errors: [
-      {
-        data: {
-          name: "data-xml-anything",
-        },
-        messageId: "unknownProp",
-      },
-    ],
-  }, {
-    code: '<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;',
-    errors: [
-      {
-        data: {
-          name: "data-testID",
-          lowerCaseName: "data-testid",
-        },
-        messageId: "dataLowercaseRequired",
-      },
-      {
-        data: {
-          name: "data-under_sCoRe",
-          lowerCaseName: "data-under_score",
-        },
-        messageId: "dataLowercaseRequired",
-      },
-      {
-        data: {
-          name: "dataNotAnDataAttribute",
-          lowerCaseName: "datanotandataattribute",
-        },
-        messageId: "unknownProp",
-      },
-    ],
-    options: [{ requireDataLowercase: true }],
-  }, {
-    code: '<App data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;',
-    errors: [
-      {
-        data: {
-          name: "data-testID",
-          lowerCaseName: "data-testid",
-        },
-        messageId: "dataLowercaseRequired",
-      },
-      {
-        data: {
-          name: "data-under_sCoRe",
-          lowerCaseName: "data-under_score",
-        },
-        messageId: "dataLowercaseRequired",
-      },
-    ],
-    options: [{ requireDataLowercase: true }],
-  }, {
-    code: '<div abbr="abbr" />',
-    errors: [
-      {
-        data: {
-          name: "abbr",
-          allowedTags: "th, td",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div webkitDirectory="" />',
-    errors: [
-      {
-        data: {
-          name: "webkitDirectory",
-          allowedTags: "input",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div webkitdirectory="" />',
-    errors: [
-      {
-        data: {
-          name: "webkitdirectory",
-          allowedTags: "input",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div precedence="medium" />',
-    errors: [
-      {
-        data: {
-          name: "precedence",
-          allowedTags: "link, style",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<div blocking="render" />',
-    errors: [
-      {
-        data: {
-          name: "blocking",
-          allowedTags: "link, script, style",
-          tagName: "div",
-        },
-        messageId: "invalidPropOnTag",
-      },
-    ],
-  }, {
-    code: '<style precedence="default">{`body { color: red; }`}</style>',
-    settings: {
-      "react-x": {
-        version: "18.3.1",
-      },
+      ],
     },
-    errors: [
-      {
-        data: {
-          name: "precedence",
+    {
+      code: '<div abc="should not be allowed property"></div>;',
+      errors: [
+        {
+          data: {
+            name: "abc",
+          },
+          messageId: "unknownProp",
         },
-        messageId: "unknownProp",
-      },
-    ],
-  }, {
-    code: '<script blocking="render" />',
-    settings: {
-      "react-x": {
-        version: "18.3.1",
-      },
+      ],
     },
-    errors: [
-      {
-        data: {
-          name: "blocking",
+    {
+      code: '<div aria-fake="should not be allowed property"></div>;',
+      errors: [
+        {
+          data: {
+            name: "aria-fake",
+          },
+          messageId: "unknownProp",
         },
-        messageId: "unknownProp",
+      ],
+    },
+    {
+      code: '<div someProp="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "someProp",
+          },
+          messageId: "unknownProp",
+        },
+      ],
+    },
+    {
+      code: '<div class="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "class",
+            standardName: "className",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div className="bar"></div>;',
+    },
+    {
+      code: '<div for="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "for",
+            standardName: "htmlFor",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div htmlFor="bar"></div>;',
+    },
+    {
+      code: '<div accept-charset="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "accept-charset",
+            standardName: "acceptCharset",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div acceptCharset="bar"></div>;',
+    },
+    {
+      code: '<div http-equiv="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "http-equiv",
+            standardName: "httpEquiv",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div httpEquiv="bar"></div>;',
+    },
+    {
+      code: '<div accesskey="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "accesskey",
+            standardName: "accessKey",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div accessKey="bar"></div>;',
+    },
+    {
+      code: '<div onclick="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "onclick",
+            standardName: "onClick",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div onClick="bar"></div>;',
+    },
+    {
+      code: '<div onmousedown="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "onmousedown",
+            standardName: "onMouseDown",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div onMouseDown="bar"></div>;',
+    },
+    {
+      code: '<div onMousedown="bar"></div>;',
+      errors: [
+        {
+          data: {
+            name: "onMousedown",
+            standardName: "onMouseDown",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<div onMouseDown="bar"></div>;',
+    },
+    {
+      code: '<use xlink:href="bar" />;',
+      errors: [
+        {
+          data: {
+            name: "xlink:href",
+            standardName: "xlinkHref",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<use xlinkHref="bar" />;',
+    },
+    {
+      code: '<rect clip-path="bar" />;',
+      errors: [
+        {
+          data: {
+            name: "clip-path",
+            standardName: "clipPath",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: '<rect clipPath="bar" />;',
+    },
+    {
+      code: "<script crossorigin nomodule />",
+      errors: [
+        {
+          data: {
+            name: "crossorigin",
+            standardName: "crossOrigin",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+        {
+          data: {
+            name: "nomodule",
+            standardName: "noModule",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: "<script crossOrigin noModule />",
+    },
+    {
+      code: "<div crossorigin />",
+      errors: [
+        {
+          data: {
+            name: "crossorigin",
+            standardName: "crossOrigin",
+          },
+          messageId: "unknownPropWithStandardName",
+        },
+      ],
+      output: "<div crossOrigin />",
+    },
+    {
+      code: "<div crossOrigin />",
+      errors: [
+        {
+          data: {
+            name: "crossOrigin",
+            allowedTags: "script, img, video, audio, link, image",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div as="audio" />',
+      errors: [
+        {
+          data: {
+            name: "as",
+            allowedTags: "link",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code:
+        "<div onAbort={this.abort} onDurationChange={this.durationChange} onEmptied={this.emptied} onEnded={this.end} onResize={this.resize} onError={this.error} />",
+      errors: [
+        {
+          data: {
+            name: "onAbort",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "onDurationChange",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "onEmptied",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "onEnded",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "onResize",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "onError",
+            allowedTags: "audio, video, img, link, source, script, picture, iframe",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: "<div onLoad={this.load} />",
+      errors: [
+        {
+          data: {
+            name: "onLoad",
+            allowedTags: "script, img, link, picture, iframe, object, source",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div fill="pink" />',
+      errors: [
+        {
+          data: {
+            name: "fill",
+            allowedTags:
+              "altGlyph, circle, ellipse, g, line, marker, mask, path, polygon, polyline, rect, svg, symbol, text, textPath, tref, tspan, use, animate, animateColor, animateMotion, animateTransform, set",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code:
+        "<div controls={this.controls} loop={true} muted={false} src={this.videoSrc} playsInline={true} allowFullScreen></div>",
+      errors: [
+        {
+          data: {
+            name: "controls",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "loop",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "muted",
+            allowedTags: "audio, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "playsInline",
+            allowedTags: "video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+        {
+          data: {
+            name: "allowFullScreen",
+            allowedTags: "iframe, video",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div download="foo" />',
+      errors: [
+        {
+          data: {
+            name: "download",
+            allowedTags: "a, area",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div imageSrcSet="someImageSrcSet" />',
+      errors: [
+        {
+          data: {
+            name: "imageSrcSet",
+            allowedTags: "link",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div imageSizes="someImageSizes" />',
+      errors: [
+        {
+          data: {
+            name: "imageSizes",
+            allowedTags: "link",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div data-xml-anything="invalid" />',
+      errors: [
+        {
+          data: {
+            name: "data-xml-anything",
+          },
+          messageId: "unknownProp",
+        },
+      ],
+    },
+    {
+      code: '<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;',
+      errors: [
+        {
+          data: {
+            name: "data-testID",
+            lowerCaseName: "data-testid",
+          },
+          messageId: "dataLowercaseRequired",
+        },
+        {
+          data: {
+            name: "data-under_sCoRe",
+            lowerCaseName: "data-under_score",
+          },
+          messageId: "dataLowercaseRequired",
+        },
+        {
+          data: {
+            name: "dataNotAnDataAttribute",
+            lowerCaseName: "datanotandataattribute",
+          },
+          messageId: "unknownProp",
+        },
+      ],
+      options: [{ requireDataLowercase: true }],
+    },
+    {
+      code: '<App data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;',
+      errors: [
+        {
+          data: {
+            name: "data-testID",
+            lowerCaseName: "data-testid",
+          },
+          messageId: "dataLowercaseRequired",
+        },
+        {
+          data: {
+            name: "data-under_sCoRe",
+            lowerCaseName: "data-under_score",
+          },
+          messageId: "dataLowercaseRequired",
+        },
+      ],
+      options: [{ requireDataLowercase: true }],
+    },
+    {
+      code: '<div abbr="abbr" />',
+      errors: [
+        {
+          data: {
+            name: "abbr",
+            allowedTags: "th, td",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div webkitDirectory="" />',
+      errors: [
+        {
+          data: {
+            name: "webkitDirectory",
+            allowedTags: "input",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div webkitdirectory="" />',
+      errors: [
+        {
+          data: {
+            name: "webkitdirectory",
+            allowedTags: "input",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div precedence="medium" />',
+      errors: [
+        {
+          data: {
+            name: "precedence",
+            allowedTags: "link, style",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<div blocking="render" />',
+      errors: [
+        {
+          data: {
+            name: "blocking",
+            allowedTags: "link, script, style",
+            tagName: "div",
+          },
+          messageId: "invalidPropOnTag",
+        },
+      ],
+    },
+    {
+      code: '<style precedence="default">{`body { color: red; }`}</style>',
+      settings: {
+        "react-x": {
+          version: "18.3.1",
+        },
       },
-    ],
-  }, {
-    code: tsx`
+      errors: [
+        {
+          data: {
+            name: "precedence",
+          },
+          messageId: "unknownProp",
+        },
+      ],
+    },
+    {
+      code: '<script blocking="render" />',
+      settings: {
+        "react-x": {
+          version: "18.3.1",
+        },
+      },
+      errors: [
+        {
+          data: {
+            name: "blocking",
+          },
+          messageId: "unknownProp",
+        },
+      ],
+    },
+    {
+      code: tsx`
       <div className="App" data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash:c="customValue">
         Hello, world!
       </div>
     `,
-    errors: [
-      {
-        data: {
-          name:
-            "data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash:c",
+      errors: [
+        {
+          data: {
+            name:
+              "data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash:c",
+          },
+          messageId: "unknownProp",
         },
-        messageId: "unknownProp",
-      },
-    ],
-  }],
+      ],
+    }, // Boundary: JSXAttribute with empty expression container should still be checked
+    {
+      code: "<div class={}></div>",
+      errors: [{
+        data: { name: "class", standardName: "className" },
+        messageId: "unknownPropWithStandardName",
+      }],
+      output: "<div className={}></div>",
+    },
+  ],
   valid: [
     //
     // React components and their props/attributes should be fine
@@ -729,6 +774,30 @@ ruleTester.run(RULE_NAME, rule, {
           version: "19.0.0-rc.0",
         },
       },
+    },
+    // Boundary: JSXAttribute with no value (boolean attribute shorthand)
+    {
+      code: "<input disabled />",
+    },
+    {
+      code: "<input readOnly />",
+    },
+    {
+      code: "<button disabled>Click</button>",
+    },
+    // Boundary: JSXAttribute with empty expression container
+    {
+      code: "<div data-foo={}></div>",
+    },
+    {
+      code: "<div aria-label={}></div>",
+    },
+    // Boundary: custom component attributes (parent is not HTML tag)
+    {
+      code: '<Foo unknownProp="bar" />',
+    },
+    {
+      code: '<Foo.Bar abc="def" />',
     },
   ],
 });

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.spec.ts
@@ -194,5 +194,7 @@ ruleTester.run(RULE_NAME, rule, {
         return <iframe sandbox={useSandbox ? "allow-scripts allow-same-origin" : ""} />;
       }
     `,
+    // Boundary: JSXAttribute with empty expression container (resolveAttributeValue handles JSXEmptyExpression)
+    tsx`<iframe sandbox={} />;`,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.spec.ts
@@ -637,5 +637,44 @@ ruleTester.run(RULE_NAME, rule, {
         }, [text]);
       }
     `,
+    // try/catch in IIFE inside component (should not crash getEnclosingTryBlock)
+    tsx`
+      function Component() {
+        const result = (() => {
+          try {
+            return computeValue();
+          } catch (e) {
+            return null;
+          }
+        })();
+        return <div>{result}</div>;
+      }
+    `,
+    // try/catch in nested function declaration (not component render)
+    tsx`
+      function Component() {
+        function helper() {
+          try {
+            return riskyOperation();
+          } catch (e) {
+            return fallback;
+          }
+        }
+        return <div>{helper()}</div>;
+      }
+    `,
+    // try/catch in non-component IIFE (should not be reported)
+    tsx`
+      const helper = () => {
+        const result = (() => {
+          try {
+            return computeValue();
+          } catch (e) {
+            return null;
+          }
+        })();
+        return result;
+      };
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.spec.ts
@@ -1733,5 +1733,47 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    // useState in conditional expression (should not crash when parent is ConditionalExpression)
+    {
+      code: tsx`
+        import { useState } from "react";
+        function Component() {
+          const x = condition ? useState(0) : null;
+          return <div>{x}</div>;
+        }
+      `,
+    },
+    // useState in assignment expression (should not crash when parent is AssignmentExpression)
+    {
+      code: tsx`
+        import { useState } from "react";
+        function Component() {
+          let state;
+          state = useState(0);
+          return <div>{state[0]}</div>;
+        }
+      `,
+    },
+    // useReducer in assignment expression (should not crash when parent is AssignmentExpression)
+    {
+      code: tsx`
+        import { useReducer } from "react";
+        function Component() {
+          let state;
+          state = useReducer(reducer, {});
+          return <div>{state[0]}</div>;
+        }
+      `,
+    },
+    // useState in array expression (should not crash when parent is ArrayExpression)
+    {
+      code: tsx`
+        import { useState } from "react";
+        function Component() {
+          const arr = [useState(0)];
+          return <div>{arr[0][0]}</div>;
+        }
+      `,
+    },
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.spec.ts
@@ -246,5 +246,36 @@ ruleTester.run(RULE_NAME, rule, {
           return <svg xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon" />
       };
     `,
+    // Single JSX element with key (no siblings, should not crash)
+    tsx`
+      const App = () => {
+        return <div key="only">text</div>;
+      };
+    `,
+    // JSX element with key inside conditional expression (not in array/map)
+    tsx`
+      const App = ({ flag }) => {
+        return flag ? <div key="a">yes</div> : <div key="b">no</div>;
+      };
+    `,
+    // JSX element with key inside nested JSX (not direct sibling in array)
+    tsx`
+      const App = () => {
+        return (
+          <div>
+            <span key="nested">text</span>
+          </div>
+        );
+      };
+    `,
+    // JSX element with key inside object property (not array/map context)
+    tsx`
+      const App = () => {
+        const elements = {
+          foo: <div key="obj">text</div>,
+        };
+        return elements.foo;
+      };
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.spec.ts
@@ -295,6 +295,24 @@ ruleTester.run(RULE_NAME, rule, {
         ) : null;
       }
     `,
+    // JSXFragment not in array (node.parent !== ArrayExpression, should not crash)
+    tsx`
+      function Component() {
+        return <>hello</>;
+      }
+    `,
+    tsx`
+      function Component() {
+        const fragment = <>hello</>;
+        return fragment;
+      }
+    `,
+    tsx`
+      function Component() {
+        const el = condition ? <>a</> : <>b</>;
+        return <div>{el}</div>;
+      }
+    `,
     tsx`
       import React, { FC, useRef, useState } from 'react';
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.spec.ts
@@ -896,5 +896,30 @@ ruleTesterWithTypes.run(RULE_NAME, rule, {
         return <div />;
       }
     `,
+    // Boundary: props identifier in non-MemberExpression/VariableDeclarator parent
+    // (collectUsedPropKeysOfReference returns false, rule bails out — should not crash)
+    tsx`
+      function Component(props: { foo: string }) {
+        doSomething(props);
+        return null;
+      }
+    `,
+    tsx`
+      function Component(props: { foo: string }) {
+        return props;
+      }
+    `,
+    tsx`
+      function Component(props: { foo: string }) {
+        const items = [props];
+        return null;
+      }
+    `,
+    tsx`
+      function Component(props: { foo: string }) {
+        const x = props || {};
+        return null;
+      }
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.spec.ts
@@ -177,5 +177,33 @@ ruleTester.run(RULE_NAME, rule, {
         const Component = () => useState(0);
       `,
     },
+    // useState in assignment expression (should not crash when parent is AssignmentExpression)
+    {
+      code: tsx`
+        function Component() {
+          let state;
+          state = useState(0);
+          return <div>{state[0]}</div>;
+        }
+      `,
+    },
+    // useState in conditional expression (should not crash when parent is ConditionalExpression)
+    {
+      code: tsx`
+        function Component() {
+          const x = condition ? useState(0) : null;
+          return <div>{x}</div>;
+        }
+      `,
+    },
+    // useState in array expression (should not crash when parent is ArrayExpression)
+    {
+      code: tsx`
+        function Component() {
+          const arr = [useState(0)];
+          return <div>{arr[0][0]}</div>;
+        }
+      `,
+    },
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.spec.ts
@@ -978,6 +978,51 @@ ruleTester.run(RULE_NAME, rule, {
         { messageId: "writeDuringRender" },
       ],
     },
+    // ref.current === null in variable declaration should not crash isInNullCheckTest
+    {
+      code: tsx`
+        function Component() {
+          const ref = useRef(null);
+          const isNull = ref.current === null;
+          ref.current = 1;
+          return <div>{String(isNull)}</div>;
+        }
+      `,
+      errors: [
+        { messageId: "readDuringRender" },
+        { messageId: "writeDuringRender" },
+      ],
+    },
+    // ref.current === null in logical expression should not crash isInNullCheckTest
+    {
+      code: tsx`
+        function Component() {
+          const ref = useRef(null);
+          const result = ref.current === null || true;
+          ref.current = 1;
+          return <div>{String(result)}</div>;
+        }
+      `,
+      errors: [
+        { messageId: "readDuringRender" },
+        { messageId: "writeDuringRender" },
+      ],
+    },
+    // !(ref.current === null) as expression statement should not crash isInNullCheckTest
+    {
+      code: tsx`
+        function Component() {
+          const ref = useRef(null);
+          !(ref.current === null);
+          ref.current = 1;
+          return <div />;
+        }
+      `,
+      errors: [
+        { messageId: "readDuringRender" },
+        { messageId: "writeDuringRender" },
+      ],
+    },
   ],
   valid: [
     // Initialize only once on first use with nullish coalescing assignment is valid pattern
@@ -1775,6 +1820,25 @@ ruleTester.run(RULE_NAME, rule, {
           }
           ref.current = computeExpensiveValue();
           return <div />;
+        }
+      `,
+    },
+    // ref.current === null in variable declaration inside non-component should not crash isInNullCheckTest
+    {
+      code: tsx`
+        function notAComponent() {
+          const ref = useRef(null);
+          const isNull = ref.current === null;
+          return isNull;
+        }
+      `,
+    },
+    // ref.current === null in return statement inside non-component should not crash isInNullCheckTest
+    {
+      code: tsx`
+        function notAComponent() {
+          const ref = useRef(null);
+          return ref.current === null;
         }
       `,
     },

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
@@ -1802,5 +1802,35 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    // Setter identifier assigned to variable in effect (parent is VariableDeclarator, not CallExpression)
+    {
+      name: "setter identifier assigned to local variable in effect",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          useEffect(() => {
+            const fn = setData;
+          }, []);
+          return null;
+        }
+      `,
+    },
+    // Setter identifier in conditional expression in effect (parent is ConditionalExpression)
+    {
+      name: "setter identifier in conditional expression in effect",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        function Component() {
+          const [data, setData] = useState(0);
+          useEffect(() => {
+            const fn = condition ? setData : null;
+          }, []);
+          return null;
+        }
+      `,
+    },
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.spec.ts
@@ -647,5 +647,33 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    // useState without assignment should not crash isIdFromUseStateCall
+    {
+      code: tsx`
+        function Component() {
+          useState(0);
+          return <div />;
+        }
+      `,
+    },
+    // useState in conditional expression should not crash isIdFromUseStateCall
+    {
+      code: tsx`
+        function Component() {
+          const x = condition ? useState(0) : null;
+          return <div>{x}</div>;
+        }
+      `,
+    },
+    // useState in assignment expression should not crash isIdFromUseStateCall
+    {
+      code: tsx`
+        function Component() {
+          let state;
+          state = useState(0);
+          return <div>{state[0]}</div>;
+        }
+      `,
+    },
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.ts
@@ -507,5 +507,35 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    // Component variable referenced in non-assignment context should not crash
+    {
+      code: tsx`
+        function Parent() {
+          let Component = DefaultComponent;
+          console.log(Component);
+          return <Component />;
+        }
+      `,
+    },
+    // Component variable in array expression should not crash
+    {
+      code: tsx`
+        function Parent() {
+          let Component = DefaultComponent;
+          const arr = [Component];
+          return <Component />;
+        }
+      `,
+    },
+    // Component variable passed as argument should not crash
+    {
+      code: tsx`
+        function Parent() {
+          let Component = DefaultComponent;
+          fn(Component);
+          return <Component />;
+        }
+      `,
+    },
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.spec.ts
@@ -340,5 +340,38 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    // Boundary: function as non-call-expression child (isIifeCall parent traversal)
+    {
+      code: tsx`
+        function Component() {
+          const fn = () => <div />;
+          return fn();
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+          const fns = [() => <div />, () => <span />];
+          return fns[0]();
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+          const obj = { render: () => <div /> };
+          return obj.render();
+        }
+      `,
+    },
+    {
+      code: tsx`
+        function Component() {
+          const result = (() => <div />) as any;
+          return result;
+        }
+      `,
+    },
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.spec.ts
@@ -900,5 +900,59 @@ ruleTester.run(RULE_NAME, rule, {
         return [outer, y];
       }
     `,
+    // useMemo in conditional expression (parent is ConditionalExpression, should not crash)
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ flag, a, b }) {
+        const value = flag ? useMemo(() => a, []) : useMemo(() => b, []);
+        return <div>{value}</div>;
+      }
+    `,
+    // useMemo in array expression (parent is ArrayExpression, should not crash)
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ a, b }) {
+        const [x, y] = [useMemo(() => a, []), useMemo(() => b, [])];
+        return <div>{x}{y}</div>;
+      }
+    `,
+    // useMemo in return statement (parent is ReturnStatement, should not crash)
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ items }) {
+        return useMemo(() => items.sort(), [items]);
+      }
+    `,
+    // useMemo in assignment expression (parent is AssignmentExpression, should not crash)
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ items }) {
+        let sorted;
+        sorted = useMemo(() => items.sort(), [items]);
+        return <div>{sorted}</div>;
+      }
+    `,
+    // useMemo in logical expression (parent is LogicalExpression, should not crash)
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ flag, items }) {
+        const value = flag && useMemo(() => items.length, [items]);
+        return <div>{value}</div>;
+      }
+    `,
+    // useMemo in spread element (parent is SpreadElement, should not crash)
+    tsx`
+      import { useMemo } from "react";
+
+      function Component({ a, b }) {
+        const merged = { ...useMemo(() => a, []), ...useMemo(() => b, []) };
+        return <div>{merged}</div>;
+      }
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.spec.ts
@@ -402,6 +402,46 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    // useState in assignment expression (should not crash when parent is AssignmentExpression)
+    {
+      code: tsx`
+        function Component() {
+          let state;
+          state = useState(0);
+          return <div>{state[0]}</div>;
+        }
+      `,
+      errors: [{ messageId: "invalidAssignment" }],
+    },
+    // useState in conditional expression (should not crash when parent is ConditionalExpression)
+    {
+      code: tsx`
+        function Component() {
+          const x = condition ? useState(0) : null;
+          return <div>{x}</div>;
+        }
+      `,
+      errors: [{ messageId: "invalidAssignment" }],
+    },
+    // useState in array expression (should not crash when parent is ArrayExpression)
+    {
+      code: tsx`
+        function Component() {
+          const arr = [useState(0)];
+          return <div>{arr[0][0]}</div>;
+        }
+      `,
+      errors: [{ messageId: "invalidAssignment" }],
+    },
+    // useState in return statement (should not crash when parent is ReturnStatement)
+    {
+      code: tsx`
+        function Component() {
+          return useState(0);
+        }
+      `,
+      errors: [{ messageId: "invalidAssignment" }],
+    },
   ],
   valid: [
     // --- Assignment / setter naming ---


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Test

### Does this PR introduce a breaking change?

- [x] No

### Checklist

- [x] I have added a convincing reason for adding this feature, if necessary

### What

Expands null-safety boundary tests across rules affected by PR #1792'\''s removal of optional chaining on AST parent nodes. The refactor replaced defensive `parent?.type` with direct `parent.type` access based on TypeScript AST guarantees, but runtime crash risk remains if the parser produces unexpected AST shapes.

### Coverage

**eslint-plugin-react-x** (+462 lines, 13 rule spec files):
- `immutability`, `no-unused-state`, `refs`, `set-state-in-effect`, `static-components`
- `error-boundaries`, `no-duplicate-key`, `set-state-in-render`, `use-memo`, `use-state`
- `no-missing-key`, `no-unused-props`, `unsupported-syntax`

**eslint-plugin-react-dom** (+87 lines, 6 rule spec files):
- `no-render-return-value` — parent chain traversal
- `no-unknown-property` — JSXAttribute parent.name access, empty expression containers
- `no-script-url` — JSXAttribute value == null checks
- `no-missing-iframe-sandbox` — JSXEmptyExpression boundary
- `no-unsafe-iframe-sandbox` — JSXEmptyExpression boundary
- `no-string-style-prop` — boolean shorthand & empty expression boundaries

### Test Results

- `eslint-plugin-react-x`: **2,029 tests passing**
- `eslint-plugin-react-dom`: **487 tests passing**
