### PR TITLE
fix(jsx): align children filtering and docs with React source behaviour

### DIFF
--- a/packages/jsx/src/get-children.ts
+++ b/packages/jsx/src/get-children.ts
@@ -4,10 +4,18 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 /**
  * Get the **meaningful** children of a JSX element or fragment.
  *
- * Filters out "padding spaces" — `JSXText` nodes that consist entirely of
- * whitespace and contain at least one newline.  These nodes are artefacts of
- * source formatting that React trims away during rendering and are therefore
- * not considered meaningful content.
+ * Filters out nodes that React will not render into the DOM:
+ *
+ * 1. "Padding spaces" — `JSXText` nodes that consist entirely of whitespace
+ *    and contain at least one newline. These are code-formatting artefacts
+ *    (indentation between tags). While React's client renderer preserves them
+ *    as text nodes, browser HTML parsers may discard them during hydration,
+ *    causing hydration mismatches.
+ *
+ * 2. Empty string expressions — `JSXExpressionContainer` nodes whose expression
+ *    is a string literal with value `""`. React's reconciler and SSR renderer
+ *    explicitly skip empty strings, producing no DOM node
+ *    (see ReactChildFiber.js and ReactFizzConfigDOM.js).
  *
  * @param element - A `JSXElement` or `JSXFragment` node.
  * @returns An array of children nodes that contribute to rendered output.
@@ -27,15 +35,20 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  * ```
  */
 export function getChildren(element: TSESTreeJSXElementLike): TSESTree.JSXChild[] {
-  return element.children.filter((child: TSESTree.JSXChild) => !isPaddingSpaces(child));
+  return element.children.filter((child: TSESTree.JSXChild) => {
+    if (isPaddingSpaces(child)) return false;
+    if (isEmptyStringExpression(child)) return false;
+    return true;
+  });
 }
 
 /**
  * A `JSXText` node is considered **padding spaces** when it is purely
  * whitespace *and* contains at least one newline character.
  *
- * These nodes are formatting artefacts (indentation between JSX tags) that
- * React discards at render time.
+ * These nodes are code-formatting artefacts (indentation between JSX tags).
+ * While React's client renderer preserves them as text nodes, browser HTML
+ * parsers may discard them during hydration, leading to hydration mismatches.
  *
  * @param node The JSX child node to check.
  * @internal
@@ -43,4 +56,23 @@ export function getChildren(element: TSESTreeJSXElementLike): TSESTree.JSXChild[
 function isPaddingSpaces(node: TSESTree.JSXChild): boolean {
   if (node.type !== AST.JSXText) return false;
   return node.raw.trim() === "" && node.raw.includes("\n");
+}
+
+/**
+ * A `JSXExpressionContainer` node is considered an empty string expression
+ * when it wraps a string literal with value `""`.
+ *
+ * React's reconciler explicitly ignores empty strings
+ * (`typeof newChild === 'string' && newChild !== ''` in ReactChildFiber.js),
+ * and the SSR renderer skips them as well (`if (text === '') { return; }`
+ * in ReactFizzConfigDOM.js). They produce no DOM node.
+ *
+ * @param node The JSX child node to check.
+ * @internal
+ */
+function isEmptyStringExpression(node: TSESTree.JSXChild): boolean {
+  if (node.type !== AST.JSXExpressionContainer) return false;
+  const expr = node.expression;
+  if (expr.type !== AST.Literal) return false;
+  return expr.value === "";
 }

--- a/packages/jsx/src/has-children.ts
+++ b/packages/jsx/src/has-children.ts
@@ -3,12 +3,17 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
  * Check whether a JSX element (or fragment) has **meaningful** children —
- * that is, at least one child that is not purely whitespace text.
+ * that is, at least one child that is not purely whitespace text or an empty
+ * string expression.
  *
- * A `JSXText` child whose `raw` content is empty after trimming is
- * considered non-meaningful regardless of whether it contains a line break.
- * This matches React's rendering behaviour where whitespace-only text nodes
- * do not produce visible output.
+ * A `JSXText` child whose `raw` content is empty after trimming is considered
+ * non-meaningful because it is typically a code-formatting artefact
+ * (indentation between tags). While React's client renderer preserves these
+ * nodes as text nodes, they rarely represent intentionally rendered content.
+ *
+ * An empty string expression (`children={""}`) is also considered
+ * non-meaningful because React's reconciler and SSR renderer explicitly skip
+ * empty strings, producing no DOM node.
  *
  * @param element - A `JSXElement` or `JSXFragment` node.
  * @returns `true` when the element has at least one meaningful child.
@@ -23,6 +28,7 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  * // <div>                      -> false  (whitespace-only, with newlines)
  * // </div>
  * // <div></div>                -> false  (no children at all)
