### PR TITLE
docs: fix missing presets in rule documentation

### DIFF
--- a/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.mdx
@@ -15,12 +15,6 @@ react-dom/no-string-style-prop
 @eslint-react/dom-no-string-style-prop
 ```
 
-**Presets**
-
-`dom`
-`recommended`
-`strict`
-
 ## Rule Details
 
 Using a string value for the `style` prop is not valid in React. The style prop must be an object with camelCased CSS properties. This rule helps catch incorrect string usage that would cause runtime errors.

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.mdx
@@ -17,6 +17,10 @@ react-dom/no-unsafe-iframe-sandbox
 
 **Presets**
 
+`dom`
+`recommended`
+`recommended-typescript`
+`recommended-type-checked`
 `strict`
 `strict-typescript`
 `strict-type-checked`

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.mdx
@@ -17,6 +17,7 @@ react-naming-convention/context-name
 
 **Presets**
 
+`naming-convention`
 `recommended`
 `recommended-typescript`
 `recommended-type-checked`

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.mdx
@@ -17,6 +17,7 @@ react-naming-convention/id-name
 
 **Presets**
 
+`naming-convention`
 `recommended`
 `recommended-typescript`
 `recommended-type-checked`

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.mdx
@@ -17,6 +17,7 @@ react-naming-convention/ref-name
 
 **Presets**
 
+`naming-convention`
 `recommended`
 `recommended-typescript`
 `recommended-type-checked`

--- a/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/no-unnecessary-use-prefix.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/no-unnecessary-use-prefix.mdx
@@ -17,6 +17,7 @@ react-x/no-unnecessary-use-prefix
 
 **Presets**
 
+`x`
 `recommended`
 `recommended-typescript`
 `recommended-type-checked`


### PR DESCRIPTION
Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR'\''s title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Fixes mismatched presets found by `pnpm run verify:docs` for 6 rules.

This PR is a follow up of https://github.com/Rel1cx/eslint-react/pull/1822 and https://github.com/Rel1cx/eslint-react/pull/1825.