### PR TITLE
docs: align presets details for `no-unused-class-component-members` closes #1821

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.mdx
@@ -17,6 +17,10 @@ react-x/no-unused-class-component-members
 
 **Presets**
 
+`x`
+`recommended`
+`recommended-typescript`
+`recommended-type-checked`
 `strict`
 `strict-typescript`
 `strict-type-checked`


### PR DESCRIPTION
Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Closes https://github.com/Rel1cx/eslint-react/issues/1821 by fixing the presets mentioned for `no-unused-class-component-members` on its rules detail page.