### PR TITLE
fix(rules/no-direct-mutation-state): detect nested state mutations an…

### DIFF
--- a/packages/ast/src/extract.ts
+++ b/packages/ast/src/extract.ts
@@ -20,9 +20,7 @@ export function getRootIdentifier(node: TSESTree.Expression | TSESTree.PrivateId
 }
 
 export function getPropertyName(node: TSESTree.Node): string | null {
-  if (Check.isTypeExpression(node)) {
-    return getPropertyName(unwrap(node));
-  }
+  node = unwrap(node);
   if (node.type === AST.Identifier || node.type === AST.PrivateIdentifier) {
     return node.name;
   }

--- a/packages/core/src/class-component.test.ts
+++ b/packages/core/src/class-component.test.ts
@@ -235,8 +235,60 @@ describe("isAssignmentToThisState", () => {
     expect(result).toBe(true);
   });
 
+  it("should return true for this.state.foo = 'baz'", () => {
+    const code = "this.state.foo = 'baz'";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.AssignmentExpression) {
+          result = isAssignmentToThisState(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should return true for this.state.foo.bar = 'baz'", () => {
+    const code = "this.state.foo.bar = 'baz'";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.AssignmentExpression) {
+          result = isAssignmentToThisState(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should return true for (this.state as any).foo = 'baz'", () => {
+    const code = "(this.state as any).foo = 'baz'";
+    let result = false;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.AssignmentExpression) {
+          result = isAssignmentToThisState(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
   it("should return false for unrelated assignments", () => {
     const code = "this.props = {}";
+    let result = true;
+    simpleTraverse(parse(code).ast, {
+      enter(node) {
+        if (node.type === AST.AssignmentExpression) {
+          result = isAssignmentToThisState(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(false);
+  });
+
+  it("should return false for this.props.foo = 'baz'", () => {
+    const code = "this.props.foo = 'baz'";
     let result = true;
     simpleTraverse(parse(code).ast, {
       enter(node) {

--- a/packages/core/src/class-component.ts
+++ b/packages/core/src/class-component.ts
@@ -159,9 +159,15 @@ export function isThisSetStateCall(node: TSESTree.CallExpression) {
  */
 export function isAssignmentToThisState(node: TSESTree.AssignmentExpression) {
   const { left } = node;
-  return left.type === AST.MemberExpression
-    && left.object.type === AST.ThisExpression
-    && Extract.getPropertyName(left.property) === "state";
+  let current: TSESTree.Node = Extract.unwrap(left);
+  while (current.type === AST.MemberExpression) {
+    const { object, property } = current;
+    if (object.type === AST.ThisExpression && Extract.getPropertyName(property) === "state") {
+      return true;
+    }
+    current = Extract.unwrap(object);
+  }
+  return false;
 }
 
 // #endregion

--- a/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.8.8] - 2026-06-01
+
+### Fixed
+
+- Fixed `isAssignmentToThisState` helper to correctly detect nested state mutations (e.g. `this.state.foo = "baz"`) and TypeScript-wrapped expressions (e.g. `(this.state as any).foo = "baz"`). Previously, only whole-state assignments (`this.state = X`) were detected.
+
 ## [5.2.3-beta.0] - 2026-04-14
 
 ### Changed

--- a/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.spec.ts
@@ -109,6 +109,55 @@ ruleTester.run(RULE_NAME, rule, {
         messageId: "default",
       }],
     },
+    // Direct mutation of nested state property in event handler
+    {
+      code: tsx`
+        class Hello extends React.Component {
+          render() {
+            return (
+              <button onClick={() => {
+                this.state.foo = 'baz';
+              }}>
+                Click
+              </button>
+            );
+          }
+        }
+      `,
+      errors: [{
+        messageId: "default",
+      }],
+    },
+    // Direct mutation of deeply nested state property
+    {
+      code: tsx`
+        class Hello extends React.Component {
+          updateState() {
+            this.state.foo.bar = 'baz';
+          }
+        }
+      `,
+      errors: [{
+        messageId: "default",
+      }],
+    },
+    // Direct mutation of nested state property in callback within constructor
+    {
+      code: tsx`
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props)
+
+            doSomethingAsync(() => {
+              this.state.foo = 'baz';
+            });
+          }
+        }
+      `,
+      errors: [{
+        messageId: "default",
+      }],
+    },
   ],
   valid: [
     // Nested class component (mutation in inner class)
@@ -132,6 +181,16 @@ ruleTester.run(RULE_NAME, rule, {
           this.state = {
             foo: 'bar',
           }
+        }
+      }
+    `,
+    // Constructor nested property assignment (allowed)
+    tsx`
+      class Hello extends React.Component {
+        constructor(props) {
+          super(props)
+
+          this.state.foo = 'bar';
         }
       }
     `,


### PR DESCRIPTION
…d TS-wrapped expressions

- Update isAssignmentToThisState to descend MemberExpression chain, so this.state.foo = X and this.state.foo.bar = X are detected.
- Use Extract.unwrap to handle TSAsExpression / TSSatisfiesExpression wrappers, e.g. (this.state as any).foo = X.
- Add core unit tests and rule tests for the new cases.

Closes #1817

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [x] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
