### PR TITLE
docs(naming-convention): expand examples and annotate Ok cases

### DIFF
--- a/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
@@ -57,6 +57,16 @@ const themeContext = createContext("");
 const context = createContext("");
 ```
 
+```tsx
+// Problem: Context name must end with 'Context' (not just contain it)
+const ThemeContext2 = createContext("");
+```
+
+```tsx
+// Problem: Context name should be PascalCase and end with 'Context'
+obj.nested.theme = createContext("");
+```
+
 ### Naming context correctly
 
 ```tsx
@@ -67,6 +77,21 @@ const ThemeContext = createContext("");
 ```tsx
 // Recommended: PascalCase with 'Context' suffix
 const Context = createContext("");
+```
+
+```tsx
+// Recommended: PascalCase with 'Context' suffix (MemberExpression)
+obj.nested.ThemeContext = createContext("");
+```
+
+```tsx
+// Recommended: PascalCase with 'Context' suffix (class property)
+class Foo { ThemeContext = createContext(""); }
+```
+
+```tsx
+// Ok: Not assigned to an identifier or member expression, so there is no name to validate
+export default createContext("");
 ```
 
 ## Resources

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.spec.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.spec.ts
@@ -62,6 +62,34 @@ ruleTester.run(RULE_NAME, rule, {
         },
       },
     },
+    {
+      code: tsx`
+        import { createContext } from "react";
+        const ThemeContext2 = createContext("");
+      `,
+      errors: [{ messageId: "invalidContextName" }],
+    },
+    {
+      code: tsx`
+        import { createContext } from "react";
+        class Foo { theme = createContext(""); }
+      `,
+      errors: [{ messageId: "invalidContextName" }],
+    },
+    {
+      code: tsx`
+        import { createContext } from "react";
+        obj.nested.theme = createContext("");
+      `,
+      errors: [{ messageId: "invalidContextName" }],
+    },
+    {
+      code: tsx`
+        import { createContext } from "react";
+        const contexts = { ThemeContext: createContext("") };
+      `,
+      errors: [{ messageId: "invalidContextName" }],
+    },
   ],
   valid: [
     tsx`
@@ -84,6 +112,34 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     tsx`
       ctxs.ThemeContext = createContext("");
+    `,
+    tsx`
+      import { createContext } from "react";
+      const AContext = createContext("");
+    `,
+    tsx`
+      import { createContext } from "react";
+      const MyUIContext = createContext("");
+    `,
+    tsx`
+      import { createContext } from "react";
+      createContext("");
+    `,
+    tsx`
+      import { createContext } from "react";
+      export default createContext("");
+    `,
+    tsx`
+      import { createContext } from "react";
+      class Foo { ThemeContext = createContext(""); }
+    `,
+    tsx`
+      import { createContext } from "react";
+      obj.nested.ThemeContext = createContext("");
+    `,
+    tsx`
+      import { createContext } from "react";
+      const Theme_Context = createContext("");
     `,
   ],
 });

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
@@ -47,6 +47,16 @@ const unique = useId();
 const foo = useId();
 ```
 
+```tsx
+// Problem: Suffix must be exactly 'Id' (case-sensitive)
+const myID = useId();
+```
+
+```tsx
+// Problem: A variable assigned from `useId()` must be named 'id' or end with 'Id'.
+obj.nested.value = useId();
+```
+
 ### Assigning `useId` to a properly named variable
 
 ```tsx
@@ -62,6 +72,21 @@ const inputId = useId();
 ```tsx
 // Recommended: Descriptive name ending with 'Id'
 const dialogTitleId = useId();
+```
+
+```tsx
+// Recommended: Descriptive name ending with 'Id' (MemberExpression)
+obj.nested.myId = useId();
+```
+
+```tsx
+// Ok: Not assigned to an identifier or member expression, so there is no name to validate
+export default useId();
+```
+
+```tsx
+// Ok: The call sits inside an array literal, so it is not directly assigned to a checkable name
+const [value] = [useId()];
 ```
 
 ## Resources

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.spec.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.spec.ts
@@ -32,6 +32,34 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: "invalidIdName" }],
     },
+    {
+      code: tsx`
+        import { useId } from "react";
+        const myID = useId();
+      `,
+      errors: [{ messageId: "invalidIdName" }],
+    },
+    {
+      code: tsx`
+        import { useId } from "react";
+        class Foo { value = useId(); }
+      `,
+      errors: [{ messageId: "invalidIdName" }],
+    },
+    {
+      code: tsx`
+        import { useId } from "react";
+        obj.nested.value = useId();
+      `,
+      errors: [{ messageId: "invalidIdName" }],
+    },
+    {
+      code: tsx`
+        import { useId } from "react";
+        const ids = { myId: useId() };
+      `,
+      errors: [{ messageId: "invalidIdName" }],
+    },
   ],
   valid: [
     tsx`
@@ -57,6 +85,34 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     tsx`
       ctxs.myId = useId();
+    `,
+    tsx`
+      import { useId } from "react";
+      useId();
+    `,
+    tsx`
+      import { useId } from "react";
+      export default useId();
+    `,
+    tsx`
+      import { useId } from "react";
+      const Id = useId();
+    `,
+    tsx`
+      import { useId } from "react";
+      class Foo { myId = useId(); }
+    `,
+    tsx`
+      import { useId } from "react";
+      obj.nested.myId = useId();
+    `,
+    tsx`
+      import { useId } from "react";
+      const [value] = [useId()];
+    `,
+    tsx`
+      import { useId } from "react";
+      const { value } = { value: useId() };
     `,
   ],
 });

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
@@ -47,6 +47,16 @@ const input = useRef<HTMLInputElement>(null);
 const value = useRef(null);
 ```
 
+```tsx
+// Problem: Suffix must be exactly 'Ref' (case-sensitive)
+const myREF = useRef(0);
+```
+
+```tsx
+// Problem: A ref identifier must be named 'ref' or end in 'Ref'.
+obj.nested.value = useRef(0);
+```
+
 ### Assigning `useRef` to a properly named variable
 
 ```tsx
