### PR TITLE
test: add regression tests for oxc issues compatibility verification

### DIFF
--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.spec.ts
@@ -134,5 +134,17 @@ ruleTester.run(RULE_NAME, rule, {
           return <button {...buttonAttrs}>Click me</button>;
       }
     `,
+    // https://github.com/oxc-project/oxc/issues/20938
+    // `document.createElement('button')` is a DOM API, not React createElement
+    tsx`
+      function App() {
+        return document.createElement("button");
+      }
+    `,
+    tsx`
+      function App() {
+        return Foo.createElement("button");
+      }
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.spec.ts
@@ -256,5 +256,52 @@ ruleTester.run(RULE_NAME, rule, {
       errors: [{ messageId: "default" }],
     },
   ],
-  valid: [],
+  valid: [
+    // https://github.com/oxc-project/oxc/issues/21110
+    // Composite key using template literal with string concatenation should be allowed
+    tsx`
+      function List({ items }) {
+        return (
+          <ul>
+            {items.map((item, index) => (
+              <li key={\`\${item.type + index}\`}>{item.text}</li>
+            ))}
+          </ul>
+        );
+      }
+    `,
+    tsx`
+      function List({ items }) {
+        return (
+          <ul>
+            {items.map((item, index) => (
+              <li key={\`\${item.type}\`}>{item.text}</li>
+            ))}
+          </ul>
+        );
+      }
+    `,
+    tsx`
+      function List({ items }) {
+        return (
+          <ul>
+            {items.map((item, index) => (
+              <li key={\`prefix-\${item.type}\`}>{item.text}</li>
+            ))}
+          </ul>
+        );
+      }
+    `,
+    tsx`
+      function List({ items }) {
+        return (
+          <ul>
+            {items.map((item, index) => (
+              <li key={item.type + item.text}>{item.text}</li>
+            ))}
+          </ul>
+        );
+      }
+    `,
+  ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name/no-missing-component-display-name.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name/no-missing-component-display-name.spec.ts
@@ -173,5 +173,18 @@ ruleTester.run(RULE_NAME, rule, {
 
       FancyButton.displayName = 'FancyButton';
     `,
+    // https://github.com/oxc-project/oxc/issues/22685
+    // should not flag functions that don't return JSX and don't start with capital letter
+    tsx`
+      const createHandler = () => () => {
+        someGlobalFunc(<div />);
+      };
+    `,
+    // variant with memo - should not flag inner function that doesn't return JSX
+    tsx`
+      const createHandler = React.memo(() => () => {
+        someGlobalFunc(<div />);
+      });
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.spec.ts
@@ -444,5 +444,26 @@ ruleTester.run(RULE_NAME, rule, {
         );
       }
     `,
+    // https://github.com/oxc-project/oxc/issues/17743
+    // `value ?? {}` creates a new object, but `min` is a scalar.
+    // This rule should not flag it because there is no default prop with an object/array.
+    tsx`
+      export const FloatBoundsInput = ({ value }) => {
+        const { min } = value ?? {};
+        return <InputNumber value={min} />;
+      };
+    `,
+    tsx`
+      export const FloatBoundsInput = ({ value }) => {
+        const { min } = value || {};
+        return <InputNumber value={min} />;
+      };
+    `,
+    tsx`
+      export const FloatBoundsInput = (props) => {
+        const { min } = props ?? {};
+        return <InputNumber value={min} />;
+      };
+    `,
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6388,8 +6388,9 @@ packages:
   node-html-parser@6.1.13:
     resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
-  node-releases@2.0.44:
-    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+  node-releases@2.0.45:
+    resolution: {integrity: sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==}
+    engines: {node: '>=18'}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -8041,7 +8042,6 @@ snapshots:
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -8051,7 +8051,6 @@ snapshots:
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@emnapi/runtime@1.4.5':
     dependencies:
@@ -8064,7 +8063,6 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
-    optional: true
 
   '@es-joy/jsdoccomment@0.86.0':
     dependencies:
@@ -8499,8 +8497,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
-      '@emnapi/core': 1.4.5
-      '@emnapi/runtime': 1.4.5
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.9.0
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -10337,7 +10335,7 @@ snapshots:
 
   brace-expansion@5.0.2:
     dependencies:
-      balanced-match: 4.0.3
+      balanced-match: 4.0.4
 
   brace-expansion@5.0.6:
     dependencies:
@@ -10352,7 +10350,7 @@ snapshots:
       baseline-browser-mapping: 2.10.31
       caniuse-lite: 1.0.30001793
       electron-to-chromium: 1.5.360
-      node-releases: 2.0.44
+      node-releases: 2.0.45
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   bsky-react-post@0.1.7(react@19.2.6)(swr@2.4.1(react@19.2.6)):
@@ -10942,7 +10940,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   es-toolkit@1.46.1: {}
 
@@ -11394,7 +11392,7 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       mime-types: 2.1.35
 
   format@0.2.2: {}
@@ -11597,7 +11595,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-nonce@1.0.1: {}
@@ -12941,7 +12939,7 @@ snapshots:
       css-select: 5.2.2
       he: 1.2.0
 
-  node-releases@2.0.44: {}
+  node-releases@2.0.45: {}
 
   nopt@7.2.1:
     dependencies:


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [x] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)

### Other information

Adds test cases covering the following oxc-project issues to verify correct behavior (no false positives) in our rules:

- **oxc#22608** (react/no-unstable-nested-components) → verified not reproducible in `no-nested-component-definitions`
- **oxc#22685** (react/display-name) → verified not reproducible in `no-missing-component-display-name`
- **oxc#17743** (react-perf/jsx-no-new-object-as-prop) → verified not reproducible in `no-unstable-default-props`
- **oxc#20938** (react/button-has-type) → verified not reproducible in `no-missing-button-type`
- **oxc#21110** (react/no-array-index-key) → verified not reproducible in `no-array-index-key`

These tests serve as regression coverage to prevent future false positives that match the patterns reported in the upstream oxc issues.