### PR TITLE
docs: update Meta legal name and add brand assets page

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ export default defineConfig(
 
 ## Disclaimer
 
-This project is not affiliated with Meta Corporation or the [facebook/react](https://github.com/facebook/react) project or team, nor is it endorsed or sponsored by them.
+This project is not affiliated with Meta Platforms, Inc. or the [facebook/react](https://github.com/facebook/react) project or team, nor is it endorsed or sponsored by them.
 
 This project is, and will remain, [90% of its code written by humans](https://eslint-react.xyz/docs/faq#what-does-90-human-written-mean).
 

--- a/apps/website/CHANGELOG.md
+++ b/apps/website/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the `apps/website` documentation and its content.
 - Updated `kit.mdx` callout example and AST explanation.
 - Added missing inline table of contents to `contributing.mdx`.
 - Updated default React fallback version references to `19.2.7` across analyzer and kit docs (#1827).
+- Corrected Meta's legal company name to `Meta Platforms, Inc.` across disclaimers and added a new **Brand Assets** documentation page (#1832).
 
 ### 🏗️ Internal
 

--- a/apps/website/app/(home)/page.tsx
+++ b/apps/website/app/(home)/page.tsx
@@ -52,7 +52,7 @@ export default function HomePage() {
       </article>
       <footer className="text-sm text-center md:text-base text-gray-500 mt-12 mb-6">
         <small>
-          ESLint React is not affiliated with Meta Corporation or the{" "}
+          ESLint React is not affiliated with Meta Platforms, Inc. or the{" "}
           <Link
             aria-label="Visit the official facebook/react GitHub repository"
             className="underline"

--- a/apps/website/content/docs/brand-assets.mdx
+++ b/apps/website/content/docs/brand-assets.mdx
@@ -1,0 +1,26 @@
+---
+title: Brand Assets
+description: ESLint React brand assets are available under the MIT License.
+---
+
+## Logo
+
+The ESLint React logo is a 6-fold symmetry motif composed of a hexagon and an atomic orbital symbol.
+
+| Format | Size        | Download                                                                     |
+| ------ | ----------- | ---------------------------------------------------------------------------- |
+| PNG    | 1024 × 1024 | [logo.png](https://github.com/Rel1cx/eslint-react/blob/main/assets/logo.png) |
+| SVG    | Scalable    | [logo.svg](https://github.com/Rel1cx/eslint-react/blob/main/assets/logo.svg) |
+
+## License
+
+All brand assets are released under the [MIT License](https://github.com/Rel1cx/eslint-react/blob/main/LICENSE).
+
+## Trademark Notice
+
+The ESLint React name and logo reference the ESLint and React ecosystems to describe the project's purpose and compatibility.
+
+- "ESLint" is a trademark of the OpenJS Foundation. For OpenJS Foundation trademarks, see the [Trademark Policy](https://trademark-policy.openjsf.org/) and [Trademark List](https://trademark-list.openjsf.org/).
+- The React-inspired element in the ESLint React logo is used only as an ecosystem reference and does not imply any affiliation with, endorsement by, or sponsorship from Meta Platforms, Inc., the React project or team, the OpenJS Foundation, ESLint, or ESLint contributors.
+
+Other trademarks and logos are trademarks™ or registered® trademarks of their respective holders.

--- a/apps/website/content/docs/meta.json
+++ b/apps/website/content/docs/meta.json
@@ -21,6 +21,7 @@
     "glossary",
     "community",
     "contributing",
+    "brand-assets",
     "third-party-plugins"
   ]
 }

--- a/plugins/eslint-plugin/README.md
+++ b/plugins/eslint-plugin/README.md
@@ -202,7 +202,7 @@ export default defineConfig(
 
 ## Disclaimer
 
-This project is not affiliated with Meta Corporation or the [facebook/react](https://github.com/facebook/react) project or team, nor is it endorsed or sponsored by them.
+This project is not affiliated with Meta Platforms, Inc. or the [facebook/react](https://github.com/facebook/react) project or team, nor is it endorsed or sponsored by them.
 
 This project is, and will remain, [90% of its code written by humans](https://eslint-react.xyz/docs/faq#what-does-90-human-written-mean).
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Docs
- [ ] Bugfix
- [ ] Feature
- [ ] Chore
- [ ] Enhancement

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

This PR corrects Meta's legal company name from "Meta Corporation" to "Meta Platforms, Inc." in all disclaimers (README, plugin README, and website footer) and adds a dedicated brand assets page under the documentation site.
