### PR TITLE
refactor(jsx): rename cleanJSXTextValue to collapseMultilineText

### DIFF
--- a/packages/jsx/docs/README.md
+++ b/packages/jsx/docs/README.md
@@ -19,7 +19,7 @@
 
 | Function | Description |
 | ------ | ------ |
-| [cleanJSXTextValue](functions/cleanJSXTextValue.md) | Clean a `JSXText` node's value following React's whitespace rules. |
+| [collapseMultilineText](functions/collapseMultilineText.md) | Collapse a multiline JSX text string following React's whitespace rules. |
 | [findAttribute](functions/findAttribute.md) | Find a JSX attribute (or spread attribute containing the property) by name on a given element. |
 | [findParentAttribute](functions/findParentAttribute.md) | Walk **up** the AST from `node` to find the nearest ancestor that is a `JSXAttribute` and (optionally) passes a predicate. |
 | [getAttributeName](functions/getAttributeName.md) | Get the stringified name of a `JSXAttribute` node. |

--- a/packages/jsx/docs/functions/collapseMultilineText.md
+++ b/packages/jsx/docs/functions/collapseMultilineText.md
@@ -1,12 +1,12 @@
-[@eslint-react/jsx](../README.md) / cleanJSXTextValue
+[@eslint-react/jsx](../README.md) / collapseMultilineText
 
-# Function: cleanJSXTextValue()
+# Function: collapseMultilineText()
 
 ```ts
-function cleanJSXTextValue(node: JSXText): string | null;
+function collapseMultilineText(text: string): string | null;
 ```
 
-Clean a `JSXText` node's value following React's whitespace rules.
+Collapse a multiline JSX text string following React's whitespace rules.
 
 This mirrors Babel's `cleanJSXElementLiteralChild` algorithm:
 1. Split the raw text into lines.
@@ -19,13 +19,13 @@ This mirrors Babel's `cleanJSXElementLiteralChild` algorithm:
 
 | Parameter | Type | Description |
 | ------ | ------ | ------ |
-| `node` | `JSXText` | The JSXText node to clean. |
+| `text` | `string` | The raw JSX text string to collapse. |
 
 ## Returns
 
 `string` \| `null`
 
-The cleaned string, or `null` if the text contains only whitespace.
+The collapsed string, or `null` if the text contains only whitespace.
 
 ## See
 

--- a/packages/jsx/docs/functions/isWhitespace.md
+++ b/packages/jsx/docs/functions/isWhitespace.md
@@ -11,7 +11,7 @@ trim away during rendering.
 
 A child is considered whitespace padding when it is a `JSXText` node whose
 content is empty after applying React's whitespace normalization
