### PR TITLE
docs(kit) & test(react-x): add is.APICall callout and captureOwnerStack edge-case tests

### DIFF
--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -292,8 +292,27 @@ nodes.filter(is.memoCall);
 
 // Factory for any API name
 const isCreateRefCall = is.APICall("createRef");
+
+// Returns true when the node is a call to `createRef`
 isCreateRefCall(node);
 ```
+
+<Callout type="info" title="Why `is.API` / `is.APICall` instead of a hand-written check?">
+  Consider this single statement:
+
+  ```ts
+  const ownerStack = ((React as any)?.captureOwnerStack)?.()!;
+  ```
+
+  The call to `captureOwnerStack` is buried under four layers of syntax — a `React as any` cast (`TSAsExpression`), an optional member access (`?.captureOwnerStack` → `ChainExpression`), an optional call (`?.()` → `ChainExpression`), and a trailing non-null assertion (`!` → `TSNonNullExpression`). A naive guard such as `node.callee.type === "Identifier" && node.callee.name === "captureOwnerStack"` matches **nothing**: the callee isn't even an `Identifier` — it's a `ChainExpression` wrapping a `MemberExpression` whose object is itself a `TSAsExpression`.
+
+  `is.APICall("captureOwnerStack")` still returns `true`, because the factory:
+
+  - runs `ast.unwrap` first, peeling off `ChainExpression` and TS wrappers (`TSAsExpression`, `TSSatisfiesExpression`, `TSNonNullExpression`, `TSTypeAssertion`, parentheses) until it reaches the real callee;
+  - matches on the **fully-qualified name**, so a single predicate covers both the bare `captureOwnerStack` and the namespaced `React.captureOwnerStack` (any name ending in `.captureOwnerStack`).
+
+  Use `is.API(name)` for the reference itself and `is.APICall(name)` for a call to it. Hand-rolling this means re-implementing unwrapping and member-expression resolution for **every** API — and breaking the moment someone adds a `?.`, an `as`, or a `React.` prefix. To additionally assert the symbol truly comes from React (and not a local same-named binding), pair it with [`is.APIFromReact`](#import-source).
+</Callout>
 
 #### Import source
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.spec.ts
@@ -175,7 +175,53 @@ ruleTester.run(RULE_NAME, rule, {
         // Failing: Named import with TSTypeAssertion on callee
         import { captureOwnerStack } from "react";
 
-        const ownerStack = (<any>captureOwnerStack)();
+        const ownerStack = (<any>captureOwnerStack)?.();
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: false },
+        },
+      },
+      errors: [
+        {
+          type: AST.ImportSpecifier,
+          messageId: "useNamespaceImport",
+        },
+        {
+          type: AST.CallExpression,
+          messageId: "missingDevelopmentOnlyCheck",
+        },
+      ],
+    },
+    {
+      code: tsx`
+        // Failing: Named import with TSTypeAssertion on callee
+        import { captureOwnerStack } from "react";
+
+        const ownerStack = (<() => {}>captureOwnerStack)?.()!;
+      `,
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: false },
+        },
+      },
+      errors: [
+        {
+          type: AST.ImportSpecifier,
+          messageId: "useNamespaceImport",
+        },
+        {
+          type: AST.CallExpression,
+          messageId: "missingDevelopmentOnlyCheck",
+        },
+      ],
+    },
+    {
+      code: tsx`
+        // Failing: Multi-layer TS wrapper with namespace member call
+        import { captureOwnerStack } from "react";
+
+        const ownerStack = (<object?>(React as unknown)?.captureOwnerStack)?.()!;
       `,
       languageOptions: {
         parserOptions: {


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Docs
- [x] Test

### Does this PR introduce a breaking change?

- [x] No

### Checklist

- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

- **Docs**: Adds a callout in `@eslint-react/kit` documentation explaining why `is.API` / `is.APICall` should be preferred over hand-written AST checks. Uses `((React as any)?.captureOwnerStack)?.()!` as a concrete example to illustrate how deeply the callee can be buried under `TSAsExpression`, `ChainExpression`, `TSNonNullExpression`, and other wrappers.
- **Tests**: Expands `no-misused-capture-owner-stack` test coverage with cases involving optional chaining (`?.()`), `TSTypeAssertion`, `TSAsExpression`, and `TSNonNullExpression` layered together, ensuring the rule correctly identifies `captureOwnerStack` calls through complex TypeScript syntax.
