### PR TITLE
refactor: remove redundant single-argument merge() calls in rules

### DIFF
--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { isFromReact } from "./lib";
@@ -51,7 +51,5 @@ export function create(context: RuleContext<MessageID, []>) {
       node,
     });
   }
-  return merge(
-    { Identifier: visitorFunction, JSXIdentifier: visitorFunction },
-  );
+  return { Identifier: visitorFunction, JSXIdentifier: visitorFunction };
 }

--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { type TSESTree } from "@typescript-eslint/types";
 import { getRefInitNode } from "./lib";
 
@@ -44,7 +44,5 @@ export function create(context: RuleContext<MessageID, []>) {
       });
     }
   }
-  return merge(
-    { Identifier: visitorFunction, JSXIdentifier: visitorFunction },
-  );
+  return { Identifier: visitorFunction, JSXIdentifier: visitorFunction };
 }

--- a/plugins/eslint-plugin-react-debug/src/rules/jsx/jsx.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/jsx/jsx.ts
@@ -2,7 +2,7 @@ import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getElementFullType, isFragmentElement } from "@eslint-react/jsx";
 import { flow } from "@local/eff";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
@@ -69,7 +69,7 @@ export function create(context: RuleContext<MessageID, []>) {
       node,
     } as const);
   }