-(see [cleanJSXTextValue](cleanJSXTextValue.md), modelled after Babel's
+(see [collapseMultilineText](collapseMultilineText.md), modelled after Babel's
 `cleanJSXElementLiteralChild`). This is the whitespace that appears between
 JSX tags purely for formatting:
 

--- a/packages/jsx/src/collapse-multiline-text.ts
+++ b/packages/jsx/src/collapse-multiline-text.ts
@@ -1,7 +1,5 @@
-import type { TSESTree } from "@typescript-eslint/types";
-
 /**
- * Clean a `JSXText` node's value following React's whitespace rules.
+ * Collapse a multiline JSX text string following React's whitespace rules.
  *
  * This mirrors Babel's `cleanJSXElementLiteralChild` algorithm:
  * 1. Split the raw text into lines.
@@ -10,13 +8,13 @@ import type { TSESTree } from "@typescript-eslint/types";
  * 4. Collapse tabs into spaces.
  * 5. Append a single space after each non-last non-empty line.
  *
- * @param node - The JSXText node to clean.
- * @returns The cleaned string, or `null` if the text contains only whitespace.
+ * @param text - The raw JSX text string to collapse.
+ * @returns The collapsed string, or `null` if the text contains only whitespace.
  *
  * @see https://github.com/babel/babel/blob/main/packages/babel-types/src/utils/react/cleanJSXElementLiteralChild.ts
  */
-export function cleanJSXTextValue(node: TSESTree.JSXText): string | null {
-  const lines = node.value.split(/\r\n|\n|\r/);
+export function collapseMultilineText(text: string): string | null {
+  const lines = text.split(/\r\n|\n|\r/);
 
   let lastNonEmptyLine = 0;
   for (let i = 0; i < lines.length; i++) {

--- a/packages/jsx/src/get-children.ts
+++ b/packages/jsx/src/get-children.ts
@@ -1,7 +1,7 @@
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
 import type { TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
-import { cleanJSXTextValue } from "./clean-jsx-text";
+import { collapseMultilineText } from "./collapse-multiline-text";
 import { isEmptyStringExpression } from "./is-whitespace";
 
 /**
@@ -37,7 +37,7 @@ export function getChildren(element: TSESTreeJSXElementLike): TSESTree.JSXChild[
   for (const child of element.children) {
     if (child.type === AST.JSXText) {
       // Padding whitespace (whitespace containing a newline) that React trims away.
-      if (cleanJSXTextValue(child) == null && child.value.includes("\n")) continue;
+      if (collapseMultilineText(child.value) == null && child.value.includes("\n")) continue;
       elements.push(child);
       continue;
     }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -1,4 +1,4 @@
-export * from "./clean-jsx-text";
+export * from "./collapse-multiline-text";
 export * from "./find-attribute";
 export * from "./find-parent-attribute";
 export * from "./get-attribute-name";

--- a/packages/jsx/src/is-whitespace.ts
+++ b/packages/jsx/src/is-whitespace.ts
@@ -1,5 +1,5 @@
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
-import { cleanJSXTextValue } from "./clean-jsx-text";
+import { collapseMultilineText } from "./collapse-multiline-text";
 
 /**
  * Check whether a JSX child node is **whitespace padding** that React would
@@ -7,7 +7,7 @@ import { cleanJSXTextValue } from "./clean-jsx-text";
  *
  * A child is considered whitespace padding when it is a `JSXText` node whose
  * content is empty after applying React's whitespace normalization
- * (see {@link cleanJSXTextValue}, modelled after Babel's
+ * (see {@link collapseMultilineText}, modelled after Babel's
  * `cleanJSXElementLiteralChild`). This is the whitespace that appears between
  * JSX tags purely for formatting:
  *
@@ -23,7 +23,7 @@ import { cleanJSXTextValue } from "./clean-jsx-text";
  */
 export function isWhitespace(node: TSESTree.JSXChild): boolean {
   if (node.type !== AST.JSXText) return false;
-  return cleanJSXTextValue(node) == null && node.value.includes("\n");
+  return collapseMultilineText(node.value) == null && node.value.includes("\n");
 }
 
 /**

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.spec.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.spec.ts
@@ -463,7 +463,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
       output: "<main><span /><span /></main>",
     },
-    // Multiline text is collapsed to a single space (cleanJSXTextValue)
+    // Multiline text is collapsed to a single space (collapseMultilineText)
     {
       code: "<div><>hello\nworld</></div>",
       errors: [
@@ -526,7 +526,7 @@ ruleTester.run(RULE_NAME, rule, {
       ],
       output: null,
     },
-    // Whitespace-only text with newline is fully trimmed by cleanJSXTextValue
+    // Whitespace-only text with newline is fully trimmed by collapseMultilineText
     {
       code: tsx`
         <div>

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.ts
@@ -3,7 +3,7 @@ import { Check, type TSESTreeJSXElementLike } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, type RuleFix, type RuleFixer, merge } from "@eslint-react/eslint";
 import {
-  cleanJSXTextValue,
+  collapseMultilineText,
   getChildren,
   hasAnyAttribute,
   isFragmentElement,
@@ -163,7 +163,7 @@ export function create(context: RuleContext<MessageID, Options>, [option]: Optio
       let text = "";
       for (const child of node.children) {
         if (child.type === AST.JSXText) {
-          const cleaned = cleanJSXTextValue(child);
+          const cleaned = collapseMultilineText(child.value);
           if (cleaned != null) text += cleaned;
         } else {
           text += context.sourceCode.getText(child);


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

- Renames `cleanJSXTextValue` to `collapseMultilineText` to better reflect its purpose.
- Changes the function signature from accepting a `TSESTree.JSXText` node to accepting a `string`, making it more reusable and easier to test.
- Updates all internal call sites and documentation accordingly.
- Internal whitespace-collapsing logic remains unchanged.