### PR TITLE
refactor(jsx): consolidate whitespace child predicates

### DIFF
--- a/packages/jsx/docs/README.md
+++ b/packages/jsx/docs/README.md
@@ -32,6 +32,7 @@
 | [hasChildren](functions/hasChildren.md) | Check whether a JSX element (or fragment) has **meaningful** children — that is, at least one child that is not purely whitespace text or an empty string expression. |
 | [hasEveryAttribute](functions/hasEveryAttribute.md) | Check whether a JSX element carries **all** of the given attributes (props). |
 | [isElement](functions/isElement.md) | Check whether a node is a `JSXElement` (or `JSXFragment`) and optionally matches a given test. |
+| [isEmptyStringExpression](functions/isEmptyStringExpression.md) | Check whether a JSX child node is an **empty string expression** (`{""}`). |
 | [isFragmentElement](functions/isFragmentElement.md) | Check whether a node is a React **Fragment** element. |
 | [isHostElement](functions/isHostElement.md) | Check whether a node is a **host** (intrinsic / DOM) element. |
 | [isWhitespace](functions/isWhitespace.md) | Check whether a JSX child node is **whitespace padding** that React would trim away during rendering. |

--- a/packages/jsx/docs/functions/getChildren.md
+++ b/packages/jsx/docs/functions/getChildren.md
@@ -11,15 +11,21 @@ Get the **meaningful** children of a JSX element or fragment.
 Filters out nodes that React will not render into the DOM:
 
 1. "Padding spaces" — `JSXText` nodes that consist entirely of whitespace
-   and contain at least one newline. These are code-formatting artefacts
-   (indentation between tags). While React's client renderer preserves them
-   as text nodes, browser HTML parsers may discard them during hydration,
-   causing hydration mismatches.
+   and contain at least one newline (see [isWhitespace](isWhitespace.md)). These are
+   code-formatting artefacts (indentation between tags). While React's client
+   renderer preserves them as text nodes, browser HTML parsers may discard
+   them during hydration, causing hydration mismatches.
 
 2. Empty string expressions — `JSXExpressionContainer` nodes whose expression
-   is a string literal with value `""`. React's reconciler and SSR renderer
-   explicitly skip empty strings, producing no DOM node
-   (see ReactChildFiber.js and ReactFizzConfigDOM.js).
+   is a string literal with value `""` (see [isEmptyStringExpression](isEmptyStringExpression.md)).
+   React's reconciler and SSR renderer explicitly skip empty strings,
+   producing no DOM node.
+
+Whitespace-only text **without** a newline (e.g. the single space in
+`<div> </div>`) is intentionally **kept**, because React renders it. For
+this reason `getChildren(node).length > 0` is **not** equivalent to
+[hasChildren](hasChildren.md), which applies a stricter "any whitespace-only text is
+non-meaningful" heuristic. Pick the one that matches your rule's intent.
 
 ## Parameters
 

--- a/packages/jsx/docs/functions/hasChildren.md
+++ b/packages/jsx/docs/functions/hasChildren.md
@@ -19,6 +19,13 @@ An empty string expression (`children={""}`) is also considered
 non-meaningful because React's reconciler and SSR renderer explicitly skip
 empty strings, producing no DOM node.
 
+Unlike [getChildren](getChildren.md) — which only filters whitespace that contains a
+newline — this check treats **any** whitespace-only text as non-meaningful
+(see [isWhitespaceText](isWhitespaceText.md)). As a result `hasChildren(node)` is **not**
+always equal to `getChildren(node).length > 0`: they differ for
+whitespace-only children that have no newline, such as `<div> </div>` or
+`<div>\t\t</div>`. Choose the API that matches your rule's intent.
+
 ## Parameters
 
 | Parameter | Type | Description |

--- a/packages/jsx/docs/functions/isEmptyStringExpression.md
+++ b/packages/jsx/docs/functions/isEmptyStringExpression.md
@@ -1,0 +1,37 @@
+[@eslint-react/jsx](../README.md) / isEmptyStringExpression
+
+# Function: isEmptyStringExpression()
+
+```ts
+function isEmptyStringExpression(node: JSXChild): boolean;
+```
+
+Check whether a JSX child node is an **empty string expression** (`{""}`).
+
+React's reconciler and SSR renderer explicitly skip empty strings,
+producing no DOM node (see `ReactChildFiber.js` and `ReactFizzConfigDOM.js`).
+Such expressions are therefore treated as non-rendered children, in the same
+way as whitespace padding.
+
+## Parameters
+
+| Parameter | Type | Description |
+| ------ | ------ | ------ |
+| `node` | `JSXChild` | A JSX child node. |
+
+## Returns
+
+`boolean`
+
+`true` when the node is a `{""}` expression container.
+
+## Example
+
+```ts
+import { isEmptyStringExpression } from "@eslint-react/jsx";
+
+// <div>{""}</div> -> the expression container is an empty string expression
+const meaningful = element.children.filter(
+  (child) => !isEmptyStringExpression(child),
+);
+```