-  return merge({
+  return {
     "JSXElement, JSXFragment": flow(getReportDescriptor(context), report(context)),
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children/no-dangerously-set-innerhtml-with-children.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children/no-dangerously-set-innerhtml-with-children.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute, hasAttribute, isWhitespace } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-dangerously-set-innerhtml-with-children";
@@ -32,22 +32,20 @@ export function create(context: RuleContext<MessageID, []>) {
     return {};
   }
 
-  return merge(
-    {
-      JSXElement(node) {
-        // Check if the element has the 'dangerouslySetInnerHTML' prop. If not, we can stop
-        if (!hasAttribute(context, node, DSIH)) return;
-        // Check for a 'children' prop or actual child nodes that are not just whitespace
-        const childrenPropOrNode = findAttribute(context, node, "children")
-          ?? node.children.find((child) => !isWhitespace(child));
-        // If no children are found, the rule passes
-        if (childrenPropOrNode == null) return;
-        // If both 'dangerouslySetInnerHTML' and children are present, report an error
-        context.report({
-          messageId: "default",
-          node: childrenPropOrNode,
-        });
-      },
+  return {
+    JSXElement(node) {
+      // Check if the element has the 'dangerouslySetInnerHTML' prop. If not, we can stop
+      if (!hasAttribute(context, node, DSIH)) return;
+      // Check for a 'children' prop or actual child nodes that are not just whitespace
+      const childrenPropOrNode = findAttribute(context, node, "children")
+        ?? node.children.find((child) => !isWhitespace(child));
+      // If no children are found, the rule passes
+      if (childrenPropOrNode == null) return;
+      // If both 'dangerouslySetInnerHTML' and children are present, report an error
+      context.report({
+        messageId: "default",
+        node: childrenPropOrNode,
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml/no-dangerously-set-innerhtml.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml/no-dangerously-set-innerhtml.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-dangerously-set-innerhtml";
@@ -29,19 +29,17 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `dangerouslySetInnerHTML` is not present in the file
   if (!context.sourceCode.text.includes(DSIH)) return {};
-  return merge(
-    {
-      JSXElement(node) {
-        // Check if the element has the 'dangerouslySetInnerHTML' prop
-        const dsihProp = findAttribute(context, node, DSIH);
-        // If the prop is not found, do nothing
-        if (dsihProp == null) return;
-        // If the prop is found, report an error
-        context.report({
-          messageId: "default",
-          node: dsihProp,
-        });
-      },
+  return {
+    JSXElement(node) {
+      // Check if the element has the 'dangerouslySetInnerHTML' prop
+      const dsihProp = findAttribute(context, node, DSIH);
+      // If the prop is not found, do nothing
+      if (dsihProp == null) return;
+      // If the prop is found, report an error
+      context.report({
+        messageId: "default",
+        node: dsihProp,
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-find-dom-node";
@@ -29,25 +29,23 @@ const findDOMNode = "findDOMNode";
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `findDOMNode` is not present in the file
   if (!context.sourceCode.text.includes(findDOMNode)) return {};
-  return merge(
-    {
-      CallExpression(node) {
-        const { callee } = node;
-        switch (callee.type) {
-          // Handles cases like `findDOMNode()`.
-          case AST.Identifier:
-            if (callee.name === findDOMNode) {
-              context.report({ messageId: "default", node });
-            }
-            return;
-          // Handles cases like `ReactDOM.findDOMNode()`.
-          case AST.MemberExpression:
-            if (callee.property.type === AST.Identifier && callee.property.name === findDOMNode) {
-              context.report({ messageId: "default", node });
-            }
-            return;
-        }
-      },
+  return {
+    CallExpression(node) {
+      const { callee } = node;
+      switch (callee.type) {
+        // Handles cases like `findDOMNode()`.
+        case AST.Identifier:
+          if (callee.name === findDOMNode) {
+            context.report({ messageId: "default", node });
+          }
+          return;
+        // Handles cases like `ReactDOM.findDOMNode()`.
+        case AST.MemberExpression:
+          if (callee.property.type === AST.Identifier && callee.property.name === findDOMNode) {
+            context.report({ messageId: "default", node });
+          }
+          return;
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-flush-sync";
@@ -29,25 +29,23 @@ const flushSync = "flushSync";
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `flushSync` is not present in the file
   if (!context.sourceCode.text.includes(flushSync)) return {};
-  return merge(
-    {
-      CallExpression(node) {
-        const { callee } = node;
-        switch (callee.type) {
-          // Handle direct calls like `flushSync()`
-          case AST.Identifier:
-            if (callee.name === flushSync) {
-              context.report({ messageId: "default", node });
-            }
-            return;
-          // Handle member access calls like `ReactDOM.flushSync()`
-          case AST.MemberExpression:
-            if (callee.property.type === AST.Identifier && callee.property.name === flushSync) {
-              context.report({ messageId: "default", node });
-            }
-            return;
-        }
-      },
+  return {
+    CallExpression(node) {
+      const { callee } = node;
+      switch (callee.type) {
+        // Handle direct calls like `flushSync()`
+        case AST.Identifier:
+          if (callee.name === flushSync) {
+            context.report({ messageId: "default", node });
+          }
+          return;
+        // Handle member access calls like `ReactDOM.flushSync()`
+        case AST.MemberExpression:
+          if (callee.property.type === AST.Identifier && callee.property.name === flushSync) {
+            context.report({ messageId: "default", node });
+          }
+          return;
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, type RuleFixer, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -43,57 +43,55 @@ export function create(context: RuleContext<MessageID, []>) {
   const reactDomNames = new Set<string>(); // For `import ReactDOM from 'react-dom'`
   const hydrateNames = new Set<string>(); // For `import { hydrate } from 'react-dom'`
 
-  return merge(
-    {
-      CallExpression(node) {
-        const callee = Extract.unwrap(node.callee);
-        switch (true) {
-          // Case 1: Direct call to `hydrate()`.
-          case callee.type === AST.Identifier
-            && hydrateNames.has(callee.name):
-            context.report({
-              fix: getFix(context, node),
-              messageId: "default",
-              node,
-            });
-            return;
-          // Case 2: Call on a `react-dom` import, like `ReactDOM.hydrate()`
-          case callee.type === AST.MemberExpression
-            && callee.object.type === AST.Identifier
-            && callee.property.type === AST.Identifier
-            && callee.property.name === hydrate
-            && reactDomNames.has(callee.object.name):
-            context.report({
-              fix: getFix(context, node),
-              messageId: "default",
-              node,
-            });
-            return;
-        }
-      },
-      ImportDeclaration(node) {
-        const [baseSource] = node.source.value.split("/");
-        // We only care about imports from 'react-dom'
-        if (baseSource !== "react-dom") return;
-        for (const specifier of node.specifiers) {
-          switch (specifier.type) {
-            // `import { hydrate } from 'react-dom'`
-            case AST.ImportSpecifier:
-              if (specifier.imported.type !== AST.Identifier) continue;
-              if (specifier.imported.name === hydrate) {
-                hydrateNames.add(specifier.local.name);
-              }
-              continue;
-            // `import ReactDOM from 'react-dom'` or `import * as ReactDOM from 'react-dom'`
-            case AST.ImportDefaultSpecifier:
-            case AST.ImportNamespaceSpecifier:
-              reactDomNames.add(specifier.local.name);
-              continue;
-          }
-        }
-      },
+  return {
+    CallExpression(node) {
+      const callee = Extract.unwrap(node.callee);
+      switch (true) {
+        // Case 1: Direct call to `hydrate()`.
+        case callee.type === AST.Identifier
+          && hydrateNames.has(callee.name):
+          context.report({
+            fix: getFix(context, node),
+            messageId: "default",
+            node,
+          });
+          return;
+        // Case 2: Call on a `react-dom` import, like `ReactDOM.hydrate()`
+        case callee.type === AST.MemberExpression
+          && callee.object.type === AST.Identifier
+          && callee.property.type === AST.Identifier
+          && callee.property.name === hydrate
+          && reactDomNames.has(callee.object.name):
+          context.report({
+            fix: getFix(context, node),
+            messageId: "default",
+            node,
+          });
+          return;
+      }
     },
-  );
+    ImportDeclaration(node) {
+      const [baseSource] = node.source.value.split("/");
+      // We only care about imports from 'react-dom'
+      if (baseSource !== "react-dom") return;
+      for (const specifier of node.specifiers) {
+        switch (specifier.type) {
+          // `import { hydrate } from 'react-dom'`
+          case AST.ImportSpecifier:
+            if (specifier.imported.type !== AST.Identifier) continue;
+            if (specifier.imported.name === hydrate) {
+              hydrateNames.add(specifier.local.name);
+            }
+            continue;
+          // `import ReactDOM from 'react-dom'` or `import * as ReactDOM from 'react-dom'`
+          case AST.ImportDefaultSpecifier:
+          case AST.ImportNamespaceSpecifier:
+            reactDomNames.add(specifier.local.name);
+            continue;
+        }
+      }
+    },
+  };
 }
 
 function getFix(context: RuleContext, node: TSESTree.CallExpression) {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { hasAttribute } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-missing-button-type";
@@ -36,33 +36,31 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const resolver = createJsxElementResolver(context);
 
-  return merge(
-    {
-      JSXElement(node) {
-        // Resolve the JSX element to its corresponding DOM element type
-        // If it's not a '<button>', skip it
-        if (resolver.resolve(node).domElementType !== "button") {
-          return;
-        }
+  return {
+    JSXElement(node) {
+      // Resolve the JSX element to its corresponding DOM element type
+      // If it's not a '<button>', skip it
+      if (resolver.resolve(node).domElementType !== "button") {
+        return;
+      }
 
-        // Check if the 'type' attribute already exists on the button element
-        if (hasAttribute(context, node, "type")) {
-          return;
-        }
+      // Check if the 'type' attribute already exists on the button element
+      if (hasAttribute(context, node, "type")) {
+        return;
+      }
 
-        // If the 'type' attribute is missing, report an error
-        context.report({
-          messageId: "missingTypeAttribute",
-          node: node.openingElement,
-          // Provide suggestions to automatically fix the issue
-          suggest: BUTTON_TYPES.map((type) => ({
-            data: { type },
-            // The fix function inserts the 'type' attribute with a suggested value
-            fix: (fixer) => fixer.insertTextAfter(node.openingElement.name, ` type="${type}"`),
-            messageId: "addTypeAttribute",
-          } as const)),
-        });
-      },
+      // If the 'type' attribute is missing, report an error
+      context.report({
+        messageId: "missingTypeAttribute",
+        node: node.openingElement,
+        // Provide suggestions to automatically fix the issue
+        suggest: BUTTON_TYPES.map((type) => ({
+          data: { type },
+          // The fix function inserts the 'type' attribute with a suggested value
+          fix: (fixer) => fixer.insertTextAfter(node.openingElement.name, ` type="${type}"`),
+          messageId: "addTypeAttribute",
+        } as const)),
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute, resolveAttributeValue } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-missing-iframe-sandbox";
@@ -35,58 +35,56 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const resolver = createJsxElementResolver(context);
 
-  return merge(
-    {
-      JSXElement(node) {
-        const { domElementType } = resolver.resolve(node);
-        // If the element is not an iframe, we don't need to do anything
-        if (domElementType !== "iframe") return;
+  return {
+    JSXElement(node) {
+      const { domElementType } = resolver.resolve(node);
+      // If the element is not an iframe, we don't need to do anything
+      if (domElementType !== "iframe") return;
 
-        // Find the 'sandbox' prop on the iframe element.
-        const sandboxProp = findAttribute(context, node, "sandbox");
+      // Find the 'sandbox' prop on the iframe element.
+      const sandboxProp = findAttribute(context, node, "sandbox");
 
-        // If the 'sandbox' prop is missing, report an error
-        if (sandboxProp == null) {
-          context.report({
-            messageId: "missingSandboxAttribute",
-            node: node.openingElement,
-            suggest: [{
-              data: { value: "" },
-              fix(fixer) {
-                // Suggest adding a 'sandbox' attribute
-                return fixer.insertTextAfter(node.openingElement.name, ` sandbox=""`);
-              },
-              messageId: "addSandboxAttribute",
-            }],
-          });
-          return;
-        }
-
-        // Resolve the value of the 'sandbox' attribute
-        const sandboxValue = resolveAttributeValue(context, sandboxProp);
-        // If the value is a static string, the prop is correctly used
-        if (typeof sandboxValue.toStatic() === "string") return;
-        // If the value is a spread attribute that includes a 'sandbox' property, we can assume it's correctly used
-        if (sandboxValue.kind === "spreadProps" && typeof sandboxValue.getProperty("sandbox") === "string") return;
-
-        // If the value is not a static string (ex: a variable), report an error
+      // If the 'sandbox' prop is missing, report an error
+      if (sandboxProp == null) {
         context.report({
           messageId: "missingSandboxAttribute",
-          node: sandboxValue.node ?? sandboxProp,
-          suggest: [
-            {
-              data: { value: "" },
-              fix(fixer) {
-                // Do not try to fix spread attributes
-                if (sandboxValue.kind.startsWith("spread")) return null;
-                // Suggest replacing the prop with a valid one
-                return fixer.replaceText(sandboxProp, `sandbox=""`);
-              },
-              messageId: "addSandboxAttribute",
+          node: node.openingElement,
+          suggest: [{
+            data: { value: "" },
+            fix(fixer) {
+              // Suggest adding a 'sandbox' attribute
+              return fixer.insertTextAfter(node.openingElement.name, ` sandbox=""`);
             },
-          ],
+            messageId: "addSandboxAttribute",
+          }],
         });
-      },
+        return;
+      }
+
+      // Resolve the value of the 'sandbox' attribute
+      const sandboxValue = resolveAttributeValue(context, sandboxProp);
+      // If the value is a static string, the prop is correctly used
+      if (typeof sandboxValue.toStatic() === "string") return;
+      // If the value is a spread attribute that includes a 'sandbox' property, we can assume it's correctly used
+      if (sandboxValue.kind === "spreadProps" && typeof sandboxValue.getProperty("sandbox") === "string") return;
+
+      // If the value is not a static string (ex: a variable), report an error
+      context.report({
+        messageId: "missingSandboxAttribute",
+        node: sandboxValue.node ?? sandboxProp,
+        suggest: [
+          {
+            data: { value: "" },
+            fix(fixer) {
+              // Do not try to fix spread attributes
+              if (sandboxValue.kind.startsWith("spread")) return null;
+              // Suggest replacing the prop with a valid one
+              return fixer.replaceText(sandboxProp, `sandbox=""`);
+            },
+            messageId: "addSandboxAttribute",
+          },
+        ],
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-render-return-value";
@@ -45,59 +45,57 @@ export function create(context: RuleContext<MessageID, []>) {
   const reactDomNames = new Set<string>(["ReactDOM", "ReactDOM"]);
   const renderNames = new Set<string>();
 
-  return merge(
-    {
-      // Checks for calls to 'render' or 'ReactDOM.render' and reports if their return value is used
-      CallExpression(node) {
-        const callee = Extract.unwrap(node.callee);
-        switch (true) {
-          // Handles direct calls to 'render' (ex: from `import { render } from 'react-dom'`)
-          case callee.type === AST.Identifier
-            && renderNames.has(callee.name)
-            // Check if the return value is being used
-            && isReturnValueUsed(node):
-            context.report({
-              messageId: "default",
-              node,
-            });
-            return;
-          // Handles member expression calls like 'ReactDOM.render'
-          case callee.type === AST.MemberExpression
-            && callee.object.type === AST.Identifier
-            && callee.property.type === AST.Identifier
-            && callee.property.name === "render"
-            && reactDomNames.has(callee.object.name)
-            // Check if the return value is being used
-            && isReturnValueUsed(node):
-            context.report({
-              messageId: "default",
-              node,
-            });
-            return;
-        }
-      },
-      // Tracks imports from 'react-dom' to identify 'ReactDOM' and 'render' related identifiers
-      ImportDeclaration(node) {
-        // Check if the import source is 'react-dom' or 'react-dom/client'
-        const [baseSource] = node.source.value.split("/");
-        if (baseSource !== "react-dom") return;
-        for (const specifier of node.specifiers) {
-          switch (specifier.type) {
-            // Handles named imports like `import { render } from 'react-dom'`
-            case AST.ImportSpecifier:
-              if (specifier.imported.type !== AST.Identifier) continue;
-              if (specifier.imported.name === "render") {
-                renderNames.add(specifier.local.name);
-              }
-              continue;
-            // Handles default or namespace imports like `import ReactDOM from 'react-dom'`
-            case AST.ImportDefaultSpecifier:
-            case AST.ImportNamespaceSpecifier:
-              reactDomNames.add(specifier.local.name);
-              continue;
-          }
-        }
-      },
+  return {
+    // Checks for calls to 'render' or 'ReactDOM.render' and reports if their return value is used
+    CallExpression(node) {
+      const callee = Extract.unwrap(node.callee);
+      switch (true) {
+        // Handles direct calls to 'render' (ex: from `import { render } from 'react-dom'`)
+        case callee.type === AST.Identifier
+          && renderNames.has(callee.name)
+          // Check if the return value is being used
+          && isReturnValueUsed(node):
+          context.report({
+            messageId: "default",
+            node,
+          });
+          return;
+        // Handles member expression calls like 'ReactDOM.render'
+        case callee.type === AST.MemberExpression
+          && callee.object.type === AST.Identifier
+          && callee.property.type === AST.Identifier
+          && callee.property.name === "render"
+          && reactDomNames.has(callee.object.name)
+          // Check if the return value is being used
+          && isReturnValueUsed(node):
+          context.report({
+            messageId: "default",
+            node,
+          });
+          return;
+      }
     },
-  );
+    // Tracks imports from 'react-dom' to identify 'ReactDOM' and 'render' related identifiers
+    ImportDeclaration(node) {
+      // Check if the import source is 'react-dom' or 'react-dom/client'
+      const [baseSource] = node.source.value.split("/");
+      if (baseSource !== "react-dom") return;
+      for (const specifier of node.specifiers) {
+        switch (specifier.type) {
+          // Handles named imports like `import { render } from 'react-dom'`
+          case AST.ImportSpecifier:
+            if (specifier.imported.type !== AST.Identifier) continue;
+            if (specifier.imported.name === "render") {
+              renderNames.add(specifier.local.name);
+            }
+            continue;
+          // Handles default or namespace imports like `import ReactDOM from 'react-dom'`
+          case AST.ImportDefaultSpecifier:
+          case AST.ImportNamespaceSpecifier:
+            reactDomNames.add(specifier.local.name);
+            continue;
+        }
+      }
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, type RuleFixer, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -42,58 +42,56 @@ export function create(context: RuleContext<MessageID, []>) {
   // Tracks imported names for the `render` function
   const renderNames = new Set<string>();
 
-  return merge(
-    {
-      // Visitor for call expressions, e.g., render() or ReactDOM.render()
-      CallExpression(node) {
-        const callee = Extract.unwrap(node.callee);
-        switch (true) {
-          // Case 1: Direct call to 'render', e.g., from `import { render } from 'react-dom'`
-          case callee.type === AST.Identifier
-            && renderNames.has(callee.name):
-            context.report({
-              fix: getFix(context, node),
-              messageId: "default",
-              node,
-            });
-            return;
-          // Case 2: Member expression call, e.g., `ReactDOM.render()`
-          case callee.type === AST.MemberExpression
-            && callee.object.type === AST.Identifier
-            && callee.property.type === AST.Identifier
-            && callee.property.name === "render"
-            && reactDomNames.has(callee.object.name):
-            context.report({
-              fix: getFix(context, node),
-              messageId: "default",
-              node,
-            });
-            return;
-        }
-      },
-      ImportDeclaration(node) {
-        const [baseSource] = node.source.value.split("/");
-        // Only consider imports from 'react-dom'
-        if (baseSource !== "react-dom") return;
-        for (const specifier of node.specifiers) {
-          switch (specifier.type) {
-            // Handles: import { render } from 'react-dom'
-            case AST.ImportSpecifier:
-              if (specifier.imported.type !== AST.Identifier) continue;
-              if (specifier.imported.name === "render") {
-                renderNames.add(specifier.local.name);
-              }
-              continue;
-            // Handles: import ReactDOM from 'react-dom' or import * as ReactDOM from 'react-dom'
-            case AST.ImportDefaultSpecifier:
-            case AST.ImportNamespaceSpecifier:
-              reactDomNames.add(specifier.local.name);
-              continue;
-          }
-        }
-      },
+  return {
+    // Visitor for call expressions, e.g., render() or ReactDOM.render()
+    CallExpression(node) {
+      const callee = Extract.unwrap(node.callee);
+      switch (true) {
+        // Case 1: Direct call to 'render', e.g., from `import { render } from 'react-dom'`
+        case callee.type === AST.Identifier
+          && renderNames.has(callee.name):
+          context.report({
+            fix: getFix(context, node),
+            messageId: "default",
+            node,
+          });
+          return;
+        // Case 2: Member expression call, e.g., `ReactDOM.render()`
+        case callee.type === AST.MemberExpression
+          && callee.object.type === AST.Identifier
+          && callee.property.type === AST.Identifier
+          && callee.property.name === "render"
+          && reactDomNames.has(callee.object.name):
+          context.report({
+            fix: getFix(context, node),
+            messageId: "default",
+            node,
+          });
+          return;
+      }
     },
-  );
+    ImportDeclaration(node) {
+      const [baseSource] = node.source.value.split("/");
+      // Only consider imports from 'react-dom'
+      if (baseSource !== "react-dom") return;
+      for (const specifier of node.specifiers) {
+        switch (specifier.type) {
+          // Handles: import { render } from 'react-dom'
+          case AST.ImportSpecifier:
+            if (specifier.imported.type !== AST.Identifier) continue;
+            if (specifier.imported.name === "render") {
+              renderNames.add(specifier.local.name);
+            }
+            continue;
+          // Handles: import ReactDOM from 'react-dom' or import * as ReactDOM from 'react-dom'
+          case AST.ImportDefaultSpecifier:
+          case AST.ImportNamespaceSpecifier:
+            reactDomNames.add(specifier.local.name);
+            continue;
+        }
+      }
+    },
+  };
 }
 
 /**

--- a/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { resolveAttributeValue } from "@eslint-react/jsx";
 import { RE_JAVASCRIPT_PROTOCOL } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
@@ -27,18 +27,16 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      JSXAttribute(node) {
-        if (node.name.type !== AST.JSXIdentifier || node.value == null) return;
-        const value = resolveAttributeValue(context, node).toStatic();
-        if (typeof value === "string" && RE_JAVASCRIPT_PROTOCOL.test(value)) {
-          context.report({
-            messageId: "default",
-            node: node.value,
-          });
-        }
-      },
+  return {
+    JSXAttribute(node) {
+      if (node.name.type !== AST.JSXIdentifier || node.value == null) return;
+      const value = resolveAttributeValue(context, node).toStatic();
+      if (typeof value === "string" && RE_JAVASCRIPT_PROTOCOL.test(value)) {
+        context.report({
+          messageId: "default",
+          node: node.value,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute, isHostElement, resolveAttributeValue } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-string-style-prop";
@@ -25,33 +25,31 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      JSXElement(node) {
-        // This rule only applies to host elements (ex: <div />, <span />), not custom components
-        if (!isHostElement(node)) {
-          return;
-        }
+  return {
+    JSXElement(node) {
+      // This rule only applies to host elements (ex: <div />, <span />), not custom components
+      if (!isHostElement(node)) {
+        return;
+      }
 
-        // Find the 'style' prop on the element
-        const styleProp = findAttribute(context, node, "style");
-        if (styleProp == null) {
-          return;
-        }
+      // Find the 'style' prop on the element
+      const styleProp = findAttribute(context, node, "style");
+      if (styleProp == null) {
+        return;
+      }
 
-        // Resolve the static value of the 'style' prop
-        const styleValue = resolveAttributeValue(context, styleProp);
-        const staticValue = styleValue.toStatic();
+      // Resolve the static value of the 'style' prop
+      const styleValue = resolveAttributeValue(context, styleProp);
+      const staticValue = styleValue.toStatic();
 
-        // If the resolved value is a string, report an error
-        // e.g., <div style="color: red;" />
-        if (typeof staticValue === "string") {
-          context.report({
-            messageId: "default",
-            node: styleValue.node ?? styleProp,
-          });
-        }
-      },
+      // If the resolved value is a string, report an error
+      // e.g., <div style="color: red;" />
+      if (typeof staticValue === "string") {
+        context.report({
+          messageId: "default",
+          node: styleValue.node ?? styleProp,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.ts
@@ -1,6 +1,6 @@
 // Ported from https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unknown-property.js
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import {
   getAttributeTagsMap,
   getStandardName,
@@ -118,107 +118,105 @@ export function create(context: RuleContext<MessageID, Options[]>) {
     return context.options[0]?.requireDataLowercase ?? DEFAULTS.requireDataLowercase;
   }
 
-  return merge(
-    {
-      JSXAttribute(node): void {
-        const ignoreNames: string[] = getIgnoreConfig();
-        const actualName: string = getText(context, node.name);
+  return {
+    JSXAttribute(node): void {
+      const ignoreNames: string[] = getIgnoreConfig();
+      const actualName: string = getText(context, node.name);
 
-        // Skip checking if the attribute name is in the ignore list
-        if (ignoreNames.includes(actualName)) {
-          return;
-        }
+      // Skip checking if the attribute name is in the ignore list
+      if (ignoreNames.includes(actualName)) {
+        return;
+      }
 
-        const name: string = normalizeAttributeCase(actualName);
+      const name: string = normalizeAttributeCase(actualName);
 
-        // Ignore tags like <Foo.bar />
-        if (tagNameHasDot(node)) {
-          return;
-        }
+      // Ignore tags like <Foo.bar />
+      if (tagNameHasDot(node)) {
+        return;
+      }
 
-        // Handle data-* attributes
-        if (isValidDataAttribute(name)) {
-          if (getRequireDataLowercase() && hasUpperCaseCharacter(name)) {
-            context.report({
-              data: {
-                name: actualName,
-                lowerCaseName: actualName.toLowerCase(),
-              },
-              messageId: "dataLowercaseRequired",
-              node,
-            });
-          }
-          return;
-        }
-
-        // Handle ARIA attributes
-        if (isValidAriaAttribute(name)) return;
-
-        const tagName: string | null = getTagName(node);
-
-        // Special case for fbt/fbs nodes
-        if (tagName === "fbt" || tagName === "fbs") return;
-
-        // Only validate HTML/DOM elements, not React components
-        if (!isValidHTMLTagInJSX(node)) return;
-
-        // Check if attribute is allowed only on specific tags
-        const attributeTagsMap = getAttributeTagsMap(context);
-        const allowedTags = has(attributeTagsMap, name)
-          ? attributeTagsMap[name]
-          : null;
-
-        if (tagName != null && allowedTags != null) {
-          // Report if attribute is used on a tag where it's not allowed
-          if (!allowedTags.includes(tagName)) {
-            context.report({
-              data: {
-                name: actualName,
-                allowedTags: allowedTags.join(", "),
-                tagName,
-              },
-              messageId: "invalidPropOnTag",
-              node,
-            });
-          }
-          return;
-        }
-
-        // Check if the attribute name is similar to a standard property name
-        const standardName: string | null = getStandardName(name, context);
-
-        const hasStandardNameButIsNotUsed = standardName != null && standardName !== name;
-        const usesStandardName = standardName != null && standardName === name;
-        if (usesStandardName) {
-          // Attribute name is correct, nothing to do
-          return;
-        }
-
-        if (hasStandardNameButIsNotUsed) {
-          // Suggest the correct standard name
+      // Handle data-* attributes
+      if (isValidDataAttribute(name)) {
+        if (getRequireDataLowercase() && hasUpperCaseCharacter(name)) {
           context.report({
             data: {
               name: actualName,
-              standardName,
+              lowerCaseName: actualName.toLowerCase(),
             },
-            fix(fixer) {
-              return fixer.replaceText(node.name, standardName);
-            },
-            messageId: "unknownPropWithStandardName",
+            messageId: "dataLowercaseRequired",
             node,
           });
-          return;
         }
+        return;
+      }
 
-        // Report unknown attribute
+      // Handle ARIA attributes
+      if (isValidAriaAttribute(name)) return;
+
+      const tagName: string | null = getTagName(node);
+
+      // Special case for fbt/fbs nodes
+      if (tagName === "fbt" || tagName === "fbs") return;
+
+      // Only validate HTML/DOM elements, not React components
+      if (!isValidHTMLTagInJSX(node)) return;
+
+      // Check if attribute is allowed only on specific tags
+      const attributeTagsMap = getAttributeTagsMap(context);
+      const allowedTags = has(attributeTagsMap, name)
+        ? attributeTagsMap[name]
+        : null;
+
+      if (tagName != null && allowedTags != null) {
+        // Report if attribute is used on a tag where it's not allowed
+        if (!allowedTags.includes(tagName)) {
+          context.report({
+            data: {
+              name: actualName,
+              allowedTags: allowedTags.join(", "),
+              tagName,
+            },
+            messageId: "invalidPropOnTag",
+            node,
+          });
+        }
+        return;
+      }
+
+      // Check if the attribute name is similar to a standard property name
+      const standardName: string | null = getStandardName(name, context);
+
+      const hasStandardNameButIsNotUsed = standardName != null && standardName !== name;
+      const usesStandardName = standardName != null && standardName === name;
+      if (usesStandardName) {
+        // Attribute name is correct, nothing to do
+        return;
+      }
+
+      if (hasStandardNameButIsNotUsed) {
+        // Suggest the correct standard name
         context.report({
           data: {
             name: actualName,
+            standardName,
           },
-          messageId: "unknownProp",
+          fix(fixer) {
+            return fixer.replaceText(node.name, standardName);
+          },
+          messageId: "unknownPropWithStandardName",
           node,
         });
-      },
+        return;
+      }
+
+      // Report unknown attribute
+      context.report({
+        data: {
+          name: actualName,
+        },
+        messageId: "unknownProp",
+        node,
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute, resolveAttributeValue } from "@eslint-react/jsx";
 import { isUnsafeSandboxCombination } from "./lib";
 
@@ -29,35 +29,33 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const resolver = createJsxElementResolver(context);
 
-  return merge(
-    {
-      JSXElement(node) {
-        // 1. Resolve the JSX element to see if it's a DOM 'iframe'. If not, we don't need to check it
-        if (resolver.resolve(node).domElementType !== "iframe") {
-          return;
-        }
-        // 2. Get the 'sandbox' attribute from the 'iframe' element
-        const sandboxProp = findAttribute(context, node, "sandbox");
-        // If there's no 'sandbox' attribute, there's nothing to check
-        if (sandboxProp == null) {
-          return;
-        }
+  return {
+    JSXElement(node) {
+      // 1. Resolve the JSX element to see if it's a DOM 'iframe'. If not, we don't need to check it
+      if (resolver.resolve(node).domElementType !== "iframe") {
+        return;
+      }
+      // 2. Get the 'sandbox' attribute from the 'iframe' element
+      const sandboxProp = findAttribute(context, node, "sandbox");
+      // If there's no 'sandbox' attribute, there's nothing to check
+      if (sandboxProp == null) {
+        return;
+      }
 
-        // 3. Resolve the static value of the 'sandbox' attribute
-        const sandboxValue = resolveAttributeValue(context, sandboxProp);
-        const sandboxValueString = sandboxValue.kind === "spreadProps"
-          ? sandboxValue.getProperty("sandbox")
-          : sandboxValue.toStatic();
+      // 3. Resolve the static value of the 'sandbox' attribute
+      const sandboxValue = resolveAttributeValue(context, sandboxProp);
+      const sandboxValueString = sandboxValue.kind === "spreadProps"
+        ? sandboxValue.getProperty("sandbox")
+        : sandboxValue.toStatic();
 
-        // 4. Check if the 'sandbox' value has the unsafe combination
-        if (isUnsafeSandboxCombination(sandboxValueString)) {
-          // If it's unsafe, report an error
-          context.report({
-            messageId: "default",
-            node: sandboxValue.node ?? sandboxProp,
-          });
-        }
-      },
+      // 4. Check if the 'sandbox' value has the unsafe combination
+      if (isUnsafeSandboxCombination(sandboxValueString)) {
+        // If it's unsafe, report an error
+        context.report({
+          messageId: "default",
+          node: sandboxValue.node ?? sandboxProp,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank/no-unsafe-target-blank.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank/no-unsafe-target-blank.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute, getAttributeStaticValue } from "@eslint-react/jsx";
 import type { TSESTree } from "@typescript-eslint/types";
 import { isExternalLinkLike, isSafeRel } from "./lib";
@@ -37,58 +37,56 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const resolver = createJsxElementResolver(context);
 
-  return merge(
-    {
-      JSXElement(node: TSESTree.JSXElement) {
-        // Only process anchor tags (<a>)
-        const { domElementType } = resolver.resolve(node);
-        if (domElementType !== "a") return;
+  return {
+    JSXElement(node: TSESTree.JSXElement) {
+      // Only process anchor tags (<a>)
+      const { domElementType } = resolver.resolve(node);
+      if (domElementType !== "a") return;
 
-        // Check if target="_blank" is present
-        const targetValueString = getAttributeStaticValue(context, node, "target");
-        if (targetValueString !== "_blank") return;
+      // Check if target="_blank" is present
+      const targetValueString = getAttributeStaticValue(context, node, "target");
+      if (targetValueString !== "_blank") return;
 
-        // Check if href points to an external resource
-        const hrefValueString = getAttributeStaticValue(context, node, "href");
-        if (!isExternalLinkLike(hrefValueString)) return;
+      // Check if href points to an external resource
+      const hrefValueString = getAttributeStaticValue(context, node, "href");
+      if (!isExternalLinkLike(hrefValueString)) return;
 
-        // Check if rel prop exists and is secure
-        const relProp = findAttribute(context, node, "rel");
+      // Check if rel prop exists and is secure
+      const relProp = findAttribute(context, node, "rel");
 
-        // No rel prop case - suggest adding one
-        if (relProp == null) {
-          context.report({
-            messageId: "default",
-            node: node.openingElement,
-            suggest: [{
-              fix(fixer) {
-                return fixer.insertTextAfter(
-                  node.openingElement.name,
-                  ` rel="noreferrer noopener"`,
-                );
-              },
-              messageId: "addRelNoreferrerNoopener",
-            }],
-          });
-          return;
-        }
-
-        // Check if existing rel prop is secure
-        const relValueString = getAttributeStaticValue(context, node, "rel");
-        if (isSafeRel(relValueString)) return;
-
-        // Existing rel prop is not secure - suggest replacing it
+      // No rel prop case - suggest adding one
+      if (relProp == null) {
         context.report({
           messageId: "default",
-          node: relProp,
+          node: node.openingElement,
           suggest: [{
             fix(fixer) {
-              return fixer.replaceText(relProp, `rel="noreferrer noopener"`);
+              return fixer.insertTextAfter(
+                node.openingElement.name,
+                ` rel="noreferrer noopener"`,
+              );
             },
             messageId: "addRelNoreferrerNoopener",
           }],
         });
-      },
+        return;
+      }
+
+      // Check if existing rel prop is secure
+      const relValueString = getAttributeStaticValue(context, node, "rel");
+      if (isSafeRel(relValueString)) return;
+
+      // Existing rel prop is not secure - suggest replacing it
+      context.report({
+        messageId: "default",
+        node: relProp,
+        suggest: [{
+          fix(fixer) {
+            return fixer.replaceText(relProp, `rel="noreferrer noopener"`);
+          },
+          messageId: "addRelNoreferrerNoopener",
+        }],
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, type RuleFixer, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -42,59 +42,57 @@ export function create(context: RuleContext<MessageID, []>) {
   // Keep track of local names for 'useFormState' import
   const useFormStateNames = new Set<string>();
 
-  return merge(
-    {
-      // This visitor function is called for every function call in the code
-      CallExpression(node) {
-        const callee = Extract.unwrap(node.callee);
-        switch (true) {
-          // Case 1: Direct call like `useFormState(...)`
-          case callee.type === AST.Identifier
-            && useFormStateNames.has(callee.name):
-            context.report({
-              fix: getFix(context, node),
-              messageId: "default",
-              node,
-            });
-            return;
-          // Case 2: Member call like `ReactDOM.useFormState(...)`
-          case callee.type === AST.MemberExpression
-            && callee.object.type === AST.Identifier
-            && callee.property.type === AST.Identifier
-            && callee.property.name === "useFormState"
-            && reactDomNames.has(callee.object.name):
-            context.report({
-              fix: getFix(context, node),
-              messageId: "default",
-              node,
-            });
-            return;
-        }
-      },
-      // This visitor function is called for every import declaration
-      ImportDeclaration(node) {
-        const [baseSource] = node.source.value.split("/");
-        // We are only interested in imports from 'react-dom'
-        if (baseSource !== "react-dom") return;
-        for (const specifier of node.specifiers) {
-          switch (specifier.type) {
-            // Handles: import { useFormState } from 'react-dom';
-            case AST.ImportSpecifier:
-              if (specifier.imported.type !== AST.Identifier) continue;
-              if (specifier.imported.name === "useFormState") {
-                useFormStateNames.add(specifier.local.name);
-              }
-              continue;
-            // Handles: import ReactDOM from 'react-dom'; or import * as ReactDOM from 'react-dom';
-            case AST.ImportDefaultSpecifier:
-            case AST.ImportNamespaceSpecifier:
-              reactDomNames.add(specifier.local.name);
-              continue;
-          }
-        }
-      },
+  return {
+    // This visitor function is called for every function call in the code
+    CallExpression(node) {
+      const callee = Extract.unwrap(node.callee);
+      switch (true) {
+        // Case 1: Direct call like `useFormState(...)`
+        case callee.type === AST.Identifier
+          && useFormStateNames.has(callee.name):
+          context.report({
+            fix: getFix(context, node),
+            messageId: "default",
+            node,
+          });
+          return;
+        // Case 2: Member call like `ReactDOM.useFormState(...)`
+        case callee.type === AST.MemberExpression
+          && callee.object.type === AST.Identifier
+          && callee.property.type === AST.Identifier
+          && callee.property.name === "useFormState"
+          && reactDomNames.has(callee.object.name):
+          context.report({
+            fix: getFix(context, node),
+            messageId: "default",
+            node,
+          });
+          return;
+      }
     },
-  );
+    // This visitor function is called for every import declaration
+    ImportDeclaration(node) {
+      const [baseSource] = node.source.value.split("/");
+      // We are only interested in imports from 'react-dom'
+      if (baseSource !== "react-dom") return;
+      for (const specifier of node.specifiers) {
+        switch (specifier.type) {
+          // Handles: import { useFormState } from 'react-dom';
+          case AST.ImportSpecifier:
+            if (specifier.imported.type !== AST.Identifier) continue;
+            if (specifier.imported.name === "useFormState") {
+              useFormStateNames.add(specifier.local.name);
+            }
+            continue;
+          // Handles: import ReactDOM from 'react-dom'; or import * as ReactDOM from 'react-dom';
+          case AST.ImportDefaultSpecifier:
+          case AST.ImportNamespaceSpecifier:
+            reactDomNames.add(specifier.local.name);
+            continue;
+        }
+      }
+    },
+  };
 }
 
 function getFix(context: RuleContext, node: TSESTree.CallExpression) {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children/no-void-elements-with-children.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children/no-void-elements-with-children.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { hasAnyAttribute } from "@eslint-react/jsx";
 import { VOID_ELEMENTS } from "./lib";
 
@@ -29,26 +29,24 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const resolver = createJsxElementResolver(context);
 
-  return merge(
-    {
-      JSXElement(node) {
-        const { domElementType } = resolver.resolve(node);
-        // If the element is not a void element, do nothing
-        if (!VOID_ELEMENTS.has(domElementType)) {
-          return;
-        }
+  return {
+    JSXElement(node) {
+      const { domElementType } = resolver.resolve(node);
+      // If the element is not a void element, do nothing
+      if (!VOID_ELEMENTS.has(domElementType)) {
+        return;
+      }
 
-        // Report an error if the void element has children, a 'children' prop, or 'dangerouslySetInnerHTML'
-        if (node.children.length > 0 || hasAnyAttribute(context, node, ["children", "dangerouslySetInnerHTML"])) {
-          context.report({
-            data: {
-              elementType: domElementType,
-            },
-            messageId: "default",
-            node,
-          });
-        }
-      },
+      // Report an error if the void element has children, a 'children' prop, or 'dangerouslySetInnerHTML'
+      if (node.children.length > 0 || hasAnyAttribute(context, node, ["children", "dangerouslySetInnerHTML"])) {
+        context.report({
+          data: {
+            elementType: domElementType,
+          },
+          messageId: "default",
+          node,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute, hasChildren } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { findChildrenProperty, getChildrenContentRange, getPropRemovalRange } from "./lib";
@@ -38,7 +38,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge({
+  return {
     CallExpression(node) {
       if (!core.isCreateElementCall(context, node)) return;
 
@@ -90,5 +90,5 @@ export function create(context: RuleContext<MessageID, []>) {
         ],
       });
     },
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { findAttribute } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { findChildrenProperty, getChildrenPropText, getPropRemovalRange } from "./lib";
@@ -35,7 +35,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge({
+  return {
     CallExpression(node) {
       if (!core.isCreateElementCall(context, node)) return;
 
@@ -123,5 +123,5 @@ export function create(context: RuleContext<MessageID, []>) {
         ],
       });
     },
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-comment-textnodes/no-comment-textnodes.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-comment-textnodes/no-comment-textnodes.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, isOneOf } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-comment-textnodes";
@@ -48,10 +48,8 @@ export function create(context: RuleContext<MessageID, []>) {
       node,
     });
   };
-  return merge(
-    {
-      JSXText: visitorFunction,
-      Literal: visitorFunction,
-    },
-  );
+  return {
+    JSXText: visitorFunction,
+    Literal: visitorFunction,
+  };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import ts from "typescript";
 
@@ -36,7 +36,7 @@ export function create(context: RuleContext<MessageID, []>) {
     return {};
   }
 
-  return merge({
+  return {
     JSXOpeningElement(node) {
       let firstSpreadPropIndex: null | number = null;
       for (const [index, prop] of node.attributes.entries()) {
@@ -57,5 +57,5 @@ export function create(context: RuleContext<MessageID, []>) {
         }
       }
     },
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-dollar/no-leaked-dollar.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-dollar/no-leaked-dollar.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-leaked-dollar";
@@ -70,5 +70,5 @@ export function create(context: RuleContext<MessageID, []>) {
       });
     }
   };
-  return merge({ JSXElement: visitorFunction, JSXFragment: visitorFunction });
+  return { JSXElement: visitorFunction, JSXFragment: visitorFunction };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-semicolon/no-leaked-semicolon.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-semicolon/no-leaked-semicolon.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-leaked-semicolon";
@@ -57,8 +57,8 @@ export function create(context: RuleContext<MessageID, []>) {
       ],
     });
   };
-  return merge({
+  return {
     JSXText: visitorFunction,
     Literal: visitorFunction,
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-namespace/no-namespace.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-namespace/no-namespace.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getElementFullType } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-namespace";
@@ -25,7 +25,7 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge({
+  return {
     JSXElement(node) {
       const name = getElementFullType(node);
       if (typeof name !== "string" || !name.includes(":")) {
@@ -39,5 +39,5 @@ export function create(context: RuleContext<MessageID, []>) {
         node: node.openingElement.name,
       });
     },
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, type TSESTreeJSXElementLike } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, type RuleFix, type RuleFixer, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleFix, type RuleFixer } from "@eslint-react/eslint";
 import {
   collapseMultilineText,
   getChildren,
@@ -206,7 +206,7 @@ export function create(context: RuleContext<MessageID, Options>, [option]: Optio
     }
   }
 
-  return merge({
+  return {
     JSXElement(node) {
       if (!isFragmentElement(node, jsxConfig.jsxFragmentFactory)) return;
       if (hasAnyAttribute(context, node, ["key", "ref"])) return;
@@ -215,5 +215,5 @@ export function create(context: RuleContext<MessageID, Options>, [option]: Optio
     JSXFragment(node) {
       checkNode(node);
     },
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
@@ -31,23 +31,21 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `createContext` is not present in the file
   if (!context.sourceCode.text.includes("createContext")) return {};
-  return merge(
-    {
-      CallExpression(node) {
-        if (!core.isCreateContextCall(context, node)) return;
-        const [id, name] = match(resolveEnclosingAssignmentTarget(node))
-          // for cases like: const ThemeContext = createContext();
-          .with({ type: AST.Identifier, name: P.string }, (id) => [id, id.name] as const)
-          // for cases like: ctxs.ThemeContext = createContext();
-          .with({ type: AST.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
-          .otherwise(() => [null, null] as const);
-        if (id == null) return;
-        if (core.isFunctionComponentName(name) && name.endsWith("Context")) return;
-        context.report({
-          messageId: "invalidContextName",
-          node: id,
-        });
-      },
+  return {
+    CallExpression(node) {
+      if (!core.isCreateContextCall(context, node)) return;
+      const [id, name] = match(resolveEnclosingAssignmentTarget(node))
+        // for cases like: const ThemeContext = createContext();
+        .with({ type: AST.Identifier, name: P.string }, (id) => [id, id.name] as const)
+        // for cases like: ctxs.ThemeContext = createContext();
+        .with({ type: AST.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
+        .otherwise(() => [null, null] as const);
+      if (id == null) return;
+      if (core.isFunctionComponentName(name) && name.endsWith("Context")) return;
+      context.report({
+        messageId: "invalidContextName",
+        node: id,
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
@@ -29,23 +29,21 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>) {
   if (!context.sourceCode.text.includes("useId")) return {};
-  return merge(
-    {
-      CallExpression(node: TSESTree.CallExpression) {
-        if (!core.isUseIdCall(context, node)) return;
-        const [id, name] = match(resolveEnclosingAssignmentTarget(node))
-          // for cases like: const myId = useId();
-          .with({ type: AST.Identifier, name: P.string }, (id) => [id, id.name] as const)
-          // for cases like: ctxs.myId = useId();
-          .with({ type: AST.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
-          .otherwise(() => [null, null] as const);
-        if (id == null) return;
-        if (name.endsWith("Id") || name === "id") return;
-        context.report({
-          messageId: "invalidIdName",
-          node: id,
-        });
-      },
+  return {
+    CallExpression(node: TSESTree.CallExpression) {
+      if (!core.isUseIdCall(context, node)) return;
+      const [id, name] = match(resolveEnclosingAssignmentTarget(node))
+        // for cases like: const myId = useId();
+        .with({ type: AST.Identifier, name: P.string }, (id) => [id, id.name] as const)
+        // for cases like: ctxs.myId = useId();
+        .with({ type: AST.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
+        .otherwise(() => [null, null] as const);
+      if (id == null) return;
+      if (name.endsWith("Id") || name === "id") return;
+      context.report({
+        messageId: "invalidIdName",
+        node: id,
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
@@ -30,25 +30,23 @@ export default createRule<[], MessageID>({
 
 export function create(context: RuleContext<MessageID, []>) {
   if (!context.sourceCode.text.includes("useRef")) return {};
-  return merge(
-    {
-      CallExpression(node: TSESTree.CallExpression) {
-        if (!core.isUseRefCall(context, node)) return;
-        // https://github.com/Rel1cx/eslint-react/issues/1375
-        if (Extract.unwrap(node.parent).type === AST.MemberExpression) return;
-        const [id, name] = match(resolveEnclosingAssignmentTarget(node))
-          // for cases like: const inputRef = useRef();
-          .with({ type: AST.Identifier, name: P.string }, (id) => [id, id.name] as const)
-          // for cases like: refs.inputRef = useRef();
-          .with({ type: AST.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
-          .otherwise(() => [null, null] as const);
-        if (id == null) return;
-        if (name.endsWith("Ref") || name === "ref") return;
-        context.report({
-          messageId: "invalidRefName",
-          node: id,
-        });
-      },
+  return {
+    CallExpression(node: TSESTree.CallExpression) {
+      if (!core.isUseRefCall(context, node)) return;
+      // https://github.com/Rel1cx/eslint-react/issues/1375
+      if (Extract.unwrap(node.parent).type === AST.MemberExpression) return;
+      const [id, name] = match(resolveEnclosingAssignmentTarget(node))
+        // for cases like: const inputRef = useRef();
+        .with({ type: AST.Identifier, name: P.string }, (id) => [id, id.name] as const)
+        // for cases like: refs.inputRef = useRef();
+        .with({ type: AST.MemberExpression, property: { name: P.string } }, (id) => [id, id.property.name] as const)
+        .otherwise(() => [null, null] as const);
+      if (id == null) return;
+      if (name.endsWith("Ref") || name === "ref") return;
+      context.report({
+        messageId: "invalidRefName",
+        node: id,
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
@@ -1,13 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import {
-  type ReportFixFunction,
-  type RuleContext,
-  type RuleFeature,
-  type RuleFixer,
-  merge,
-} from "@eslint-react/eslint";
+import { type ReportFixFunction, type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
 import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
@@ -205,65 +199,63 @@ export function create(context: RuleContext<MessageID, []>) {
     }
   }
 
-  return merge(
-    {
-      ArrowFunctionExpression(node) {
-        checkFunctionDirectives(node);
-        checkLocalServerFunction(node);
-      },
-      ExportDefaultDeclaration(node) {
-        if (!hasFileLevelUseServerDirective) {
-          return;
-        }
+  return {
+    ArrowFunctionExpression(node) {
+      checkFunctionDirectives(node);
+      checkLocalServerFunction(node);
+    },
+    ExportDefaultDeclaration(node) {
+      if (!hasFileLevelUseServerDirective) {
+        return;
+      }
 
+      const decl = node.declaration;
+      // export default function foo() {}
+      if (reportNonAsyncFunction(decl, "file")) {
+        return;
+      }
+      if (decl.type === AST.Identifier) {
+        findAndCheckExportedFunctionDeclarations(decl);
+      }
+    },
+    // Handle exported declarations like `export const foo = () => {}` or `export class A {}`
+    ExportNamedDeclaration(node) {
+      if (!hasFileLevelUseServerDirective) {
+        return;
+      }
+      // Handle named export
+      if (node.declaration != null) {
         const decl = node.declaration;
-        // export default function foo() {}
+        // export function foo() {}
         if (reportNonAsyncFunction(decl, "file")) {
           return;
         }
-        if (decl.type === AST.Identifier) {
-          findAndCheckExportedFunctionDeclarations(decl);
-        }
-      },
-      // Handle exported declarations like `export const foo = () => {}` or `export class A {}`
-      ExportNamedDeclaration(node) {
-        if (!hasFileLevelUseServerDirective) {
-          return;
-        }
-        // Handle named export
-        if (node.declaration != null) {
-          const decl = node.declaration;
-          // export function foo() {}
-          if (reportNonAsyncFunction(decl, "file")) {
-            return;
-          }
-          // export const foo = () => {}
-          // export const foo = function() {}
-          if (decl.type === AST.VariableDeclaration) {
-            for (const declarator of decl.declarations) {
-              reportNonAsyncFunction(declarator.init, "file");
-            }
-          }
-          return;
-        }
-        // Handle `export { foo }` (local binding)
-        if (node.source == null && node.specifiers.length > 0) {
-          for (const spec of node.specifiers) {
-            findAndCheckExportedFunctionDeclarations(spec.local);
+        // export const foo = () => {}
+        // export const foo = function() {}
+        if (decl.type === AST.VariableDeclaration) {
+          for (const declarator of decl.declarations) {
+            reportNonAsyncFunction(declarator.init, "file");
           }
         }
-      },
-      FunctionDeclaration(node) {
-        checkFunctionDirectives(node);
-        checkLocalServerFunction(node);
-      },
-      FunctionExpression(node) {
-        checkFunctionDirectives(node);
-        checkLocalServerFunction(node);
-      },
-      Program() {
-        checkFileLevelDirectives();
-      },
+        return;
+      }
+      // Handle `export { foo }` (local binding)
+      if (node.source == null && node.specifiers.length > 0) {
+        for (const spec of node.specifiers) {
+          findAndCheckExportedFunctionDeclarations(spec.local);
+        }
+      }
     },
-  );
+    FunctionDeclaration(node) {
+      checkFunctionDirectives(node);
+      checkLocalServerFunction(node);
+    },
+    FunctionExpression(node) {
+      checkFunctionDirectives(node);
+      checkLocalServerFunction(node);
+    },
+    Program() {
+      checkFileLevelDirectives();
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
@@ -7,7 +7,7 @@ import {
 import { createRule } from "@/utils/create-rule";
 import { Check, Compare, Extract, type TSESTreeFunction } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { isValueEqual } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, isMatching, match } from "ts-pattern";
@@ -131,106 +131,104 @@ export function create(context: RuleContext<MessageID, []>) {
       node: listener,
     });
   }
-  return merge(
-    {
-      [":function"](node: TSESTreeFunction) {
-        const kind = getFunctionKind(node);
-        fEntries.push({ kind, node });
-      },
-      [":function:exit"]() {
-        fEntries.pop();
-      },
-      ["CallExpression"](node) {
-        const fKind = fEntries.findLast((x) => x.kind !== "other")?.kind;
-        if (fKind == null) {
-          return;
-        }
-        if (!ComponentPhaseRelevance.has(fKind)) {
-          return;
-        }
-        const unwrappedCallee = Extract.unwrap(node.callee);
-        match(getCallKind(node))
-          .with("addEventListener", (callKind) => {
-            // https://github.com/Rel1cx/eslint-react/issues/1323
-            const isFromReactNative = unwrappedCallee.type === AST.MemberExpression
-              && unwrappedCallee.object.type === AST.Identifier
-              && core.isAPIFromReactNative(unwrappedCallee.object.name, context.sourceCode.getScope(node));
-            if (isFromReactNative) {
-              return;
-            }
-            const [type, listener, options] = node.arguments;
-            if (type == null || listener == null) {
-              return;
-            }
-            const opts = options == null
-              ? defaultOptions
-              : getOptions(context, options);
-            const { callee } = node;
-            checkInlineFunction(node, callKind, opts);
-            aEntries.push({
-              ...opts,
-              type,
-              callee,
-              listener,
-              method: "addEventListener",
-              node,
-              phase: fKind,
-            });
-          })
-          .with("removeEventListener", (callKind) => {
-            const [type, listener, options] = node.arguments;
-            if (type == null || listener == null) {
-              return;
-            }
-            const opts = options == null
-              ? defaultOptions
-              : getOptions(context, options);
-            const { callee } = node;
-            checkInlineFunction(node, callKind, opts);
-            rEntries.push({
-              ...opts,
-              type,
-              callee,
-              listener,
-              method: "removeEventListener",
-              node,
-              phase: fKind,
-            });
-          })
-          .with("abort", () => {
-            abortedSignals.push(node.callee);
-          })
-          .otherwise(() => null);
-      },
-      ["Program:exit"]() {
-        for (const aEntry of aEntries) {
-          const signal = aEntry.signal;
-          // https://github.com/Rel1cx/eslint-react/issues/1282#issuecomment-3536511881
-          // if (signal != null && abortedSignals.some((a) => isSameObject(a, signal))) {
-          //   continue;
-          // }
-          if (signal != null) {
-            continue;
-          }
-          if (rEntries.some((rEntry) => isInverseEntry(aEntry, rEntry))) {
-            continue;
-          }
-          switch (aEntry.phase) {
-            case "setup":
-            case "cleanup":
-              context.report({
-                data: {
-                  effectMethodKind: "useEffect",
-                },
-                messageId: "expectedRemoveEventListenerInCleanup",
-                node: aEntry.node,
-              });
-              continue;
-          }
-        }
-      },
+  return {
+    [":function"](node: TSESTreeFunction) {
+      const kind = getFunctionKind(node);
+      fEntries.push({ kind, node });
     },
-  );
+    [":function:exit"]() {
+      fEntries.pop();
+    },
+    ["CallExpression"](node) {
+      const fKind = fEntries.findLast((x) => x.kind !== "other")?.kind;
+      if (fKind == null) {
+        return;
+      }
+      if (!ComponentPhaseRelevance.has(fKind)) {
+        return;
+      }
+      const unwrappedCallee = Extract.unwrap(node.callee);
+      match(getCallKind(node))
+        .with("addEventListener", (callKind) => {
+          // https://github.com/Rel1cx/eslint-react/issues/1323
+          const isFromReactNative = unwrappedCallee.type === AST.MemberExpression
+            && unwrappedCallee.object.type === AST.Identifier
+            && core.isAPIFromReactNative(unwrappedCallee.object.name, context.sourceCode.getScope(node));
+          if (isFromReactNative) {
+            return;
+          }
+          const [type, listener, options] = node.arguments;
+          if (type == null || listener == null) {
+            return;
+          }
+          const opts = options == null
+            ? defaultOptions
+            : getOptions(context, options);
+          const { callee } = node;
+          checkInlineFunction(node, callKind, opts);
+          aEntries.push({
+            ...opts,
+            type,
+            callee,
+            listener,
+            method: "addEventListener",
+            node,
+            phase: fKind,
+          });
+        })
+        .with("removeEventListener", (callKind) => {
+          const [type, listener, options] = node.arguments;
+          if (type == null || listener == null) {
+            return;
+          }
+          const opts = options == null
+            ? defaultOptions
+            : getOptions(context, options);
+          const { callee } = node;
+          checkInlineFunction(node, callKind, opts);
+          rEntries.push({
+            ...opts,
+            type,
+            callee,
+            listener,
+            method: "removeEventListener",
+            node,
+            phase: fKind,
+          });
+        })
+        .with("abort", () => {
+          abortedSignals.push(node.callee);
+        })
+        .otherwise(() => null);
+    },
+    ["Program:exit"]() {
+      for (const aEntry of aEntries) {
+        const signal = aEntry.signal;
+        // https://github.com/Rel1cx/eslint-react/issues/1282#issuecomment-3536511881
+        // if (signal != null && abortedSignals.some((a) => isSameObject(a, signal))) {
+        //   continue;
+        // }
+        if (signal != null) {
+          continue;
+        }
+        if (rEntries.some((rEntry) => isInverseEntry(aEntry, rEntry))) {
+          continue;
+        }
+        switch (aEntry.phase) {
+          case "setup":
+          case "cleanup":
+            context.report({
+              data: {
+                effectMethodKind: "useEffect",
+              },
+              messageId: "expectedRemoveEventListenerInCleanup",
+              node: aEntry.node,
+            });
+            continue;
+        }
+      }
+    },
+  };
 }
 
 // #endregion

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findProperty, resolveToObjectExpression } from "./lib";
@@ -143,73 +143,71 @@ export function create(context: RuleContext<MessageID, []>) {
   const fEntries: { kind: FunctionKind; node: TSESTreeFunction }[] = [];
   const fetchEntries: FetchEntry[] = [];
   const abortEntries: AbortEntry[] = [];
-  return merge(
-    {
-      [":function"](node: TSESTreeFunction) {
-        const kind = getPhaseKindOfFunction(node) ?? "other";
-        fEntries.push({ kind, node });
-      },
-      [":function:exit"]() {
-        fEntries.pop();
-      },
-      ["CallExpression"](node) {
-        const fEntry = fEntries.at(-1);
-        if (fEntry == null || !ComponentPhaseRelevance.has(fEntry.kind)) {
-          return;
-        }
-        switch (getCallKind(node)) {
-          case "fetch": {
-            if (fEntry.kind !== "setup") return;
-            const { controller, isParamSignal } = getFetchController(context, node);
-            fetchEntries.push({
-              controller,
-              isParamSignal,
-              node,
-              phase: fEntry.kind,
-            });
-            break;
-          }
-          case "abort": {
-            if (fEntry.kind !== "cleanup") return;
-            const controller = getAbortController(node);
-            if (controller == null) break;
-            abortEntries.push({
-              controller,
-              node,
-              phase: fEntry.kind,
-            });
-            break;
-          }
-        }
-      },
-      ["Program:exit"]() {
-        for (const fEntry of fetchEntries) {
-          const controller = fEntry.controller;
-          if (controller == null) {
-            context.report({
-              messageId: "expectedAbortController",
-              node: fEntry.node,
-            });
-            continue;
-          }
-          // If the signal comes from a function parameter (e.g. use-abortable-effect),
-          // assume the caller manages the abort lifecycle.
-          if (fEntry.isParamSignal) {
-            continue;
-          }
-          const hasMatchingAbort = abortEntries.some((aEntry) =>
-            isAssignmentTargetEqual(context, aEntry.controller, controller)
-          );
-          if (!hasMatchingAbort) {
-            context.report({
-              messageId: "expectedAbortInCleanup",
-              node: fEntry.node,
-            });
-          }
-        }
-      },
+  return {
+    [":function"](node: TSESTreeFunction) {
+      const kind = getPhaseKindOfFunction(node) ?? "other";
+      fEntries.push({ kind, node });
     },
-  );
+    [":function:exit"]() {
+      fEntries.pop();
+    },
+    ["CallExpression"](node) {
+      const fEntry = fEntries.at(-1);
+      if (fEntry == null || !ComponentPhaseRelevance.has(fEntry.kind)) {
+        return;
+      }
+      switch (getCallKind(node)) {
+        case "fetch": {
+          if (fEntry.kind !== "setup") return;
+          const { controller, isParamSignal } = getFetchController(context, node);
+          fetchEntries.push({
+            controller,
+            isParamSignal,
+            node,
+            phase: fEntry.kind,
+          });
+          break;
+        }
+        case "abort": {
+          if (fEntry.kind !== "cleanup") return;
+          const controller = getAbortController(node);
+          if (controller == null) break;
+          abortEntries.push({
+            controller,
+            node,
+            phase: fEntry.kind,
+          });
+          break;
+        }
+      }
+    },
+    ["Program:exit"]() {
+      for (const fEntry of fetchEntries) {
+        const controller = fEntry.controller;
+        if (controller == null) {
+          context.report({
+            messageId: "expectedAbortController",
+            node: fEntry.node,
+          });
+          continue;
+        }
+        // If the signal comes from a function parameter (e.g. use-abortable-effect),
+        // assume the caller manages the abort lifecycle.
+        if (fEntry.isParamSignal) {
+          continue;
+        }
+        const hasMatchingAbort = abortEntries.some((aEntry) =>
+          isAssignmentTargetEqual(context, aEntry.controller, controller)
+        );
+        if (!hasMatchingAbort) {
+          context.report({
+            messageId: "expectedAbortInCleanup",
+            node: fEntry.node,
+          });
+        }
+      }
+    },
+  };
 }
 
 // #endregion

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, type TimerEntry, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeFunction } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, isMatching } from "ts-pattern";
@@ -79,86 +79,84 @@ export function create(context: RuleContext<MessageID, []>) {
   function isInverseEntry(a: TimerEntry, b: TimerEntry) {
     return isAssignmentTargetEqual(context, a.timerId, b.timerId);
   }
-  return merge(
-    {
-      [":function"](node: TSESTreeFunction) {
-        const kind = getPhaseKindOfFunction(node) ?? "other";
-        fEntries.push({ kind, node });
-      },
-      [":function:exit"]() {
-        fEntries.pop();
-      },
-      ["CallExpression"](node) {
-        switch (getCallKind(node)) {
-          case "setInterval": {
-            const fEntry = fEntries.findLast((x) => x.kind !== "other");
-            if (fEntry == null) {
-              break;
-            }
-            if (!ComponentPhaseRelevance.has(fEntry.kind)) {
-              break;
-            }
-            const intervalIdNode = resolveEnclosingAssignmentTarget(node);
-            if (intervalIdNode == null) {
-              context.report({
-                messageId: "expectedIntervalId",
-                node,
-              });
-              break;
-            }
-            sEntries.push({
-              kind: "interval",
-              callee: node.callee,
-              node,
-              phase: fEntry.kind,
-              timerId: intervalIdNode,
-            });
-            break;
-          }
-          case "clearInterval": {
-            const fEntry = fEntries.findLast((x) => x.kind !== "other");
-            if (fEntry == null) {
-              break;
-            }
-            if (!ComponentPhaseRelevance.has(fEntry.kind)) {
-              break;
-            }
-            const [intervalIdNode] = node.arguments;
-            if (intervalIdNode == null) {
-              break;
-            }
-            cEntries.push({
-              kind: "interval",
-              callee: node.callee,
-              node,
-              phase: fEntry.kind,
-              timerId: intervalIdNode,
-            });
-            break;
-          }
-        }
-      },
-      ["Program:exit"]() {
-        for (const sEntry of sEntries) {
-          if (cEntries.some((cEntry) => isInverseEntry(sEntry, cEntry))) {
-            continue;
-          }
-          switch (sEntry.phase) {
-            case "setup":
-            case "cleanup":
-              context.report({
-                data: {
-                  kind: "useEffect",
-                },
-                messageId: "expectedClearIntervalInCleanup",
-                node: sEntry.node,
-              });
-              continue;
-          }
-        }
-      },
+  return {
+    [":function"](node: TSESTreeFunction) {
+      const kind = getPhaseKindOfFunction(node) ?? "other";
+      fEntries.push({ kind, node });
     },
-  );
+    [":function:exit"]() {
+      fEntries.pop();
+    },
+    ["CallExpression"](node) {
+      switch (getCallKind(node)) {
+        case "setInterval": {
+          const fEntry = fEntries.findLast((x) => x.kind !== "other");
+          if (fEntry == null) {
+            break;
+          }
+          if (!ComponentPhaseRelevance.has(fEntry.kind)) {
+            break;
+          }
+          const intervalIdNode = resolveEnclosingAssignmentTarget(node);
+          if (intervalIdNode == null) {
+            context.report({
+              messageId: "expectedIntervalId",
+              node,
+            });
+            break;
+          }
+          sEntries.push({
+            kind: "interval",
+            callee: node.callee,
+            node,
+            phase: fEntry.kind,
+            timerId: intervalIdNode,
+          });
+          break;
+        }
+        case "clearInterval": {
+          const fEntry = fEntries.findLast((x) => x.kind !== "other");
+          if (fEntry == null) {
+            break;
+          }
+          if (!ComponentPhaseRelevance.has(fEntry.kind)) {
+            break;
+          }
+          const [intervalIdNode] = node.arguments;
+          if (intervalIdNode == null) {
+            break;
+          }
+          cEntries.push({
+            kind: "interval",
+            callee: node.callee,
+            node,
+            phase: fEntry.kind,
+            timerId: intervalIdNode,
+          });
+          break;
+        }
+      }
+    },
+    ["Program:exit"]() {
+      for (const sEntry of sEntries) {
+        if (cEntries.some((cEntry) => isInverseEntry(sEntry, cEntry))) {
+          continue;
+        }
+        switch (sEntry.phase) {
+          case "setup":
+          case "cleanup":
+            context.report({
+              data: {
+                kind: "useEffect",
+              },
+              messageId: "expectedClearIntervalInCleanup",
+              node: sEntry.node,
+            });
+            continue;
+        }
+      }
+    },
+  };
 }
 
 // #endregion

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, type ObserverEntry, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { or } from "@local/eff";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -96,117 +96,115 @@ export function create(context: RuleContext<MessageID, []>) {
   const oEntries: OEntry[] = [];
   const uEntries: UEntry[] = [];
   const dEntries: DEntry[] = [];
-  return merge(
-    {
-      [":function"](node: TSESTreeFunction) {
-        const kind = getFunctionKind(node);
-        fEntries.push({ kind, node });
-      },
-      [":function:exit"]() {
-        fEntries.pop();
-      },
-      ["CallExpression"](node) {
-        const unwrappedCallee = Extract.unwrap(node.callee);
-        if (unwrappedCallee.type !== AST.MemberExpression) {
-          return;
-        }
-        const fKind = fEntries.findLast((x) => x.kind !== "other")?.kind;
-        if (fKind == null || !ComponentPhaseRelevance.has(fKind)) {
-          return;
-        }
-        const { object } = unwrappedCallee;
-        match(getCallKind(context, node))
-          .with("disconnect", () => {
-            dEntries.push({
-              kind: "ResizeObserver",
-              callee: node.callee,
-              method: "disconnect",
-              node,
-              observer: object,
-              phase: fKind,
-            });
-          })
-          .with("observe", () => {
-            const [element] = node.arguments;
-            if (element == null) {
-              return;
-            }
-            oEntries.push({
-              kind: "ResizeObserver",
-              callee: node.callee,
-              element,
-              method: "observe",
-              node,
-              observer: object,
-              phase: fKind,
-            });
-          })
-          .with("unobserve", () => {
-            const [element] = node.arguments;
-            if (element == null) {
-              return;
-            }
-            uEntries.push({
-              kind: "ResizeObserver",
-              callee: node.callee,
-              element,
-              method: "unobserve",
-              node,
-              observer: object,
-              phase: fKind,
-            });
-          })
-          .otherwise(() => null);
-      },
-      ["NewExpression"](node) {
-        const fEntry = fEntries.findLast((x) => x.kind !== "other");
-        if (fEntry == null) return;
-        if (!ComponentPhaseRelevance.has(fEntry.kind)) {
-          return;
-        }
-        if (!isNewResizeObserver(node)) {
-          return;
-        }
-        const id = resolveEnclosingAssignmentTarget(node);
-        if (id == null) {
-          context.report({
-            messageId: "unexpectedFloatingInstance",
-            node,
-          });
-          return;
-        }
-        observers.push({
-          id,
-          node,
-          phase: fEntry.kind,
-          phaseNode: fEntry.node,
-        });
-      },
-      ["Program:exit"]() {
-        for (const { id, node, phaseNode } of observers) {
-          if (dEntries.some((e) => isAssignmentTargetEqual(context, e.observer, id))) {
-            continue;
-          }
-          const oentries = oEntries.filter((e) => isAssignmentTargetEqual(context, e.observer, id));
-          const uentries = uEntries.filter((e) => isAssignmentTargetEqual(context, e.observer, id));
-          const isDynamic = (node: TSESTree.Node | null) => node?.type === AST.CallExpression || isConditional(node);
-          const isPhaseNode = (node: TSESTree.Node | null) => node === phaseNode;
-          const hasDynamicallyAdded = oentries
-            .some((e) => !isPhaseNode(Traverse.findParent(e.node, or(isDynamic, isPhaseNode))));
-          if (hasDynamicallyAdded) {
-            context.report({ messageId: "expectedDisconnectInControlFlow", node });
-            continue;
-          }
-          for (const oEntry of oentries) {
-            if (uentries.some((uEntry) => isAssignmentTargetEqual(context, uEntry.element, oEntry.element))) {
-              continue;
-            }
-            context.report({ messageId: "expectedDisconnectOrUnobserveInCleanup", node: oEntry.node });
-          }
-        }
-      },
+  return {
+    [":function"](node: TSESTreeFunction) {
+      const kind = getFunctionKind(node);
+      fEntries.push({ kind, node });
     },
-  );
+    [":function:exit"]() {
+      fEntries.pop();
+    },
+    ["CallExpression"](node) {
+      const unwrappedCallee = Extract.unwrap(node.callee);
+      if (unwrappedCallee.type !== AST.MemberExpression) {
+        return;
+      }
+      const fKind = fEntries.findLast((x) => x.kind !== "other")?.kind;
+      if (fKind == null || !ComponentPhaseRelevance.has(fKind)) {
+        return;
+      }
+      const { object } = unwrappedCallee;
+      match(getCallKind(context, node))
+        .with("disconnect", () => {
+          dEntries.push({
+            kind: "ResizeObserver",
+            callee: node.callee,
+            method: "disconnect",
+            node,
+            observer: object,
+            phase: fKind,
+          });
+        })
+        .with("observe", () => {
+          const [element] = node.arguments;
+          if (element == null) {
+            return;
+          }
+          oEntries.push({
+            kind: "ResizeObserver",
+            callee: node.callee,
+            element,
+            method: "observe",
+            node,
+            observer: object,
+            phase: fKind,
+          });
+        })
+        .with("unobserve", () => {
+          const [element] = node.arguments;
+          if (element == null) {
+            return;
+          }
+          uEntries.push({
+            kind: "ResizeObserver",
+            callee: node.callee,
+            element,
+            method: "unobserve",
+            node,
+            observer: object,
+            phase: fKind,
+          });
+        })
+        .otherwise(() => null);
+    },
+    ["NewExpression"](node) {
+      const fEntry = fEntries.findLast((x) => x.kind !== "other");
+      if (fEntry == null) return;
+      if (!ComponentPhaseRelevance.has(fEntry.kind)) {
+        return;
+      }
+      if (!isNewResizeObserver(node)) {
+        return;
+      }
+      const id = resolveEnclosingAssignmentTarget(node);
+      if (id == null) {
+        context.report({
+          messageId: "unexpectedFloatingInstance",
+          node,
+        });
+        return;
+      }
+      observers.push({
+        id,
+        node,
+        phase: fEntry.kind,
+        phaseNode: fEntry.node,
+      });
+    },
+    ["Program:exit"]() {
+      for (const { id, node, phaseNode } of observers) {
+        if (dEntries.some((e) => isAssignmentTargetEqual(context, e.observer, id))) {
+          continue;
+        }
+        const oentries = oEntries.filter((e) => isAssignmentTargetEqual(context, e.observer, id));
+        const uentries = uEntries.filter((e) => isAssignmentTargetEqual(context, e.observer, id));
+        const isDynamic = (node: TSESTree.Node | null) => node?.type === AST.CallExpression || isConditional(node);
+        const isPhaseNode = (node: TSESTree.Node | null) => node === phaseNode;
+        const hasDynamicallyAdded = oentries
+          .some((e) => !isPhaseNode(Traverse.findParent(e.node, or(isDynamic, isPhaseNode))));
+        if (hasDynamicallyAdded) {
+          context.report({ messageId: "expectedDisconnectInControlFlow", node });
+          continue;
+        }
+        for (const oEntry of oentries) {
+          if (uentries.some((uEntry) => isAssignmentTargetEqual(context, uEntry.element, oEntry.element))) {
+            continue;
+          }
+          context.report({ messageId: "expectedDisconnectOrUnobserveInCleanup", node: oEntry.node });
+        }
+      }
+    },
+  };
 }
 
 // #endregion

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, type TimerEntry, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeFunction } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, isMatching } from "ts-pattern";
@@ -77,76 +77,74 @@ export function create(context: RuleContext<MessageID, []>) {
   function isInverseEntry(a: TimerEntry, b: TimerEntry) {
     return isAssignmentTargetEqual(context, a.timerId, b.timerId);
   }
-  return merge(
-    {
-      [":function"](node: TSESTreeFunction) {
-        const kind = getPhaseKindOfFunction(node) ?? "other";
-        fEntries.push({ kind, node });
-      },
-      [":function:exit"]() {
-        fEntries.pop();
-      },
-      ["CallExpression"](node) {
-        const fEntry = fEntries.findLast((f) => f.kind !== "other");
-        if (!ComponentPhaseRelevance.has(fEntry?.kind)) {
-          return;
-        }
-        switch (getCallKind(node)) {
-          case "setTimeout": {
-            const timeoutIdNode = resolveEnclosingAssignmentTarget(node);
-            if (timeoutIdNode == null) {
-              context.report({
-                messageId: "expectedTimeoutId",
-                node,
-              });
-              break;
-            }
-            sEntries.push({
-              kind: "timeout",
-              callee: node.callee,
-              node,
-              phase: fEntry.kind,
-              timerId: timeoutIdNode,
-            });
-            break;
-          }
-          case "clearTimeout": {
-            const [timeoutIdNode] = node.arguments;
-            if (timeoutIdNode == null) {
-              break;
-            }
-            rEntries.push({
-              kind: "timeout",
-              callee: node.callee,
-              node,
-              phase: fEntry.kind,
-              timerId: timeoutIdNode,
-            });
-            break;
-          }
-        }
-      },
-      ["Program:exit"]() {
-        for (const sEntry of sEntries) {
-          if (rEntries.some((rEntry) => isInverseEntry(sEntry, rEntry))) {
-            continue;
-          }
-          switch (sEntry.phase) {
-            case "setup":
-            case "cleanup":
-              context.report({
-                data: {
-                  kind: "useEffect",
-                },
-                messageId: "expectedClearTimeoutInCleanup",
-                node: sEntry.node,
-              });
-              continue;
-          }
-        }
-      },
+  return {
+    [":function"](node: TSESTreeFunction) {
+      const kind = getPhaseKindOfFunction(node) ?? "other";
+      fEntries.push({ kind, node });
     },
-  );
+    [":function:exit"]() {
+      fEntries.pop();
+    },
+    ["CallExpression"](node) {
+      const fEntry = fEntries.findLast((f) => f.kind !== "other");
+      if (!ComponentPhaseRelevance.has(fEntry?.kind)) {
+        return;
+      }
+      switch (getCallKind(node)) {
+        case "setTimeout": {
+          const timeoutIdNode = resolveEnclosingAssignmentTarget(node);
+          if (timeoutIdNode == null) {
+            context.report({
+              messageId: "expectedTimeoutId",
+              node,
+            });
+            break;
+          }
+          sEntries.push({
+            kind: "timeout",
+            callee: node.callee,
+            node,
+            phase: fEntry.kind,
+            timerId: timeoutIdNode,
+          });
+          break;
+        }
+        case "clearTimeout": {
+          const [timeoutIdNode] = node.arguments;
+          if (timeoutIdNode == null) {
+            break;
+          }
+          rEntries.push({
+            kind: "timeout",
+            callee: node.callee,
+            node,
+            phase: fEntry.kind,
+            timerId: timeoutIdNode,
+          });
+          break;
+        }
+      }
+    },
+    ["Program:exit"]() {
+      for (const sEntry of sEntries) {
+        if (rEntries.some((rEntry) => isInverseEntry(sEntry, rEntry))) {
+          continue;
+        }
+        switch (sEntry.phase) {
+          case "setup":
+          case "cleanup":
+            context.report({
+              data: {
+                kind: "useEffect",
+              },
+              messageId: "expectedClearTimeoutInCleanup",
+              node: sEntry.node,
+            });
+            continue;
+        }
+      }
+    },
+  };
 }
 
 // #endregion

--- a/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeMethodOrPropertyDefinition } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { constFalse, constTrue } from "@local/eff";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { match } from "ts-pattern";
@@ -55,117 +55,115 @@ export function create(context: RuleContext<MessageID, []>) {
   // Stack to track `setState` call expressions
   const setStateStack: [node: TSESTree.CallExpression, hasThisState: boolean][] = [];
 
-  return merge(
-    {
-      // Push `setState` calls to the stack upon entry
-      CallExpression(node) {
-        if (!core.isThisSetStateCall(node)) {
-          return;
-        }
-        setStateStack.push([node, false]);
-      },
-      // Pop `setState` calls from the stack upon exit
-      "CallExpression:exit"(node) {
-        if (!core.isThisSetStateCall(node)) {
-          return;
-        }
-        setStateStack.pop();
-      },
-      // Push class declarations to the stack upon entry
-      ClassDeclaration(node) {
-        classStack.push([node, core.isClassComponent(node)]);
-      },
-      // Pop class declarations from the stack upon exit
-      "ClassDeclaration:exit"() {
-        classStack.pop();
-      },
-      // Push class expressions to the stack upon entry
-      ClassExpression(node) {
-        classStack.push([node, core.isClassComponent(node)]);
-      },
-      // Pop class expressions from the stack upon exit
-      "ClassExpression:exit"() {
-        classStack.pop();
-      },
-      // Main logic for detecting `this.state` access
-      MemberExpression(node) {
-        // Check for `this` expressions
-        if (node.object.type !== AST.ThisExpression) {
-          return;
-        }
-        // Ensure we are inside a React class component
-        const [currClass, isComponent = false] = classStack.at(-1) ?? [];
-        if (currClass == null || !isComponent) {
-          return;
-        }
-        // Ensure we are inside a non-static method
-        const [currMethod, isStatic = false] = methodStack.at(-1) ?? [];
-        if (currMethod == null || isStatic) {
-          return;
-        }
-        // Ensure we are inside a `setState` call
-        const [setState, hasThisState = false] = setStateStack.at(-1) ?? [];
-        if (setState == null || hasThisState) {
-          return;
-        }
-        // Check if the property being accessed is `state`
-        if (Extract.getPropertyName(node.property) !== "state") {
-          return;
-        }
-        // Report an issue if `this.state` is accessed
-        context.report({ messageId: "default", node });
-      },
-      // Push method definitions to the stack upon entry
-      MethodDefinition(node) {
-        methodStack.push([node, node.static]);
-      },
-      // Pop method definitions from the stack upon exit
-      "MethodDefinition:exit"() {
-        methodStack.pop();
-      },
-      // Push property definitions to the stack upon entry
-      PropertyDefinition(node) {
-        methodStack.push([node, node.static]);
-      },
-      // Pop property definitions from the stack upon exit
-      "PropertyDefinition:exit"() {
-        methodStack.pop();
-      },
-      // Logic for detecting destructuring of `this.state`
-      VariableDeclarator(node) {
-        // Get current class and method context
-        const [currClass, isComponent = false] = classStack.at(-1) ?? [];
-        if (currClass == null || !isComponent) {
-          return;
-        }
-        const [currMethod, isStatic = false] = methodStack.at(-1) ?? [];
-        if (currMethod == null || isStatic) {
-          return;
-        }
-        // Ensure we are inside a `setState` call
-        const [setState, hasThisState = false] = setStateStack.at(-1) ?? [];
-        if (setState == null || hasThisState) {
-          return;
-        }
-        // Check for destructuring from `this`
-        if (node.init == null || node.init.type !== AST.ThisExpression || node.id.type !== AST.ObjectPattern) {
-          return;
-        }
-        // Check if `state` is one of the destructured properties
-        const hasState = node
-          .id
-          .properties
-          .some((prop) =>
-            prop.type === AST.Property
-            && isKeyLiteral(prop, prop.key)
-            && Extract.getPropertyName(prop.key) === "state"
-          );
-        if (!hasState) {
-          return;
-        }
-        // Report an issue if `state` is destructured from `this`
-        context.report({ messageId: "default", node });
-      },
+  return {
+    // Push `setState` calls to the stack upon entry
+    CallExpression(node) {
+      if (!core.isThisSetStateCall(node)) {
+        return;
+      }
+      setStateStack.push([node, false]);
     },
-  );
+    // Pop `setState` calls from the stack upon exit
+    "CallExpression:exit"(node) {
+      if (!core.isThisSetStateCall(node)) {
+        return;
+      }
+      setStateStack.pop();
+    },
+    // Push class declarations to the stack upon entry
+    ClassDeclaration(node) {
+      classStack.push([node, core.isClassComponent(node)]);
+    },
+    // Pop class declarations from the stack upon exit
+    "ClassDeclaration:exit"() {
+      classStack.pop();
+    },
+    // Push class expressions to the stack upon entry
+    ClassExpression(node) {
+      classStack.push([node, core.isClassComponent(node)]);
+    },
+    // Pop class expressions from the stack upon exit
+    "ClassExpression:exit"() {
+      classStack.pop();
+    },
+    // Main logic for detecting `this.state` access
+    MemberExpression(node) {
+      // Check for `this` expressions
+      if (node.object.type !== AST.ThisExpression) {
+        return;
+      }
+      // Ensure we are inside a React class component
+      const [currClass, isComponent = false] = classStack.at(-1) ?? [];
+      if (currClass == null || !isComponent) {
+        return;
+      }
+      // Ensure we are inside a non-static method
+      const [currMethod, isStatic = false] = methodStack.at(-1) ?? [];
+      if (currMethod == null || isStatic) {
+        return;
+      }
+      // Ensure we are inside a `setState` call
+      const [setState, hasThisState = false] = setStateStack.at(-1) ?? [];
+      if (setState == null || hasThisState) {
+        return;
+      }
+      // Check if the property being accessed is `state`
+      if (Extract.getPropertyName(node.property) !== "state") {
+        return;
+      }
+      // Report an issue if `this.state` is accessed
+      context.report({ messageId: "default", node });
+    },
+    // Push method definitions to the stack upon entry
+    MethodDefinition(node) {
+      methodStack.push([node, node.static]);
+    },
+    // Pop method definitions from the stack upon exit
+    "MethodDefinition:exit"() {
+      methodStack.pop();
+    },
+    // Push property definitions to the stack upon entry
+    PropertyDefinition(node) {
+      methodStack.push([node, node.static]);
+    },
+    // Pop property definitions from the stack upon exit
+    "PropertyDefinition:exit"() {
+      methodStack.pop();
+    },
+    // Logic for detecting destructuring of `this.state`
+    VariableDeclarator(node) {
+      // Get current class and method context
+      const [currClass, isComponent = false] = classStack.at(-1) ?? [];
+      if (currClass == null || !isComponent) {
+        return;
+      }
+      const [currMethod, isStatic = false] = methodStack.at(-1) ?? [];
+      if (currMethod == null || isStatic) {
+        return;
+      }
+      // Ensure we are inside a `setState` call
+      const [setState, hasThisState = false] = setStateStack.at(-1) ?? [];
+      if (setState == null || hasThisState) {
+        return;
+      }
+      // Check for destructuring from `this`
+      if (node.init == null || node.init.type !== AST.ThisExpression || node.id.type !== AST.ObjectPattern) {
+        return;
+      }
+      // Check if `state` is one of the destructured properties
+      const hasState = node
+        .id
+        .properties
+        .some((prop) =>
+          prop.type === AST.Property
+          && isKeyLiteral(prop, prop.key)
+          && Extract.getPropertyName(prop.key) === "state"
+        );
+      if (!hasState) {
+        return;
+      }
+      // Report an issue if `state` is destructured from `this`
+      context.report({ messageId: "default", node });
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
 import { isMatching } from "ts-pattern";
@@ -104,59 +104,57 @@ export function create(context: RuleContext<MessageID, []>) {
     return [];
   }
 
-  return merge(
-    {
-      CallExpression(node) {
-        // Push the index parameter name (if any) to the stack
-        indexParamNames.push(getMapIndexParamName(context, node));
-        if (node.arguments.length === 0) {
-          return;
+  return {
+    CallExpression(node) {
+      // Push the index parameter name (if any) to the stack
+      indexParamNames.push(getMapIndexParamName(context, node));
+      if (node.arguments.length === 0) {
+        return;
+      }
+      // Check for array index usage in `createElement` and `cloneElement` calls
+      if (!isCreateOrCloneElementCall(node)) {
+        return;
+      }
+      const [, props] = node.arguments;
+      if (props?.type !== AST.ObjectExpression) {
+        return;
+      }
+      for (const prop of props.properties) {
+        // Find the 'key' prop
+        if (!isMatching({ key: { name: "key" } })(prop)) {
+          continue;
         }
-        // Check for array index usage in `createElement` and `cloneElement` calls
-        if (!isCreateOrCloneElementCall(node)) {
-          return;
+        if (!("value" in prop)) {
+          continue;
         }
-        const [, props] = node.arguments;
-        if (props?.type !== AST.ObjectExpression) {
-          return;
-        }
-        for (const prop of props.properties) {
-          // Find the 'key' prop
-          if (!isMatching({ key: { name: "key" } })(prop)) {
-            continue;
-          }
-          if (!("value" in prop)) {
-            continue;
-          }
-          // Check its value and report if it uses an array index
-          for (const descriptor of getReportDescriptors(prop.value)) {
-            report(context)(descriptor);
-          }
-        }
-      },
-      // When exiting a CallExpression, pop the index name from the stack to manage scope
-      "CallExpression:exit"() {
-        indexParamNames.pop();
-      },
-      // Handles JSX attributes
-      JSXAttribute(node) {
-        // Check only for the 'key' attribute
-        if (node.name.name !== "key") {
-          return;
-        }
-        // Ignore if we are not inside a map-like call
-        if (indexParamNames.length === 0) {
-          return;
-        }
-        // The key's value must be an expression container (ex: key={...})
-        if (node.value?.type !== AST.JSXExpressionContainer) {
-          return;
-        }
-        // Check the expression and report if it uses an array index
-        for (const descriptor of getReportDescriptors(node.value.expression)) {
+        // Check its value and report if it uses an array index
+        for (const descriptor of getReportDescriptors(prop.value)) {
           report(context)(descriptor);
         }
-      },
+      }
     },
-  );
+    // When exiting a CallExpression, pop the index name from the stack to manage scope
+    "CallExpression:exit"() {
+      indexParamNames.pop();
+    },
+    // Handles JSX attributes
+    JSXAttribute(node) {
+      // Check only for the 'key' attribute
+      if (node.name.name !== "key") {
+        return;
+      }
+      // Ignore if we are not inside a map-like call
+      if (indexParamNames.length === 0) {
+        return;
+      }
+      // The key's value must be an expression container (ex: key={...})
+      if (node.value?.type !== AST.JSXExpressionContainer) {
+        return;
+      }
+      // Check the expression and report if it uses an array index
+      for (const descriptor of getReportDescriptors(node.value.expression)) {
+        report(context)(descriptor);
+      }
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-count";
 
@@ -25,16 +25,14 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      MemberExpression(node) {
-        if (core.isChildrenCount(context, node)) {
-          context.report({
-            messageId: "default",
-            node: node.property,
-          });
-        }
-      },
+  return {
+    MemberExpression(node) {
+      if (core.isChildrenCount(context, node)) {
+        context.report({
+          messageId: "default",
+          node: node.property,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-for-each";
 
@@ -25,16 +25,14 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      MemberExpression(node) {
-        if (core.isChildrenForEach(context, node)) {
-          context.report({
-            messageId: "default",
-            node: node.property,
-          });
-        }
-      },
+  return {
+    MemberExpression(node) {
+      if (core.isChildrenForEach(context, node)) {
+        context.report({
+          messageId: "default",
+          node: node.property,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-map";
 
@@ -25,16 +25,14 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      MemberExpression(node) {
-        if (core.isChildrenMap(context, node)) {
-          context.report({
-            messageId: "default",
-            node: node.property,
-          });
-        }
-      },
+  return {
+    MemberExpression(node) {
+      if (core.isChildrenMap(context, node)) {
+        context.report({
+          messageId: "default",
+          node: node.property,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-only";
 
@@ -25,16 +25,14 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      MemberExpression(node) {
-        if (core.isChildrenOnly(context, node)) {
-          context.report({
-            messageId: "default",
-            node: node.property,
-          });
-        }
-      },
+  return {
+    MemberExpression(node) {
+      if (core.isChildrenOnly(context, node)) {
+        context.report({
+          messageId: "default",
+          node: node.property,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-to-array";
 
@@ -25,16 +25,14 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      MemberExpression(node) {
-        if (core.isChildrenToArray(context, node)) {
-          context.report({
-            messageId: "default",
-            node: node.property,
-          });
-        }
-      },
+  return {
+    MemberExpression(node) {
+      if (core.isChildrenToArray(context, node)) {
+        context.report({
+          messageId: "default",
+          node: node.property,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-clone-element";
 
@@ -25,16 +25,14 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      CallExpression(node) {
-        if (core.isCloneElementCall(context, node)) {
-          context.report({
-            messageId: "default",
-            node,
-          });
-        }
-      },
+  return {
+    CallExpression(node) {
+      if (core.isCloneElementCall(context, node)) {
+        context.report({
+          messageId: "default",
+          node,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getElementFullType } from "@eslint-react/jsx";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { compare } from "compare-versions";
@@ -38,44 +38,42 @@ export function create(context: RuleContext<MessageID, []>) {
   const { version } = getSettingsFromContext(context);
   // This rule only applies to React 19 and later
   if (compare(version, "19.0.0", "<")) return {};
-  return merge(
-    {
-      JSXElement(node) {
-        // Get the full name of the JSX element: "Foo.MyContext.Provider"
-        const fullName = getElementFullType(node);
-        const parts = fullName.split(".");
-        const selfName = parts.pop();
-        const contextFullName = parts.join(".");
-        const contextSelfName = parts.pop();
-        // Exit if the element is not a "Provider"
-        if (selfName !== "Provider") return;
-        // Exit if there is no context name or it doesn't end with "Context"
-        if (contextSelfName == null || !contextSelfName.endsWith("Context")) return;
-        context.report({
-          messageId: "default",
-          node,
-          suggest: [
-            {
-              fix(fixer) {
-                // Ensure the context name is a valid component name before applying the fix
-                if (!core.isFunctionComponentNameLoose(contextSelfName)) return null;
-                const openingElement = node.openingElement;
-                const closingElement = node.closingElement;
-                // Handle self-closing elements like <MyContext.Provider value={...} />
-                if (closingElement == null) {
-                  return fixer.replaceText(openingElement.name, contextFullName);
-                }
-                // Handle elements with children like <MyContext.Provider value={...}>...</MyContext.Provider>
-                return [
-                  fixer.replaceText(openingElement.name, contextFullName),
-                  fixer.replaceText(closingElement.name, contextFullName),
-                ];
-              },
-              messageId: "replace",
+  return {
+    JSXElement(node) {
+      // Get the full name of the JSX element: "Foo.MyContext.Provider"
+      const fullName = getElementFullType(node);
+      const parts = fullName.split(".");
+      const selfName = parts.pop();
+      const contextFullName = parts.join(".");
+      const contextSelfName = parts.pop();
+      // Exit if the element is not a "Provider"
+      if (selfName !== "Provider") return;
+      // Exit if there is no context name or it doesn't end with "Context"
+      if (contextSelfName == null || !contextSelfName.endsWith("Context")) return;
+      context.report({
+        messageId: "default",
+        node,
+        suggest: [
+          {
+            fix(fixer) {
+              // Ensure the context name is a valid component name before applying the fix
+              if (!core.isFunctionComponentNameLoose(contextSelfName)) return null;
+              const openingElement = node.openingElement;
+              const closingElement = node.closingElement;
+              // Handle self-closing elements like <MyContext.Provider value={...} />
+              if (closingElement == null) {
+                return fixer.replaceText(openingElement.name, contextFullName);
+              }
+              // Handle elements with children like <MyContext.Provider value={...}>...</MyContext.Provider>
+              return [
+                fixer.replaceText(openingElement.name, contextFullName),
+                fixer.replaceText(closingElement.name, contextFullName),
+              ];
             },
-          ],
-        });
-      },
+            messageId: "replace",
+          },
+        ],
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Traverse, isOneOf } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-direct-mutation-state";
@@ -36,32 +36,30 @@ export default createRule<[], MessageID>({
 });
 
 export function create(context: RuleContext<MessageID, []>) {
-  return merge(
-    {
-      AssignmentExpression(node: TSESTree.AssignmentExpression) {
-        if (!core.isAssignmentToThisState(node)) return;
-        // Find the parent class of the assignment
-        const parentClass = Traverse.findParent(
+  return {
+    AssignmentExpression(node: TSESTree.AssignmentExpression) {
+      if (!core.isAssignmentToThisState(node)) return;
+      // Find the parent class of the assignment
+      const parentClass = Traverse.findParent(
+        node,
+        isOneOf([
+          AST.ClassDeclaration,
+          AST.ClassExpression,
+        ]),
+      );
+      // If the assignment is not inside a class, do nothing
+      if (parentClass == null) return;
+      // Report an error if 'this.state' is directly mutated in a class component
+      // and the mutation is not inside the constructor
+      if (
+        core.isClassComponent(parentClass)
+        && context.sourceCode.getScope(node).block !== Traverse.findParent(node, isConstructorFunction)
+      ) {
+        context.report({
+          messageId: "default",
           node,
-          isOneOf([
-            AST.ClassDeclaration,
-            AST.ClassExpression,
-          ]),
-        );
-        // If the assignment is not inside a class, do nothing
-        if (parentClass == null) return;
-        // Report an error if 'this.state' is directly mutated in a class component
-        // and the mutation is not inside the constructor
-        if (
-          core.isClassComponent(parentClass)
-          && context.sourceCode.getScope(node).block !== Traverse.findParent(node, isConstructorFunction)
-        ) {
-          context.report({
-            messageId: "default",
-            node,
-          });
-        }
-      },
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Compare, Extract, Traverse } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-duplicate-key";
@@ -52,73 +52,71 @@ export function create(context: RuleContext<MessageID, []>) {
     // Compare the AST nodes of the values for equality
     return Compare.isEqual(aValue, bValue);
   }
-  return merge(
-    {
-      // Visitor for all JSX attributes named 'key'
-      "JSXAttribute[name.name='key']"(node: TSESTree.JSXAttribute) {
-        const jsxElement = node.parent.parent;
-        // Check the parent of the JSX element to determine the context
-        switch (jsxElement.parent.type) {
-          // Case 1: Elements in an array expression, JSX element, or JSX fragment
-          case AST.ArrayExpression:
-          case AST.JSXElement:
-          case AST.JSXFragment: {
-            const root = jsxElement.parent;
-            const prevKeys = keyedEntries.get(root)?.keys ?? [];
-            // Check for duplicates and update the map
-            keyedEntries.set(root, {
-              hasDuplicate: prevKeys.some((prevKey) => isKeyValueEqual(prevKey, node)),
-              keys: [...prevKeys, node],
-              root: jsxElement.parent,
-            });
-            break;
-          }
-          // Case 2: Elements created by an array's .map() call
-          default: {
-            const call = Traverse.findParent(
-              jsxElement,
-              (n): n is TSESTree.CallExpression => {
-                if (n.type !== AST.CallExpression) return false;
-                const callee = Extract.unwrap(n.callee);
-                return callee.type === AST.MemberExpression
-                  && callee.property.type === AST.Identifier
-                  && callee.property.name === "map";
-              },
-            );
-            const iter = Traverse.findParent(jsxElement, Check.isFunction, (n) => n === call);
-            if (!Check.isFunction(iter)) return;
-            const arg0 = call?.arguments[0];
-            if (call == null || arg0 == null) return;
-            // Ensure we are inside the callback of the .map() call
-            if (Extract.unwrap(arg0) !== iter) {
-              return;
-            }
-            // Flag literal keys in .map() calls as they are a common source of duplication
-            keyedEntries.set(call, {
-              hasDuplicate: node.value?.type === AST.Literal,
-              keys: [node],
-              root: call,
-            });
-          }
+  return {
+    // Visitor for all JSX attributes named 'key'
+    "JSXAttribute[name.name='key']"(node: TSESTree.JSXAttribute) {
+      const jsxElement = node.parent.parent;
+      // Check the parent of the JSX element to determine the context
+      switch (jsxElement.parent.type) {
+        // Case 1: Elements in an array expression, JSX element, or JSX fragment
+        case AST.ArrayExpression:
+        case AST.JSXElement:
+        case AST.JSXFragment: {
+          const root = jsxElement.parent;
+          const prevKeys = keyedEntries.get(root)?.keys ?? [];
+          // Check for duplicates and update the map
+          keyedEntries.set(root, {
+            hasDuplicate: prevKeys.some((prevKey) => isKeyValueEqual(prevKey, node)),
+            keys: [...prevKeys, node],
+            root: jsxElement.parent,
+          });
+          break;
         }
-      },
-      "Program:exit"() {
-        for (const { hasDuplicate, keys } of keyedEntries.values()) {
-          if (!hasDuplicate) {
-            continue;
+        // Case 2: Elements created by an array's .map() call
+        default: {
+          const call = Traverse.findParent(
+            jsxElement,
+            (n): n is TSESTree.CallExpression => {
+              if (n.type !== AST.CallExpression) return false;
+              const callee = Extract.unwrap(n.callee);
+              return callee.type === AST.MemberExpression
+                && callee.property.type === AST.Identifier
+                && callee.property.name === "map";
+            },
+          );
+          const iter = Traverse.findParent(jsxElement, Check.isFunction, (n) => n === call);
+          if (!Check.isFunction(iter)) return;
+          const arg0 = call?.arguments[0];
+          if (call == null || arg0 == null) return;
+          // Ensure we are inside the callback of the .map() call
+          if (Extract.unwrap(arg0) !== iter) {
+            return;
           }
-          // Report an error for each duplicate key found
-          for (const key of keys) {
-            context.report({
-              data: {
-                value: context.sourceCode.getText(key),
-              },
-              messageId: "default",
-              node: key,
-            });
-          }
+          // Flag literal keys in .map() calls as they are a common source of duplication
+          keyedEntries.set(call, {
+            hasDuplicate: node.value?.type === AST.Literal,
+            keys: [node],
+            root: call,
+          });
         }
-      },
+      }
     },
-  );
+    "Program:exit"() {
+      for (const { hasDuplicate, keys } of keyedEntries.values()) {
+        if (!hasDuplicate) {
+          continue;
+        }
+        // Report an error for each duplicate key found
+        for (const key of keys) {
+          context.report({
+            data: {
+              value: context.sourceCode.getText(key),
+            },
+            messageId: "default",
+            node: key,
+          });
+        }
+      }
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { RuleFix, RuleFixer } from "@typescript-eslint/utils/ts-eslint";
@@ -45,30 +45,28 @@ export function create(context: RuleContext<MessageID, []>) {
   if (compare(version, "19.0.0", "<")) {
     return {};
   }
-  return merge(
-    {
-      // Visitor for `forwardRef()` calls
-      CallExpression(node) {
-        if (!core.isForwardRefCall(context, node)) {
-          return;
-        }
-        const id = core.getFunctionId(node);
-        const suggest = canFix(context, node)
-          ? [
-            {
-              fix: getFix(context, node),
-              messageId: "replace" as const,
-            },
-          ]
-          : [];
-        context.report({
-          messageId: "default",
-          node: id ?? node,
-          suggest,
-        });
-      },
+  return {
+    // Visitor for `forwardRef()` calls
+    CallExpression(node) {
+      if (!core.isForwardRefCall(context, node)) {
+        return;
+      }
+      const id = core.getFunctionId(node);
+      const suggest = canFix(context, node)
+        ? [
+          {
+            fix: getFix(context, node),
+            messageId: "replace" as const,
+          },
+        ]
+        : [];
+      context.report({
+        messageId: "default",
+        node: id ?? node,
+        suggest,
+      });
     },
-  );
+  };
 }
 
 /**

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { unionConstituents } from "ts-api-utils";
@@ -36,34 +36,32 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const services = ESLintUtils.getParserServices(context, false);
   const checker = services.program.getTypeChecker();
-  return merge(
-    {
-      JSXSpreadAttribute(node) {
-        for (const type of unionConstituents(getConstrainedTypeAtLocation(services, node.argument))) {
-          const children = type.getProperty("children");
-          if (children == null) continue;
-          // Allow pass-through of React internally defined children
-          // For react, react-dom the FQN is "React.DOMAttributes.children"
-          // For PropsWithChildren the FQN is "React.PropsWithChildren.children"
-          // For @rbxts/react the FQN is "React.Attributes.children"
-          const fqn = core.getFullyQualifiedNameEx(checker, children).toLowerCase();
-          if (fqn.endsWith("attributes.children") || fqn.endsWith("propswithchildren.children")) continue;
-          // Allow when the children property's type is a React children type alias
-          // e.g. React.ReactNode, React.ReactElement, React.ReactPortal, JSX.Element
-          const childrenType = checker.getTypeOfSymbol(children);
-          const typeSymbol = childrenType.aliasSymbol ?? childrenType.symbol;
-          // TypeScript's type definition marks `Type.symbol` as required, but at runtime it can be `undefined` for certain internal types.
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          if (typeSymbol != null) {
-            const typeFqn = checker.getFullyQualifiedName(typeSymbol);
-            if (RE_REACT_CHILDREN_TYPE.test(typeFqn) || /^JSX\.Element$/i.test(typeFqn)) continue;
-          }
-          context.report({
-            messageId: "default",
-            node,
-          });
+  return {
+    JSXSpreadAttribute(node) {
+      for (const type of unionConstituents(getConstrainedTypeAtLocation(services, node.argument))) {
+        const children = type.getProperty("children");
+        if (children == null) continue;
+        // Allow pass-through of React internally defined children
+        // For react, react-dom the FQN is "React.DOMAttributes.children"
+        // For PropsWithChildren the FQN is "React.PropsWithChildren.children"
+        // For @rbxts/react the FQN is "React.Attributes.children"
+        const fqn = core.getFullyQualifiedNameEx(checker, children).toLowerCase();
+        if (fqn.endsWith("attributes.children") || fqn.endsWith("propswithchildren.children")) continue;
+        // Allow when the children property's type is a React children type alias
+        // e.g. React.ReactNode, React.ReactElement, React.ReactPortal, JSX.Element
+        const childrenType = checker.getTypeOfSymbol(children);
+        const typeSymbol = childrenType.aliasSymbol ?? childrenType.symbol;
+        // TypeScript's type definition marks `Type.symbol` as required, but at runtime it can be `undefined` for certain internal types.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (typeSymbol != null) {
+          const typeFqn = checker.getFullyQualifiedName(typeSymbol);
+          if (RE_REACT_CHILDREN_TYPE.test(typeFqn) || /^JSX\.Element$/i.test(typeFqn)) continue;
         }
-      },
+        context.report({
+          messageId: "default",
+          node,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { unionConstituents } from "ts-api-utils";
@@ -34,29 +34,27 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const services = ESLintUtils.getParserServices(context, false);
   const checker = services.program.getTypeChecker();
-  return merge(
-    {
-      JSXSpreadAttribute(node) {
-        for (const type of unionConstituents(getConstrainedTypeAtLocation(services, node.argument))) {
-          const key = type.getProperty("key");
-          if (key == null) continue;
-          // Allow pass-through of React internally defined keys
-          // For react, react-dom, and @rbxts/react the FQN is "React.Attributes.key"
-          // For preact and preact/compat the FQN is "preact.Attributes.key"
-          // https://github.com/Rel1cx/eslint-react/issues/1472
-          if (core.getFullyQualifiedNameEx(checker, key).toLowerCase().endsWith("react.attributes.key")) continue;
-          // Allow when the key property's type is React.Key (ex: `{ key: React.Key }`)
-          const keyType = checker.getTypeOfSymbol(key);
-          if (keyType.aliasSymbol != null) {
-            const aliasFqn = checker.getFullyQualifiedName(keyType.aliasSymbol).toLowerCase();
-            if (aliasFqn.endsWith("react.key")) continue;
-          }
-          context.report({
-            messageId: "default",
-            node,
-          });
+  return {
+    JSXSpreadAttribute(node) {
+      for (const type of unionConstituents(getConstrainedTypeAtLocation(services, node.argument))) {
+        const key = type.getProperty("key");
+        if (key == null) continue;
+        // Allow pass-through of React internally defined keys
+        // For react, react-dom, and @rbxts/react the FQN is "React.Attributes.key"
+        // For preact and preact/compat the FQN is "preact.Attributes.key"
+        // https://github.com/Rel1cx/eslint-react/issues/1472
+        if (core.getFullyQualifiedNameEx(checker, key).toLowerCase().endsWith("react.attributes.key")) continue;
+        // Allow when the key property's type is React.Key (ex: `{ key: React.Key }`)
+        const keyType = checker.getTypeOfSymbol(key);
+        if (keyType.aliasSymbol != null) {
+          const aliasFqn = checker.getFullyQualifiedName(keyType.aliasSymbol).toLowerCase();
+          if (aliasFqn.endsWith("react.key")) continue;
         }
-      },
+        context.report({
+          messageId: "default",
+          node,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { unionConstituents } from "ts-api-utils";
@@ -36,30 +36,28 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   const services = ESLintUtils.getParserServices(context, false);
   const checker = services.program.getTypeChecker();
-  return merge(
-    {
-      JSXSpreadAttribute(node) {
-        for (const type of unionConstituents(getConstrainedTypeAtLocation(services, node.argument))) {
-          const ref = type.getProperty("ref");
-          if (ref == null) continue;
-          // Allow pass-through of React internally defined refs
-          if (core.getFullyQualifiedNameEx(checker, ref).toLowerCase().endsWith("attributes.ref")) continue;
-          // Allow when the ref property's type is a React ref type alias
-          // e.g. React.Ref, React.LegacyRef, React.RefCallback, React.RefObject
-          const refType = checker.getTypeOfSymbol(ref);
-          const typeSymbol = refType.aliasSymbol ?? refType.symbol;
-          // TypeScript's type definition marks `Type.symbol` as required, but at runtime it can be `undefined` for certain internal types.
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          if (typeSymbol != null) {
-            const typeFqn = checker.getFullyQualifiedName(typeSymbol);
-            if (RE_REACT_REF_TYPE.test(typeFqn)) continue;
-          }
-          context.report({
-            messageId: "default",
-            node,
-          });
+  return {
+    JSXSpreadAttribute(node) {
+      for (const type of unionConstituents(getConstrainedTypeAtLocation(services, node.argument))) {
+        const ref = type.getProperty("ref");
+        if (ref == null) continue;
+        // Allow pass-through of React internally defined refs
+        if (core.getFullyQualifiedNameEx(checker, ref).toLowerCase().endsWith("attributes.ref")) continue;
+        // Allow when the ref property's type is a React ref type alias
+        // e.g. React.Ref, React.LegacyRef, React.RefCallback, React.RefObject
+        const refType = checker.getTypeOfSymbol(ref);
+        const typeSymbol = refType.aliasSymbol ?? refType.symbol;
+        // TypeScript's type definition marks `Type.symbol` as required, but at runtime it can be `undefined` for certain internal types.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        if (typeSymbol != null) {
+          const typeFqn = checker.getFullyQualifiedName(typeSymbol);
+          if (RE_REACT_REF_TYPE.test(typeFqn)) continue;
         }
-      },
+        context.report({
+          messageId: "default",
+          node,
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, is } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { flow } from "@local/eff";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
@@ -145,5 +145,5 @@ export function create(context: RuleContext<MessageID, []>) {
       // For all other node types, assume they are safe
       .otherwise(() => null);
   }
-  return merge({ JSXExpressionContainer: flow(getReportDescriptor, report(context)) });
+  return { JSXExpressionContainer: flow(getReportDescriptor, report(context)) };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
@@ -37,66 +37,64 @@ export function create(context: RuleContext<MessageID, []>) {
   // Stores all `displayName` assignment expressions
   const displayNameAssignments: TSESTree.AssignmentExpression[] = [];
 
-  return merge(
-    {
-      // Collect all `createContext()` calls
-      CallExpression(node) {
-        if (!core.isCreateContextCall(context, node)) return;
-        createCalls.push(node);
-      },
-      // Collect all `*.displayName = '...'` assignments
-      [core.SEL_FUNCTION_DISPLAY_NAME_ASSIGNMENT](node: core.FunctionDisplayNameAssignment) {
-        displayNameAssignments.push(node);
-      },
-      "Program:exit"() {
-        for (const call of createCalls) {
-          // Get the variable identifier for the context
-          const id = resolveEnclosingAssignmentTarget(call);
-          if (id == null) {
-            // Report an error if the context is not assigned to a variable
-            context.report({
-              messageId: "default",
-              node: call,
-            });
-            continue;
-          }
-          // Check if a `displayName` is assigned to this context variable
-          const hasDisplayNameAssignment = displayNameAssignments
-            .some((node) => {
-              const left = node.left;
-              if (left.type !== AST.MemberExpression) return false;
-              const object = left.object;
-              // Check if the object in the assignment matches the context's identifier
-              return isAssignmentTargetEqual(context, id, object);
-            });
-          // If no `displayName` is found, report an error and provide a fix
-          if (!hasDisplayNameAssignment) {
-            context.report({
-              fix(fixer) {
-                // Ensure the fix is applied correctly
-                if (id.type !== AST.Identifier || id.parent !== call.parent) return [];
-                // Insert `ContextName.displayName = "ContextName";` after the creation
-                return fixer.insertTextAfter(
-                  context.sourceCode.getTokenAfter(call) ?? call,
-                  [
-                    "\n",
-                    id.name,
-                    ".",
-                    "displayName",
-                    " ",
-                    "=",
-                    " ",
-                    JSON.stringify(id.name),
-                    ";",
-                  ].join(""),
-                );
-              },
-              messageId: "default",
-              node: id,
-            });
-          }
-        }
-      },
+  return {
+    // Collect all `createContext()` calls
+    CallExpression(node) {
+      if (!core.isCreateContextCall(context, node)) return;
+      createCalls.push(node);
     },
-  );
+    // Collect all `*.displayName = '...'` assignments
+    [core.SEL_FUNCTION_DISPLAY_NAME_ASSIGNMENT](node: core.FunctionDisplayNameAssignment) {
+      displayNameAssignments.push(node);
+    },
+    "Program:exit"() {
+      for (const call of createCalls) {
+        // Get the variable identifier for the context
+        const id = resolveEnclosingAssignmentTarget(call);
+        if (id == null) {
+          // Report an error if the context is not assigned to a variable
+          context.report({
+            messageId: "default",
+            node: call,
+          });
+          continue;
+        }
+        // Check if a `displayName` is assigned to this context variable
+        const hasDisplayNameAssignment = displayNameAssignments
+          .some((node) => {
+            const left = node.left;
+            if (left.type !== AST.MemberExpression) return false;
+            const object = left.object;
+            // Check if the object in the assignment matches the context's identifier
+            return isAssignmentTargetEqual(context, id, object);
+          });
+        // If no `displayName` is found, report an error and provide a fix
+        if (!hasDisplayNameAssignment) {
+          context.report({
+            fix(fixer) {
+              // Ensure the fix is applied correctly
+              if (id.type !== AST.Identifier || id.parent !== call.parent) return [];
+              // Insert `ContextName.displayName = "ContextName";` after the creation
+              return fixer.insertTextAfter(
+                context.sourceCode.getTokenAfter(call) ?? call,
+                [
+                  "\n",
+                  id.name,
+                  ".",
+                  "displayName",
+                  " ",
+                  "=",
+                  " ",
+                  JSON.stringify(id.name),
+                  ";",
+                ].join(""),
+              );
+            },
+            messageId: "default",
+            node: id,
+          });
+        }
+      }
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeJSXElementLike, is } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { hasAttribute } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
@@ -74,46 +74,44 @@ export function create(context: RuleContext<MessageID, []>) {
     return descriptors;
   }
 
-  return merge(
-    {
-      ArrayExpression(node) {
-        if (inChildrenToArray) return;
-        const elements = node.elements.filter(is(AST.JSXElement));
-        if (elements.length === 0) return;
-        for (const el of elements) {
-          if (!hasAttribute(context, el, "key")) {
-            context.report({ messageId: "default", node: el });
-          }
+  return {
+    ArrayExpression(node) {
+      if (inChildrenToArray) return;
+      const elements = node.elements.filter(is(AST.JSXElement));
+      if (elements.length === 0) return;
+      for (const el of elements) {
+        if (!hasAttribute(context, el, "key")) {
+          context.report({ messageId: "default", node: el });
         }
-      },
-      CallExpression(node) {
-        inChildrenToArray ||= core.isChildrenToArrayCall(context, node);
-        if (inChildrenToArray) return;
-        const callee = Extract.unwrap(node.callee);
-        if (callee.type !== AST.MemberExpression) return;
-        if (callee.property.type !== AST.Identifier) return;
-        const name = callee.property.name;
-        const idx = name === "from" ? 1 : name === "map" ? 0 : -1;
-        if (idx < 0) return;
-        const cb = node.arguments[idx];
-        if (!Check.isFunction(cb)) return;
-        if (cb.body.type === AST.BlockStatement) {
-          checkBlock(cb.body).forEach(report(context));
-        } else {
-          checkExpr(cb.body).forEach(report(context));
-        }
-      },
-      "CallExpression:exit"(node) {
-        if (core.isChildrenToArrayCall(context, node)) {
-          inChildrenToArray = false;
-        }
-      },
-      JSXFragment(node) {
-        if (inChildrenToArray) return;
-        if (node.parent.type === AST.ArrayExpression) {
-          context.report({ messageId: "unexpectedFragmentSyntax", node });
-        }
-      },
+      }
     },
-  );
+    CallExpression(node) {
+      inChildrenToArray ||= core.isChildrenToArrayCall(context, node);
+      if (inChildrenToArray) return;
+      const callee = Extract.unwrap(node.callee);
+      if (callee.type !== AST.MemberExpression) return;
+      if (callee.property.type !== AST.Identifier) return;
+      const name = callee.property.name;
+      const idx = name === "from" ? 1 : name === "map" ? 0 : -1;
+      if (idx < 0) return;
+      const cb = node.arguments[idx];
+      if (!Check.isFunction(cb)) return;
+      if (cb.body.type === AST.BlockStatement) {
+        checkBlock(cb.body).forEach(report(context));
+      } else {
+        checkExpr(cb.body).forEach(report(context));
+      }
+    },
+    "CallExpression:exit"(node) {
+      if (core.isChildrenToArrayCall(context, node)) {
+        inChildrenToArray = false;
+      }
+    },
+    JSXFragment(node) {
+      if (inChildrenToArray) return;
+      if (node.parent.type === AST.ArrayExpression) {
+        context.report({ messageId: "unexpectedFragmentSyntax", node });
+      }
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { isDevelopmentOnlyCheck } from "./lib";
@@ -40,34 +40,32 @@ export function create(context: RuleContext<MessageID, []>) {
   if (!context.sourceCode.text.includes("captureOwnerStack")) return {};
   const { importSource } = getSettingsFromContext(context);
 
-  return merge(
-    {
-      CallExpression(node) {
-        // Check if the call is to `captureOwnerStack`
-        if (!core.isCaptureOwnerStackCall(context, node)) return;
-        // Check if the call is wrapped in a development-only conditional block
-        if (Traverse.findParent(node, (n) => isDevelopmentOnlyCheck(context, n)) == null) {
+  return {
+    CallExpression(node) {
+      // Check if the call is to `captureOwnerStack`
+      if (!core.isCaptureOwnerStackCall(context, node)) return;
+      // Check if the call is wrapped in a development-only conditional block
+      if (Traverse.findParent(node, (n) => isDevelopmentOnlyCheck(context, n)) == null) {
+        context.report({
+          messageId: "missingDevelopmentOnlyCheck",
+          node,
+        });
+      }
+    },
+    ImportDeclaration(node) {
+      // Check if the import is from the configured source
+      if (node.source.value !== importSource) return;
+      // Iterate over import specifiers to find named imports of `captureOwnerStack`
+      for (const specifier of node.specifiers) {
+        if (specifier.type !== AST.ImportSpecifier) continue;
+        if (specifier.imported.type !== AST.Identifier) continue;
+        if (specifier.imported.name === "captureOwnerStack") {
           context.report({
-            messageId: "missingDevelopmentOnlyCheck",
-            node,
+            messageId: "useNamespaceImport",
+            node: specifier,
           });
         }
-      },
-      ImportDeclaration(node) {
-        // Check if the import is from the configured source
-        if (node.source.value !== importSource) return;
-        // Iterate over import specifiers to find named imports of `captureOwnerStack`
-        for (const specifier of node.specifiers) {
-          if (specifier.type !== AST.ImportSpecifier) continue;
-          if (specifier.imported.type !== AST.Identifier) continue;
-          if (specifier.imported.name === "captureOwnerStack") {
-            context.report({
-              messageId: "useNamespaceImport",
-              node: specifier,
-            });
-          }
-        }
-      },
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-set-state-in-component-did-mount";
@@ -29,40 +29,38 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `componentDidMount` is not present in the file
   if (!context.sourceCode.text.includes("componentDidMount")) return {};
-  return merge(
-    {
-      CallExpression(node: TSESTree.CallExpression) {
-        if (!core.isThisSetStateCall(node)) {
-          return;
-        }
-        // Find the enclosing class component
-        const enclosingClassNode = Traverse.findParent(node, core.isClassComponent);
-        // Find the enclosing 'componentDidMount' method
-        const enclosingMethodNode = Traverse.findParent(
+  return {
+    CallExpression(node: TSESTree.CallExpression) {
+      if (!core.isThisSetStateCall(node)) {
+        return;
+      }
+      // Find the enclosing class component
+      const enclosingClassNode = Traverse.findParent(node, core.isClassComponent);
+      // Find the enclosing 'componentDidMount' method
+      const enclosingMethodNode = Traverse.findParent(
+        node,
+        (n) => n === enclosingClassNode || core.isComponentDidMount(n),
+      );
+
+      // Ensure 'this.setState' is inside a 'componentDidMount' method within a class component
+      if (enclosingClassNode == null || enclosingMethodNode == null || enclosingMethodNode === enclosingClassNode) {
+        return;
+      }
+
+      // Get the scope of the 'componentDidMount' method
+      const enclosingMethodScope = context.sourceCode.getScope(enclosingMethodNode);
+      // Get the scope where 'this.setState' is called
+      const setStateCallParentScope = context.sourceCode.getScope(node).upper;
+
+      // Report an error if 'this.setState' is called directly inside 'componentDidMount'
+      if (
+        enclosingMethodNode.parent === enclosingClassNode.body && setStateCallParentScope === enclosingMethodScope
+      ) {
+        context.report({
+          messageId: "default",
           node,
-          (n) => n === enclosingClassNode || core.isComponentDidMount(n),
-        );
-
-        // Ensure 'this.setState' is inside a 'componentDidMount' method within a class component
-        if (enclosingClassNode == null || enclosingMethodNode == null || enclosingMethodNode === enclosingClassNode) {
-          return;
-        }
-
-        // Get the scope of the 'componentDidMount' method
-        const enclosingMethodScope = context.sourceCode.getScope(enclosingMethodNode);
-        // Get the scope where 'this.setState' is called
-        const setStateCallParentScope = context.sourceCode.getScope(node).upper;
-
-        // Report an error if 'this.setState' is called directly inside 'componentDidMount'
-        if (
-          enclosingMethodNode.parent === enclosingClassNode.body && setStateCallParentScope === enclosingMethodScope
-        ) {
-          context.report({
-            messageId: "default",
-            node,
-          });
-        }
-      },
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-set-state-in-component-did-update";
@@ -29,40 +29,38 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `componentDidUpdate` is not present in the file
   if (!context.sourceCode.text.includes("componentDidUpdate")) return {};
-  return merge(
-    {
-      CallExpression(node: TSESTree.CallExpression) {
-        if (!core.isThisSetStateCall(node)) {
-          return;
-        }
-        // Find the enclosing class component
-        const enclosingClassNode = Traverse.findParent(node, core.isClassComponent);
-        // Find the enclosing 'componentDidUpdate' method
-        const enclosingMethodNode = Traverse.findParent(
+  return {
+    CallExpression(node: TSESTree.CallExpression) {
+      if (!core.isThisSetStateCall(node)) {
+        return;
+      }
+      // Find the enclosing class component
+      const enclosingClassNode = Traverse.findParent(node, core.isClassComponent);
+      // Find the enclosing 'componentDidUpdate' method
+      const enclosingMethodNode = Traverse.findParent(
+        node,
+        (n) => n === enclosingClassNode || core.isComponentDidUpdate(n),
+      );
+
+      // Ensure 'this.setState' is inside a 'componentDidUpdate' method within a class component
+      if (enclosingClassNode == null || enclosingMethodNode == null || enclosingMethodNode === enclosingClassNode) {
+        return;
+      }
+
+      // Get the scope of the 'componentDidUpdate' method
+      const enclosingMethodScope = context.sourceCode.getScope(enclosingMethodNode);
+      // Get the scope where 'this.setState' is called
+      const setStateCallParentScope = context.sourceCode.getScope(node).upper;
+
+      // Report an error if 'this.setState' is called directly inside 'componentDidUpdate'
+      if (
+        enclosingMethodNode.parent === enclosingClassNode.body && setStateCallParentScope === enclosingMethodScope
+      ) {
+        context.report({
+          messageId: "default",
           node,
-          (n) => n === enclosingClassNode || core.isComponentDidUpdate(n),
-        );
-
-        // Ensure 'this.setState' is inside a 'componentDidUpdate' method within a class component
-        if (enclosingClassNode == null || enclosingMethodNode == null || enclosingMethodNode === enclosingClassNode) {
-          return;
-        }
-
-        // Get the scope of the 'componentDidUpdate' method
-        const enclosingMethodScope = context.sourceCode.getScope(enclosingMethodNode);
-        // Get the scope where 'this.setState' is called
-        const setStateCallParentScope = context.sourceCode.getScope(node).upper;
-
-        // Report an error if 'this.setState' is called directly inside 'componentDidUpdate'
-        if (
-          enclosingMethodNode.parent === enclosingClassNode.body && setStateCallParentScope === enclosingMethodScope
-        ) {
-          context.report({
-            messageId: "default",
-            node,
-          });
-        }
-      },
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-set-state-in-component-will-update";
@@ -29,40 +29,38 @@ export default createRule<[], MessageID>({
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: skip if `componentWillUpdate` is not present in the file
   if (!context.sourceCode.text.includes("componentWillUpdate")) return {};
-  return merge(
-    {
-      CallExpression(node: TSESTree.CallExpression) {
-        if (!core.isThisSetStateCall(node)) {
-          return;
-        }
-        // Find the enclosing class component
-        const enclosingClassNode = Traverse.findParent(node, core.isClassComponent);
-        // Find the enclosing 'componentWillUpdate' method
-        const enclosingMethodNode = Traverse.findParent(
+  return {
+    CallExpression(node: TSESTree.CallExpression) {
+      if (!core.isThisSetStateCall(node)) {
+        return;
+      }
+      // Find the enclosing class component
+      const enclosingClassNode = Traverse.findParent(node, core.isClassComponent);
+      // Find the enclosing 'componentWillUpdate' method
+      const enclosingMethodNode = Traverse.findParent(
+        node,
+        (n) => n === enclosingClassNode || core.isComponentWillUpdate(n),
+      );
+
+      // Ensure 'this.setState' is inside a 'componentWillUpdate' method within a class component
+      if (enclosingClassNode == null || enclosingMethodNode == null || enclosingMethodNode === enclosingClassNode) {
+        return;
+      }
+
+      // Get the scope of the 'componentWillUpdate' method
+      const enclosingMethodScope = context.sourceCode.getScope(enclosingMethodNode);
+      // Get the scope where 'this.setState' is called
+      const setStateCallParentScope = context.sourceCode.getScope(node).upper;
+
+      // Report an error if 'this.setState' is called directly inside 'componentWillUpdate'
+      if (
+        enclosingMethodNode.parent === enclosingClassNode.body && setStateCallParentScope === enclosingMethodScope
+      ) {
+        context.report({
+          messageId: "default",
           node,
-          (n) => n === enclosingClassNode || core.isComponentWillUpdate(n),
-        );
-
-        // Ensure 'this.setState' is inside a 'componentWillUpdate' method within a class component
-        if (enclosingClassNode == null || enclosingMethodNode == null || enclosingMethodNode === enclosingClassNode) {
-          return;
-        }
-
-        // Get the scope of the 'componentWillUpdate' method
-        const enclosingMethodScope = context.sourceCode.getScope(enclosingMethodNode);
-        // Get the scope where 'this.setState' is called
-        const setStateCallParentScope = context.sourceCode.getScope(node).upper;
-
-        // Report an error if 'this.setState' is called directly inside 'componentWillUpdate'
-        if (
-          enclosingMethodNode.parent === enclosingClassNode.body && setStateCallParentScope === enclosingMethodScope
-        ) {
-          context.report({
-            messageId: "default",
-            node,
-          });
-        }
-      },
+        });
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeClass, type TSESTreeMethodOrPropertyDefinition } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { LIFECYCLE_METHODS, type Property, isKeyLiteral } from "./lib";
 
@@ -113,64 +113,62 @@ export function create(context: RuleContext<MessageID, []>) {
     methodStack.pop();
   }
 
-  return merge(
-    {
-      ClassDeclaration: classEnter,
-      "ClassDeclaration:exit": classExit,
-      ClassExpression: classEnter,
-      "ClassExpression:exit": classExit,
-      // Visitor for MemberExpression to track property usages and definitions
-      MemberExpression(node) {
-        const currentClass = classStack.at(-1);
-        const currentMethod = methodStack.at(-1);
-        if (currentClass == null || currentMethod == null) {
-          return;
-        }
-        if (!core.isClassComponent(currentClass) || currentMethod.static) {
-          return;
-        }
-        // Check for expressions like `this.property`
-        if (node.object.type !== AST.ThisExpression || !isKeyLiteral(node, node.property)) {
-          return;
-        }
-        // Detect assignments like `this.property = xxx` as definitions
-        if (node.parent.type === AST.AssignmentExpression && node.parent.left === node) {
-          propertyDefs.get(currentClass)?.add(node.property);
-          return;
-        }
-        // Detect usages like `this.property()` or `x = this.property`
-        const propertyName = Extract.getPropertyName(node.property);
-        if (propertyName != null) {
-          propertyUsages.get(currentClass)?.add(propertyName);
-        }
-      },
-      MethodDefinition: methodEnter,
-      "MethodDefinition:exit": methodExit,
-      PropertyDefinition: methodEnter,
-      "PropertyDefinition:exit": methodExit,
-      // Visitor for VariableDeclarator to track property usages via destructuring
-      VariableDeclarator(node) {
-        const currentClass = classStack.at(-1);
-        const currentMethod = methodStack.at(-1);
-        if (currentClass == null || currentMethod == null) {
-          return;
-        }
-        if (!core.isClassComponent(currentClass) || currentMethod.static) {
-          return;
-        }
-        // Detect destructuring from `this`, e.g., `const { foo, bar } = this;`
-        if (node.init != null && node.init.type === AST.ThisExpression && node.id.type === AST.ObjectPattern) {
-          for (const prop of node.id.properties) {
-            if (prop.type === AST.Property && isKeyLiteral(prop, prop.key)) {
-              const keyName = Extract.getPropertyName(prop.key);
-              if (keyName != null) {
-                // Add destructured properties to the usages set
-                propertyUsages.get(currentClass)?.add(keyName);
-              }
+  return {
+    ClassDeclaration: classEnter,
+    "ClassDeclaration:exit": classExit,
+    ClassExpression: classEnter,
+    "ClassExpression:exit": classExit,
+    // Visitor for MemberExpression to track property usages and definitions
+    MemberExpression(node) {
+      const currentClass = classStack.at(-1);
+      const currentMethod = methodStack.at(-1);
+      if (currentClass == null || currentMethod == null) {
+        return;
+      }
+      if (!core.isClassComponent(currentClass) || currentMethod.static) {
+        return;
+      }
+      // Check for expressions like `this.property`
+      if (node.object.type !== AST.ThisExpression || !isKeyLiteral(node, node.property)) {
+        return;
+      }
+      // Detect assignments like `this.property = xxx` as definitions
+      if (node.parent.type === AST.AssignmentExpression && node.parent.left === node) {
+        propertyDefs.get(currentClass)?.add(node.property);
+        return;
+      }
+      // Detect usages like `this.property()` or `x = this.property`
+      const propertyName = Extract.getPropertyName(node.property);
+      if (propertyName != null) {
+        propertyUsages.get(currentClass)?.add(propertyName);
+      }
+    },
+    MethodDefinition: methodEnter,
+    "MethodDefinition:exit": methodExit,
+    PropertyDefinition: methodEnter,
+    "PropertyDefinition:exit": methodExit,
+    // Visitor for VariableDeclarator to track property usages via destructuring
+    VariableDeclarator(node) {
+      const currentClass = classStack.at(-1);
+      const currentMethod = methodStack.at(-1);
+      if (currentClass == null || currentMethod == null) {
+        return;
+      }
+      if (!core.isClassComponent(currentClass) || currentMethod.static) {
+        return;
+      }
+      // Detect destructuring from `this`, e.g., `const { foo, bar } = this;`
+      if (node.init != null && node.init.type === AST.ThisExpression && node.id.type === AST.ObjectPattern) {
+        for (const prop of node.id.properties) {
+          if (prop.type === AST.Property && isKeyLiteral(prop, prop.key)) {
+            const keyName = Extract.getPropertyName(prop.key);
+            if (keyName != null) {
+              // Add destructured properties to the usages set
+              propertyUsages.get(currentClass)?.add(keyName);
             }
           }
         }
-      },
+      }
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -40,29 +40,27 @@ export function create(context: RuleContext<MessageID, []>) {
   if (compare(version, "19.0.0", "<")) {
     return {};
   }
-  return merge(
-    {
-      CallExpression(node) {
-        if (!core.isUseContextCall(context, node)) return;
-        context.report({
-          messageId: "default",
-          node: node.callee,
-          suggest: [
-            {
-              fix(fixer) {
-                switch (node.callee.type) {
-                  case AST.Identifier:
-                    return fixer.replaceText(node.callee, "use");
-                  case AST.MemberExpression:
-                    return fixer.replaceText(node.callee.property, "use");
-                }
-                return null;
-              },
-              messageId: "replace",
+  return {
+    CallExpression(node) {
+      if (!core.isUseContextCall(context, node)) return;
+      context.report({
+        messageId: "default",
+        node: node.callee,
+        suggest: [
+          {
+            fix(fixer) {
+              switch (node.callee.type) {
+                case AST.Identifier:
+                  return fixer.replaceText(node.callee, "use");
+                case AST.MemberExpression:
+                  return fixer.replaceText(node.callee.property, "use");
+              }
+              return null;
             },
-          ],
-        });
-      },
+            messageId: "replace",
+          },
+        ],
+      });
     },
-  );
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { constVoid, getOrInsertComputed, not } from "@local/eff";
@@ -194,210 +194,208 @@ export function create(context: RuleContext<MessageID, []>) {
     }
   }
 
-  return merge(
-    {
-      ":function"(node: TSESTreeFunction) {
-        const kind = getFunctionKind(node);
-        functionEntries.push({ kind, node });
-        if (kind === "setup") {
-          onSetupFunctionEnter(node);
-        }
-      },
-      ":function:exit"(node: TSESTreeFunction) {
-        const { kind } = functionEntries.at(-1) ?? {};
-        if (kind === "setup") {
-          onSetupFunctionExit(node);
-        }
-        functionEntries.pop();
-      },
-      CallExpression(node) {
-        const setupFunction = setupFnRef.current;
-        const entry = functionEntries.at(-1);
-        if (entry == null || entry.node.async) {
-          return;
-        }
-        match(getCallKind(node))
-          .with("setState", () => {
-            switch (true) {
-              case entry.kind === "deferred":
-              case entry.node.async:
-                // do nothing, this is a deferred setState call
-                break;
-              case entry.node === setupFunction:
-              case entry.kind === "immediate"
-                && Traverse.findParent(entry.node, Check.isFunction) === setupFunction: {
-                const args0 = node.arguments.at(0);
-                // setState() without arguments, which is invalid but other tools will report it
-                if (args0 == null) return;
-                // Check if the setState call is using a ref value, which is safe to use in an effect (ex: `setState(ref.current.scrollTop)`)
-                function isArgumentUsingRefValue(context: RuleContext, node: TSESTree.CallExpressionArgument) {
-                  const isUsingRefValue = (n: TSESTree.Node): boolean => {
-                    switch (n.type) {
-                      case AST.Identifier:
-                        return isInitializedFromRef(context, n.name, context.sourceCode.getScope(n));
-                      case AST.MemberExpression:
-                        return isUsingRefValue(n.object);
-                      case AST.CallExpression:
-                        return isUsingRefValue(n.callee) || getNestedIdentifiers(n).some(isUsingRefValue);
-                      case AST.BinaryExpression:
-                      case AST.LogicalExpression:
-                        return isUsingRefValue(n.left) || isUsingRefValue(n.right);
-                      case AST.UnaryExpression:
-                      case AST.UpdateExpression:
-                        return isUsingRefValue(n.argument);
-                      case AST.ConditionalExpression:
-                        return isUsingRefValue(n.consequent) || isUsingRefValue(n.alternate);
-                      case AST.SequenceExpression:
-                        return n.expressions.some(isUsingRefValue);
-                      case AST.AssignmentExpression:
-                        return isUsingRefValue(n.right);
-                      default:
-                        return false;
-                    }
-                  };
-                  // Case 1: setState(ref.current.scrollTop);
-                  if (isUsingRefValue(node)) return true;
-                  // Case 2: setState(() => ref.current.scrollTop);
-                  return Check.isFunction(node)
-                    && context.sourceCode
-                      .getScope(node.body)
-                      .references
-                      .some((r) => isUsingRefValue(r.identifier));
-                }
-                if (isArgumentUsingRefValue(context, args0)) return;
-                if (isRefGatedContext(context, node)) return;
-                context.report({
-                  data: {
-                    name: context.sourceCode.getText(Extract.unwrap(node.callee)),
-                  },
-                  messageId: "default",
-                  node,
-                });
-                return;
-              }
-              default: {
-                const init = Traverse.findParent(node, isHookDecl)?.init;
-                if (init == null) getOrInsertComputed(setStateCallsByFn, entry.node, () => []).push(node);
-                else getOrInsertComputed(setStateInHookCallbacks, init, () => []).push(node);
-              }
-            }
-          })
-          .with("useEffect", () => {
-            if (Check.isFunction(node.arguments.at(0))) return;
-            setupFnIds.push(...getNestedIdentifiers(node));
-          })
-          .with("other", () => {
-            if (entry.node !== setupFunction) return;
-            trackedFnCalls.push(node);
-          })
-          .otherwise(constVoid);
-      },
-      Identifier(node) {
-        if (node.parent.type === AST.CallExpression && node.parent.callee === node) {
-          return;
-        }
-        if (!isIdFromUseStateCall(node, 1)) {
-          return;
-        }
-        switch (node.parent.type) {
-          case AST.ArrowFunctionExpression: {
-            const parent = node.parent.parent;
-            if (parent.type !== AST.CallExpression) {
+  return {
+    ":function"(node: TSESTreeFunction) {
+      const kind = getFunctionKind(node);
+      functionEntries.push({ kind, node });
+      if (kind === "setup") {
+        onSetupFunctionEnter(node);
+      }
+    },
+    ":function:exit"(node: TSESTreeFunction) {
+      const { kind } = functionEntries.at(-1) ?? {};
+      if (kind === "setup") {
+        onSetupFunctionExit(node);
+      }
+      functionEntries.pop();
+    },
+    CallExpression(node) {
+      const setupFunction = setupFnRef.current;
+      const entry = functionEntries.at(-1);
+      if (entry == null || entry.node.async) {
+        return;
+      }
+      match(getCallKind(node))
+        .with("setState", () => {
+          switch (true) {
+            case entry.kind === "deferred":
+            case entry.node.async:
+              // do nothing, this is a deferred setState call
               break;
+            case entry.node === setupFunction:
+            case entry.kind === "immediate"
+              && Traverse.findParent(entry.node, Check.isFunction) === setupFunction: {
+              const args0 = node.arguments.at(0);
+              // setState() without arguments, which is invalid but other tools will report it
+              if (args0 == null) return;
+              // Check if the setState call is using a ref value, which is safe to use in an effect (ex: `setState(ref.current.scrollTop)`)
+              function isArgumentUsingRefValue(context: RuleContext, node: TSESTree.CallExpressionArgument) {
+                const isUsingRefValue = (n: TSESTree.Node): boolean => {
+                  switch (n.type) {
+                    case AST.Identifier:
+                      return isInitializedFromRef(context, n.name, context.sourceCode.getScope(n));
+                    case AST.MemberExpression:
+                      return isUsingRefValue(n.object);
+                    case AST.CallExpression:
+                      return isUsingRefValue(n.callee) || getNestedIdentifiers(n).some(isUsingRefValue);
+                    case AST.BinaryExpression:
+                    case AST.LogicalExpression:
+                      return isUsingRefValue(n.left) || isUsingRefValue(n.right);
+                    case AST.UnaryExpression:
+                    case AST.UpdateExpression:
+                      return isUsingRefValue(n.argument);
+                    case AST.ConditionalExpression:
+                      return isUsingRefValue(n.consequent) || isUsingRefValue(n.alternate);
+                    case AST.SequenceExpression:
+                      return n.expressions.some(isUsingRefValue);
+                    case AST.AssignmentExpression:
+                      return isUsingRefValue(n.right);
+                    default:
+                      return false;
+                  }
+                };
+                // Case 1: setState(ref.current.scrollTop);
+                if (isUsingRefValue(node)) return true;
+                // Case 2: setState(() => ref.current.scrollTop);
+                return Check.isFunction(node)
+                  && context.sourceCode
+                    .getScope(node.body)
+                    .references
+                    .some((r) => isUsingRefValue(r.identifier));
+              }
+              if (isArgumentUsingRefValue(context, args0)) return;
+              if (isRefGatedContext(context, node)) return;
+              context.report({
+                data: {
+                  name: context.sourceCode.getText(Extract.unwrap(node.callee)),
+                },
+                messageId: "default",
+                node,
+              });
+              return;
             }
-            // const [state, setState] = useState();
-            // const set = useMemo(() => setState, []);
-            // useEffect(set, []);
-            if (!core.isUseMemoCall(context, parent)) {
-              break;
+            default: {
+              const init = Traverse.findParent(node, isHookDecl)?.init;
+              if (init == null) getOrInsertComputed(setStateCallsByFn, entry.node, () => []).push(node);
+              else getOrInsertComputed(setStateInHookCallbacks, init, () => []).push(node);
             }
-            const init = Traverse.findParent(parent, isHookDecl)?.init;
+          }
+        })
+        .with("useEffect", () => {
+          if (Check.isFunction(node.arguments.at(0))) return;
+          setupFnIds.push(...getNestedIdentifiers(node));
+        })
+        .with("other", () => {
+          if (entry.node !== setupFunction) return;
+          trackedFnCalls.push(node);
+        })
+        .otherwise(constVoid);
+    },
+    Identifier(node) {
+      if (node.parent.type === AST.CallExpression && node.parent.callee === node) {
+        return;
+      }
+      if (!isIdFromUseStateCall(node, 1)) {
+        return;
+      }
+      switch (node.parent.type) {
+        case AST.ArrowFunctionExpression: {
+          const parent = node.parent.parent;
+          if (parent.type !== AST.CallExpression) {
+            break;
+          }
+          // const [state, setState] = useState();
+          // const set = useMemo(() => setState, []);
+          // useEffect(set, []);
+          if (!core.isUseMemoCall(context, parent)) {
+            break;
+          }
+          const init = Traverse.findParent(parent, isHookDecl)?.init;
+          if (init != null) {
+            getOrInsertComputed(setStateInEffectArg, init, () => []).push(node);
+          }
+          break;
+        }
+        case AST.CallExpression: {
+          if (node !== node.parent.arguments.at(0)) {
+            break;
+          }
+          // const [state, setState] = useState();
+          // const set = useCallback(setState, []);
+          // useEffect(set, []);
+          if (core.isUseCallbackCall(context, node.parent)) {
+            const init = Traverse.findParent(node.parent, isHookDecl)?.init;
             if (init != null) {
               getOrInsertComputed(setStateInEffectArg, init, () => []).push(node);
             }
             break;
           }
-          case AST.CallExpression: {
-            if (node !== node.parent.arguments.at(0)) {
-              break;
-            }
-            // const [state, setState] = useState();
-            // const set = useCallback(setState, []);
-            // useEffect(set, []);
-            if (core.isUseCallbackCall(context, node.parent)) {
-              const init = Traverse.findParent(node.parent, isHookDecl)?.init;
-              if (init != null) {
-                getOrInsertComputed(setStateInEffectArg, init, () => []).push(node);
-              }
-              break;
-            }
-            // const [state, setState] = useState();
-            // useEffect(setState);
-            if (isUseEffectCall(node.parent)) {
-              getOrInsertComputed(setStateInEffectSetup, node.parent, () => []).push(node);
-            }
+          // const [state, setState] = useState();
+          // useEffect(setState);
+          if (isUseEffectCall(node.parent)) {
+            getOrInsertComputed(setStateInEffectSetup, node.parent, () => []).push(node);
           }
         }
-      },
-      "Program:exit"() {
-        const getSetStateCalls = (
-          context: RuleContext,
-          id: TSESTree.Identifier,
-        ): TSESTree.CallExpression[] | TSESTree.Identifier[] => {
-          const node = resolve(context, id);
-          switch (node?.type) {
-            case AST.ArrowFunctionExpression:
-            case AST.FunctionDeclaration:
-            case AST.FunctionExpression:
-              return setStateCallsByFn.get(node) ?? [];
-            case AST.CallExpression:
-              return setStateInHookCallbacks.get(node) ?? setStateInEffectArg.get(node) ?? [];
-          }
-          return [];
-        };
-        for (const [, calls] of setStateInEffectSetup) {
-          for (const call of calls) {
-            if (isRefGatedContext(context, getSetStateCallExpression(call))) continue;
-            context.report({
-              data: {
-                name: call.name,
-              },
-              messageId: "default",
-              node: call,
-            });
-          }
-        }
-        for (const { callee } of trackedFnCalls) {
-          const unwrappedCallee = Extract.unwrap(callee);
-          if (unwrappedCallee.type !== AST.Identifier) {
-            continue;
-          }
-          const setStateCalls = getSetStateCalls(context, unwrappedCallee);
-          for (const setStateCall of setStateCalls) {
-            if (isRefGatedContext(context, getSetStateCallExpression(setStateCall))) continue;
-            context.report({
-              data: {
-                name: getCallName(setStateCall),
-              },
-              messageId: "default",
-              node: setStateCall,
-            });
-          }
-        }
-        for (const id of setupFnIds) {
-          const setStateCalls = getSetStateCalls(context, id);
-          for (const setStateCall of setStateCalls) {
-            if (isRefGatedContext(context, getSetStateCallExpression(setStateCall))) continue;
-            context.report({
-              data: {
-                name: getCallName(setStateCall),
-              },
-              messageId: "default",
-              node: setStateCall,
-            });
-          }
-        }
-      },
+      }
     },
-  );
+    "Program:exit"() {
+      const getSetStateCalls = (
+        context: RuleContext,
+        id: TSESTree.Identifier,
+      ): TSESTree.CallExpression[] | TSESTree.Identifier[] => {
+        const node = resolve(context, id);
+        switch (node?.type) {
+          case AST.ArrowFunctionExpression:
+          case AST.FunctionDeclaration:
+          case AST.FunctionExpression:
+            return setStateCallsByFn.get(node) ?? [];
+          case AST.CallExpression:
+            return setStateInHookCallbacks.get(node) ?? setStateInEffectArg.get(node) ?? [];
+        }
+        return [];
+      };
+      for (const [, calls] of setStateInEffectSetup) {
+        for (const call of calls) {
+          if (isRefGatedContext(context, getSetStateCallExpression(call))) continue;
+          context.report({
+            data: {
+              name: call.name,
+            },
+            messageId: "default",
+            node: call,
+          });
+        }
+      }
+      for (const { callee } of trackedFnCalls) {
+        const unwrappedCallee = Extract.unwrap(callee);
+        if (unwrappedCallee.type !== AST.Identifier) {
+          continue;
+        }
+        const setStateCalls = getSetStateCalls(context, unwrappedCallee);
+        for (const setStateCall of setStateCalls) {
+          if (isRefGatedContext(context, getSetStateCallExpression(setStateCall))) continue;
+          context.report({
+            data: {
+              name: getCallName(setStateCall),
+            },
+            messageId: "default",
+            node: setStateCall,
+          });
+        }
+      }
+      for (const id of setupFnIds) {
+        const setStateCalls = getSetStateCalls(context, id);
+        for (const setStateCall of setStateCalls) {
+          if (isRefGatedContext(context, getSetStateCallExpression(setStateCall))) continue;
+          context.report({
+            data: {
+              name: getCallName(setStateCall),
+            },
+            messageId: "default",
+            node: setStateCall,
+          });
+        }
+      }
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { not } from "@local/eff";
@@ -120,61 +120,59 @@ export function create(context: RuleContext<MessageID, []>) {
     return "other";
   }
 
-  return merge(
-    {
-      ":function"(node: TSESTreeFunction) {
-        const kind = getFunctionKind(node);
-        functionEntries.push({ kind, node });
-        if (kind === "component") {
-          componentFnRef.current = node;
-          componentHasEarlyReturn.current = false;
-        }
-      },
-      ":function:exit"(node: TSESTreeFunction) {
-        const entry = functionEntries.at(-1);
-        if (entry?.kind === "component" && componentFnRef.current === node) {
-          componentFnRef.current = null;
-          componentHasEarlyReturn.current = false;
-        }
-        functionEntries.pop();
-      },
-      CallExpression(node) {
-        const componentFn = componentFnRef.current;
-        if (componentFn == null) return;
-        if (!isSetStateCall(node)) return;
-        // Allow setState inside nested functions (event handlers, callbacks, etc.)
-        if (isInsideEventHandler(node, componentFn)) return;
-        // Allow setState inside conditional blocks
-        if (isInsideConditional(node, componentFn)) return;
-        // Allow setState after an early return (it is conditionally guarded by the early return)
-        if (componentHasEarlyReturn.current) return;
-        context.report({
-          data: {
-            name: context.sourceCode.getText(Extract.unwrap(node.callee)),
-          },
-          messageId: "default",
-          node,
-        });
-      },
-      ReturnStatement(node: TSESTree.ReturnStatement) {
-        const componentFn = componentFnRef.current;
-        if (componentFn == null) return;
-        // Only track early returns that belong directly to the component function
-        const entry = functionEntries.at(-1);
-        if (entry == null || entry.node !== componentFn) return;
-        if (componentFn.body.type !== AST.BlockStatement) return;
-        const body = componentFn.body.body;
-        // Walk up from the return statement to find the direct child statement of the function body
-        let stmt: TSESTree.Node = node;
-        while (stmt.parent !== componentFn.body) {
-          if (stmt.parent == null) return;
-          stmt = stmt.parent;
-        }
-        const idx = body.indexOf(stmt as TSESTree.Statement);
-        if (idx !== -1 && idx < body.length - 1) {
-          componentHasEarlyReturn.current = true;
-        }
-      },
+  return {
+    ":function"(node: TSESTreeFunction) {
+      const kind = getFunctionKind(node);
+      functionEntries.push({ kind, node });
+      if (kind === "component") {
+        componentFnRef.current = node;
+        componentHasEarlyReturn.current = false;
+      }
     },
-  );
+    ":function:exit"(node: TSESTreeFunction) {
+      const entry = functionEntries.at(-1);
+      if (entry?.kind === "component" && componentFnRef.current === node) {
+        componentFnRef.current = null;
+        componentHasEarlyReturn.current = false;
+      }
+      functionEntries.pop();
+    },
+    CallExpression(node) {
+      const componentFn = componentFnRef.current;
+      if (componentFn == null) return;
+      if (!isSetStateCall(node)) return;
+      // Allow setState inside nested functions (event handlers, callbacks, etc.)
+      if (isInsideEventHandler(node, componentFn)) return;
+      // Allow setState inside conditional blocks
+      if (isInsideConditional(node, componentFn)) return;
+      // Allow setState after an early return (it is conditionally guarded by the early return)
+      if (componentHasEarlyReturn.current) return;
+      context.report({
+        data: {
+          name: context.sourceCode.getText(Extract.unwrap(node.callee)),
+        },
+        messageId: "default",
+        node,
+      });
+    },
+    ReturnStatement(node: TSESTree.ReturnStatement) {
+      const componentFn = componentFnRef.current;
+      if (componentFn == null) return;
+      // Only track early returns that belong directly to the component function
+      const entry = functionEntries.at(-1);
+      if (entry == null || entry.node !== componentFn) return;
+      if (componentFn.body.type !== AST.BlockStatement) return;
+      const body = componentFn.body.body;
+      // Walk up from the return statement to find the direct child statement of the function body
+      let stmt: TSESTree.Node = node;
+      while (stmt.parent !== componentFn.body) {
+        if (stmt.parent == null) return;
+        stmt = stmt.parent;
+      }
+      const idx = body.indexOf(stmt as TSESTree.Statement);
+      if (idx !== -1 && idx < body.length - 1) {
+        componentHasEarlyReturn.current = true;
+      }
+    },
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
@@ -73,7 +73,7 @@ export function create(context: RuleContext<MessageID, []>) {
     });
     return violations;
   }
-  return merge({
+  return {
     CallExpression(node) {
       if (!core.isUseMemoCall(context, node)) return;
 
@@ -165,5 +165,5 @@ export function create(context: RuleContext<MessageID, []>) {
         });
       }
     },
-  });
+  };
 }

--- a/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.ts
@@ -2,7 +2,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -89,7 +89,7 @@ export function create(context: RuleContext<MessageID, Options>) {
     enforceSetterName = true,
   } = options;
   const { additionalStateHooks } = getSettingsFromContext(context);
-  return merge({
+  return {
     CallExpression(node: TSESTree.CallExpression) {
       if (!core.isUseStateLikeCall(node, additionalStateHooks)) return;
 
@@ -162,5 +162,5 @@ export function create(context: RuleContext<MessageID, Options>) {
         context.report({ messageId: "invalidSetterName", node: setter });
       }
     },
-  });
+  };
 }


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Refactor

### Does this PR introduce a breaking change?

- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Removes redundant `merge()` wrapper calls that only accepted a single argument. The `merge()` utility is meant for combining multiple visitor objects; when passed only one object, it is a no-op. This change simplifies 64 rule files across all plugins while preserving behavior.