+ * // <div>{""}</div>            -> false  (empty string expression)
  *
  * if (hasChildren(node)) {
  *   // element renders visible content
@@ -31,11 +37,13 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  */
 export function hasChildren(element: TSESTreeJSXElementLike): boolean {
   if (element.children.length === 0) return false;
-  return !element.children.every((child: TSESTree.JSXChild) => isWhitespaceText(child));
+  return !element.children.every((child: TSESTree.JSXChild) =>
+    isWhitespaceText(child) || isEmptyStringExpression(child)
+  );
 }
 
 // ---------------------------------------------------------------------------
-// Internal helper
+// Internal helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -46,7 +54,22 @@ export function hasChildren(element: TSESTreeJSXElementLike): boolean {
  * nodes always return `false`.
  * @param node The JSX child node to check.
  */
-function isWhitespaceText(node: TSESTreeJSXElementLike["children"][number]): boolean {
+function isWhitespaceText(node: TSESTree.JSXChild): boolean {
   if (node.type !== AST.JSXText) return false;
   return node.raw.trim() === "";
+}
+
+/**
+ * Whether a JSX child node is an empty string expression (`{""}`).
+ *
+ * React's reconciler and SSR renderer skip empty strings, producing no DOM
+ * node. These expressions are therefore considered non-meaningful children.
+ *
+ * @param node The JSX child node to check.
+ */
+function isEmptyStringExpression(node: TSESTree.JSXChild): boolean {
+  if (node.type !== AST.JSXExpressionContainer) return false;
+  const expr = node.expression;
+  if (expr.type !== AST.Literal) return false;
+  return expr.value === "";
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/lib.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/lib.ts
@@ -7,10 +7,16 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 // ---------------------------------------------------------------------------
 
 /**
- * Trim leading / trailing whitespace the same way React does when rendering
- * JSX text.  Whitespace that contains a newline is stripped entirely;
+ * Trim leading / trailing whitespace that spans across a newline.
+ *
+ * This is used by the auto-fixer to remove indentation / formatting artefacts
+ * from the raw source text when moving a `children` prop value into element
+ * content. It does **not** model React's rendering behaviour — React DOM
+ * preserves text nodes exactly as written.
+ *
+ * Whitespace that contains a newline is stripped entirely;
  * whitespace that stays on the same line is preserved.
- * @param text The JSX text to trim.
+ * @param text The raw source text to trim.
  */
 export function trimLikeReact(text: string): string {
   const leadingSpaces = /^\s*/.exec(text)?.[0] ?? "";

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/lib.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/lib.ts
@@ -7,10 +7,16 @@ import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 // ---------------------------------------------------------------------------
 
 /**
- * Trim leading / trailing whitespace the same way React does when rendering
- * JSX text.  Whitespace that contains a newline is stripped entirely;
+ * Trim leading / trailing whitespace that spans across a newline.
+ *
+ * This is used by the auto-fixer to remove indentation / formatting artefacts
+ * from the raw source text between a fragment's opening and closing tags,
+ * producing cleaner unwrapped output. It does **not** model React's rendering
+ * behaviour — React DOM preserves text nodes exactly as written.
+ *
+ * Whitespace that contains a newline is stripped entirely;
  * whitespace that stays on the same line is preserved.
- * @param text The JSX text to trim.
+ * @param text The raw source text between JSX tags.
  */
 export function trimLikeReact(text: string): string {
   const leadingSpaces = /^\s*/.exec(text)?.[0] ?? "";

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.spec.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.spec.ts
@@ -247,8 +247,40 @@ ruleTester.run(RULE_NAME, rule, {
           data: { reason: "placed inside a host component" },
           messageId: "default",
         },
+        {
+          type: AST.JSXFragment,
+          data: { reason: "contains less than two children" },
+          messageId: "default",
+        },
       ],
       output: '<div>a {""}{""} a</div>',
+    },
+    {
+      code: "<>{''}</>",
+      errors: [
+        {
+          type: AST.JSXFragment,
+          data: { reason: "contains less than two children" },
+          messageId: "default",
+        },
+      ],
+      output: null,
+    },
+    {
+      code: "<div><>{''}</></div>",
+      errors: [
+        {
+          type: AST.JSXFragment,
+          data: { reason: "placed inside a host component" },
+          messageId: "default",
+        },
+        {
+          type: AST.JSXFragment,
+          data: { reason: "contains less than two children" },
+          messageId: "default",
+        },
+      ],
+      output: "<div>{''}</div>",
     },
     {
       code: tsx`


### PR DESCRIPTION
Based on React source code analysis:

- React's reconciler (ReactChildFiber.js) and SSR renderer (ReactFizzConfigDOM.js) explicitly skip empty strings (''). Add isEmptyStringExpression filtering to getChildren() and hasChildren() so empty string expressions are treated as non-meaningful, matching runtime behaviour.

- Correct misleading JSDoc comments that claimed React trims whitespace-only text nodes at render time. React DOM actually preserves them via document.createTextNode(text). The nodes that may discard them are browser HTML parsers during hydration.

- Correct trimLikeReact JSDoc in no-useless-fragment and no-children-prop rules: it is an auto-fixer formatting utility, not a model of React's rendering behaviour.

- Fix no-useless-fragment false negative: <>{''}</> is now correctly reported as useless because React ignores the empty string.

- Add test coverage for empty string expression cases.

Refs: ReactChildFiber.js, ReactFizzConfigDOM.js,
      ReactFiberConfigDOM.js

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [x] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