@@ -67,6 +77,31 @@ const inputRef = useRef<HTMLInputElement>(null);
 ```tsx
 // Recommended: Descriptive name ending with 'Ref'
 const valueRef = useRef(null);
+```
+
+```tsx
+// Recommended: Descriptive name ending with 'Ref' (MemberExpression)
+obj.nested.myRef = useRef();
+```
+
+```tsx
+// Ok: Not assigned to an identifier or member expression, so there is no name to validate
+export default useRef(null);
+```
+
+```tsx
+// Ok: The call sits inside an array literal, so it is not directly assigned to a checkable name
+const [value] = [useRef(null)];
+```
+
+```tsx
+// Ok: The result is immediately accessed via a member expression instead of being stored in a ref variable
+const value = useRef(null).current.value;
+```
+
+```tsx
+// Ok: The result is immediately accessed via a member expression instead of being stored in a ref variable (same as above)
+const useOnce = <T,>(fn: () => T) => (useRef<{ value: T }>().current ??= { value: fn() }).value;
 ```
 
 ## Resources

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.spec.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.spec.ts
@@ -45,6 +45,34 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: "invalidRefName" }],
     },
+    {
+      code: tsx`
+        import { useRef } from "react";
+        const myREF = useRef(0);
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+    {
+      code: tsx`
+        import { useRef } from "react";
+        class Foo { value = useRef(0); }
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+    {
+      code: tsx`
+        import { useRef } from "react";
+        obj.nested.value = useRef(0);
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
+    {
+      code: tsx`
+        import { useRef } from "react";
+        const refs = { myRef: useRef(0) };
+      `,
+      errors: [{ messageId: "invalidRefName" }],
+    },
   ],
   valid: [
     tsx`
@@ -79,6 +107,38 @@ ruleTester.run(RULE_NAME, rule, {
     `,
     tsx`
       refs.myRef = useRef();
+    `,
+    tsx`
+      import { useRef } from "react";
+      useRef(null);
+    `,
+    tsx`
+      import { useRef } from "react";
+      export default useRef(null);
+    `,
+    tsx`
+      import { useRef } from "react";
+      const Ref = useRef(null);
+    `,
+    tsx`
+      import { useRef } from "react";
+      class Foo { myRef = useRef(null); }
+    `,
+    tsx`
+      import { useRef } from "react";
+      obj.nested.myRef = useRef();
+    `,
+    tsx`
+      import { useRef } from "react";
+      const [value] = [useRef(null)];
+    `,
+    tsx`
+      import { useRef } from "react";
+      const { value } = { value: useRef(null) };
+    `,
+    tsx`
+      import { useRef } from "react";
+      const value = useRef(null).current.value;
     `,
   ],
 });


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Docs
- [x] Test

### Does this PR introduce a breaking change?

- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Expands the examples in the `context-name`, `id-name`, and `ref-name` rule docs:

- Adds `MemberExpression`, class property, and edge-case examples.
- Annotates every `// Ok:` example with the reason it is not reported (no assignment target, array-literal destructuring, or inline member-expression access).
- Adds a `useOnce` example demonstrating an inline `useRef().current ??= ...` access that is intentionally not flagged.
- Covers all new cases with matching valid/invalid test cases.
