### PR TITLE
chore: update default React fallback version to 19.2.7

### DIFF
--- a/apps/website/content/docs/configuration/configure-analyzer.mdx
+++ b/apps/website/content/docs/configuration/configure-analyzer.mdx
@@ -15,7 +15,7 @@ export default [
     files: ["**/*.ts", "**/*.tsx"],
     settings: {
       "react-x": {
-        version: "19.2.4", // React version for analysis
+        version: "19.2.7", // React version for analysis
         // ...other properties
       },
     },
@@ -33,7 +33,7 @@ export default [
 
 Defines the React version for semantic analysis.
 
-- `detect`: Auto-detects from project dependencies (defaults to `19.2.4` if undetectable)
+- `detect`: Auto-detects from project dependencies (defaults to `19.2.7` if undetectable)
 - `string`: Explicit version specification (ex: `"18.3.1"`)
 
 ### `importSource`
@@ -99,7 +99,7 @@ export default [
     files: ["**/*.ts", "**/*.tsx"],
     settings: {
       "react-x": {
-        version: "19.2.4", // Specify the React version for semantic analysis (can be "detect" for auto-detection)
+        version: "19.2.7", // Specify the React version for semantic analysis (can be "detect" for auto-detection)
         importSource: "react", // Customize the import source for the React module (defaults to "react")
       },
     },
@@ -117,7 +117,7 @@ export default [
     files: ["**/*.ts", "**/*.tsx"],
     settings: {
       "react-x": {
-        version: "19.2.4",
+        version: "19.2.7",
         importSource: "react",
         polymorphicPropName: "as", // Define the prop name used for polymorphic components (ex: <Component as="div">)
         additionalStateHooks: "/^(useMyState|useCustomState)$/u", // Regex pattern for custom hooks treated as state hooks
@@ -154,7 +154,7 @@ export default [
     files: ["**/*.ts", "**/*.tsx"],
     settings: {
       "react-x": {
-        version: "19.2.4",
+        version: "19.2.7",
         importSource: "react",
         compilationMode, // Use the same compilationMode as the React Compiler config for consistent analysis
         polymorphicPropName: "as",

--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -419,7 +419,7 @@ Exposes the normalized `react-x` settings from the ESLint shared configuration (
 
 | Property                | Type                                                    | Default     | Description                                               |
 | ----------------------- | ------------------------------------------------------- | ----------- | --------------------------------------------------------- |
-| `version`               | `string`                                                | auto-detect | Resolved React version (e.g. `"19.2.4"`).                 |
+| `version`               | `string`                                                | auto-detect | Resolved React version (e.g. `"19.2.7"`).                 |
 | `importSource`          | `string`                                                | `"react"`   | The module React is imported from (e.g. `"@pika/react"`). |
 | `compilationMode`       | `"infer" \| "annotation" \| "syntax" \| "all" \| "off"` | `"off"`     | The React Compiler compilation mode the project uses.     |
 | `polymorphicPropName`   | `string \| null`                                        | `"as"`      | Prop name used for polymorphic components.                |

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -123,7 +123,7 @@ export const normalizeSettings = ({
     compilationMode: compilationMode ?? "off",
     polymorphicPropName,
     version: match(version)
-      .with(P.union(P.nullish, "", "detect"), () => getReactVersion("19.2.4"))
+      .with(P.union(P.nullish, "", "detect"), () => getReactVersion("19.2.7"))
       .otherwise(identity),
     additionalStateHooks: toRegExp(additionalStateHooks),
     additionalEffectHooks: toRegExp(additionalEffectHooks),


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [x] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Updates the default React fallback version from `19.2.4` to `19.2.7` to match the project's current dependency version.