--- a/packages/jsx/src/get-children.ts
+++ b/packages/jsx/src/get-children.ts
@@ -1,5 +1,6 @@
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
+import type { TSESTree } from "@typescript-eslint/types";
+import { isEmptyStringExpression, isWhitespace } from "./is-whitespace";
 
 /**
  * Get the **meaningful** children of a JSX element or fragment.
@@ -7,15 +8,21 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  * Filters out nodes that React will not render into the DOM:
  *
  * 1. "Padding spaces" — `JSXText` nodes that consist entirely of whitespace
- *    and contain at least one newline. These are code-formatting artefacts
- *    (indentation between tags). While React's client renderer preserves them
- *    as text nodes, browser HTML parsers may discard them during hydration,
- *    causing hydration mismatches.
+ *    and contain at least one newline (see {@link isWhitespace}). These are
+ *    code-formatting artefacts (indentation between tags). While React's client
+ *    renderer preserves them as text nodes, browser HTML parsers may discard
+ *    them during hydration, causing hydration mismatches.
  *
  * 2. Empty string expressions — `JSXExpressionContainer` nodes whose expression
- *    is a string literal with value `""`. React's reconciler and SSR renderer
- *    explicitly skip empty strings, producing no DOM node
- *    (see ReactChildFiber.js and ReactFizzConfigDOM.js).
+ *    is a string literal with value `""` (see {@link isEmptyStringExpression}).
+ *    React's reconciler and SSR renderer explicitly skip empty strings,
+ *    producing no DOM node.
+ *
+ * Whitespace-only text **without** a newline (e.g. the single space in
+ * `<div> </div>`) is intentionally **kept**, because React renders it. For
+ * this reason `getChildren(node).length > 0` is **not** equivalent to
+ * {@link hasChildren}, which applies a stricter "any whitespace-only text is
+ * non-meaningful" heuristic. Pick the one that matches your rule's intent.
  *
  * @param element - A `JSXElement` or `JSXFragment` node.
  * @returns An array of children nodes that contribute to rendered output.
@@ -35,44 +42,11 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  * ```
  */
 export function getChildren(element: TSESTreeJSXElementLike): TSESTree.JSXChild[] {
-  return element.children.filter((child: TSESTree.JSXChild) => {
-    if (isPaddingSpaces(child)) return false;
+  return element.children.filter((child) => {
+    // Padding whitespace (whitespace containing a newline) that React trims away.
+    if (isWhitespace(child)) return false;
+    // `{""}` produces no DOM node.
     if (isEmptyStringExpression(child)) return false;
     return true;
   });
-}
-
-/**
- * A `JSXText` node is considered **padding spaces** when it is purely
- * whitespace *and* contains at least one newline character.
- *
- * These nodes are code-formatting artefacts (indentation between JSX tags).
- * While React's client renderer preserves them as text nodes, browser HTML
- * parsers may discard them during hydration, leading to hydration mismatches.
- *
- * @param node The JSX child node to check.
- * @internal
- */
-function isPaddingSpaces(node: TSESTree.JSXChild): boolean {
-  if (node.type !== AST.JSXText) return false;
-  return node.raw.trim() === "" && node.raw.includes("\n");
-}
-
-/**
- * A `JSXExpressionContainer` node is considered an empty string expression
- * when it wraps a string literal with value `""`.
- *
- * React's reconciler explicitly ignores empty strings
- * (`typeof newChild === 'string' && newChild !== ''` in ReactChildFiber.js),
- * and the SSR renderer skips them as well (`if (text === '') { return; }`
- * in ReactFizzConfigDOM.js). They produce no DOM node.
- *
- * @param node The JSX child node to check.
- * @internal
- */
-function isEmptyStringExpression(node: TSESTree.JSXChild): boolean {
-  if (node.type !== AST.JSXExpressionContainer) return false;
-  const expr = node.expression;
-  if (expr.type !== AST.Literal) return false;
-  return expr.value === "";
 }

--- a/packages/jsx/src/has-children.ts
+++ b/packages/jsx/src/has-children.ts
@@ -1,5 +1,5 @@
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
+import { isEmptyStringExpression, isWhitespaceText } from "./is-whitespace";
 
 /**
  * Check whether a JSX element (or fragment) has **meaningful** children —
@@ -14,6 +14,13 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  * An empty string expression (`children={""}`) is also considered
  * non-meaningful because React's reconciler and SSR renderer explicitly skip
  * empty strings, producing no DOM node.
+ *
+ * Unlike {@link getChildren} — which only filters whitespace that contains a
+ * newline — this check treats **any** whitespace-only text as non-meaningful
+ * (see {@link isWhitespaceText}). As a result `hasChildren(node)` is **not**
+ * always equal to `getChildren(node).length > 0`: they differ for
+ * whitespace-only children that have no newline, such as `<div> </div>` or
+ * `<div>\t\t</div>`. Choose the API that matches your rule's intent.
  *
  * @param element - A `JSXElement` or `JSXFragment` node.
  * @returns `true` when the element has at least one meaningful child.
@@ -37,39 +44,5 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  */
 export function hasChildren(element: TSESTreeJSXElementLike): boolean {
   if (element.children.length === 0) return false;
-  return !element.children.every((child: TSESTree.JSXChild) =>
-    isWhitespaceText(child) || isEmptyStringExpression(child)
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Whether a JSX child node is a whitespace-only `JSXText` node.
- *
- * Any `JSXText` whose raw content consists entirely of whitespace characters
- * (spaces, tabs, newlines, etc.) is considered whitespace text.  Non-text
- * nodes always return `false`.
- * @param node The JSX child node to check.
- */
-function isWhitespaceText(node: TSESTree.JSXChild): boolean {
-  if (node.type !== AST.JSXText) return false;
-  return node.raw.trim() === "";
-}
-
-/**
- * Whether a JSX child node is an empty string expression (`{""}`).
- *
- * React's reconciler and SSR renderer skip empty strings, producing no DOM
- * node. These expressions are therefore considered non-meaningful children.
- *
- * @param node The JSX child node to check.
- */
-function isEmptyStringExpression(node: TSESTree.JSXChild): boolean {
-  if (node.type !== AST.JSXExpressionContainer) return false;
-  const expr = node.expression;
-  if (expr.type !== AST.Literal) return false;
-  return expr.value === "";
+  return !element.children.every((child) => isWhitespaceText(child) || isEmptyStringExpression(child));
 }

--- a/packages/jsx/src/is-whitespace.ts
+++ b/packages/jsx/src/is-whitespace.ts
@@ -49,3 +49,31 @@ export function isWhitespaceText(node: TSESTree.JSXChild): boolean {
   if (node.type !== AST.JSXText) return false;
   return node.raw.trim() === "";
 }
+
+/**
+ * Check whether a JSX child node is an **empty string expression** (`{""}`).
+ *
+ * React's reconciler and SSR renderer explicitly skip empty strings,
+ * producing no DOM node (see `ReactChildFiber.js` and `ReactFizzConfigDOM.js`).
+ * Such expressions are therefore treated as non-rendered children, in the same
+ * way as whitespace padding.
+ *
+ * @param node - A JSX child node.
+ * @returns `true` when the node is a `{""}` expression container.
+ *
+ * @example
+ * ```ts
+ * import { isEmptyStringExpression } from "@eslint-react/jsx";
+ *
+ * // <div>{""}</div> -> the expression container is an empty string expression
+ * const meaningful = element.children.filter(
+ *   (child) => !isEmptyStringExpression(child),
+ * );
+ * ```
+ */
+export function isEmptyStringExpression(node: TSESTree.JSXChild): boolean {
+  if (node.type !== AST.JSXExpressionContainer) return false;
+  const expr = node.expression;
+  if (expr.type !== AST.Literal) return false;
+  return expr.value === "";
+}


### PR DESCRIPTION
Move the empty-string-expression check into is-whitespace.ts and reuse the exported isWhitespace/isWhitespaceText/isEmptyStringExpression helpers from get-children and has-children, removing the duplicated private implementations.

Document that hasChildren intentionally differs from getChildren().length > 0 for whitespace-only children without a newline (e.g. `<div> </div>`), so rule authors pick the right API deliberately. Regenerate typedoc output. No behavior change.

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
