### PR TITLE
test: add identifier resolution tests for no-leaked-conditional-rendering

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.spec.ts
@@ -232,6 +232,61 @@ ruleTesterWithTypes.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: "default" }],
     },
+    // Test case for identifier chain referencing a leaked conditional rendering value
+    {
+      code: tsx`
+        /// <reference types="react" />
+        /// <reference types="react-dom" />
+
+        const x = "";
+        const a = x && <Foo />;
+        const b = a;
+        const c = <>{true && b}</>;
+      `,
+      errors: [{ messageId: "default" }],
+      settings: {
+        "react-x": {
+          version: "17.0.0",
+        },
+      },
+    },
+    // Test case for multi-level identifier chain referencing a leaked value
+    {
+      code: tsx`
+        /// <reference types="react" />
+        /// <reference types="react-dom" />
+
+        const x = "";
+        const a = x && <Foo />;
+        const b = a;
+        const c = b;
+        const d = <>{true && c}</>;
+      `,
+      errors: [{ messageId: "default" }],
+      settings: {
+        "react-x": {
+          version: "17.0.0",
+        },
+      },
+    },
+    // Test case for identifier in ternary branch referencing a leaked value
+    {
+      code: tsx`
+        /// <reference types="react" />
+        /// <reference types="react-dom" />
+
+        const x = "";
+        const a = x && <Foo />;
+        const b = a;
+        const c = <>{true ? b : null}</>;
+      `,
+      errors: [{ messageId: "default" }],
+      settings: {
+        "react-x": {
+          version: "17.0.0",
+        },
+      },
+    },
   ],
   valid: [
     tsx`
@@ -785,5 +840,43 @@ ruleTesterWithTypes.run(RULE_NAME, rule, {
         },
       },
     },
+    // Test cases for identifier resolution with safe values
+    tsx`
+      /// <reference types="react" />
+      /// <reference types="react-dom" />
+
+      const x = true;
+      const a = x && <Foo />;
+      const b = a;
+      const c = <>{true && b}</>;
+    `,
+    // Test case for uninitialized identifier
+    tsx`
+      /// <reference types="react" />
+      /// <reference types="react-dom" />
+
+      let x;
+      const a = x;
+      const b = <>{true && a}</>;
+    `,
+    // Test case for identifier referencing a safe function parameter
+    tsx`
+      /// <reference types="react" />
+      /// <reference types="react-dom" />
+
+      const App = ({ cond }: { cond: boolean }) => {
+        const a = cond;
+        return <>{true && a}</>;
+      };
+    `,
+    // Test case for cyclic identifier references (should not cause infinite recursion)
+    tsx`
+      /// <reference types="react" />
+      /// <reference types="react-dom" />
+
+      const a = b;
+      const b = a;
+      const c = <>{true && a}</>;
+    `,
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.ts
@@ -39,6 +39,8 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
+// TODO: Evaluate whether it's possible to directly inspect type variants of `node.expression` within a JSX expression container to improve coverage.
+// This is currently not implemented to reduce false positives.
 export function create(context: RuleContext<MessageID, []>) {
   // Fast path: if the file does not contain '&&', there is no need to run this rule
   if (!context.sourceCode.text.includes("&&")) return {};


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Test

### Does this PR introduce a breaking change?

- [x] No

### Checklist

- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Adds 7 focused test cases covering the identifier resolution fallback logic in `no-leaked-conditional-rendering`:

**Invalid (3):**
- Identifier chain referencing a leaked conditional rendering value
- Multi-level identifier chain referencing a leaked value
- Identifier in ternary branch referencing a leaked value

**Valid (4):**
- Identifier resolution with safe values
- Uninitialized identifier
- Identifier referencing a safe function parameter
- Cyclic identifier references (infinite recursion guard)