### PR TITLE
refactor: add RuleListener return type to all rule create functions

### DIFF
--- a/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/function-component/function-component.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "function-component";
 
@@ -28,7 +28,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { api, visitor } = core.getFunctionComponentCollector(
     context,
     {

--- a/plugins/eslint-plugin-react-debug/src/rules/hook/hook.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/hook/hook.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "hook";
 
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { api, visitor } = core.getHookCollector(context);
 
   return merge(

--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-react/is-from-react.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { isFromReact } from "./lib";
@@ -29,7 +29,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { importSource } = getSettingsFromContext(context);
 
   function visitorFunction(node: TSESTree.Identifier | TSESTree.JSXIdentifier) {

--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/is-from-ref.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { type TSESTree } from "@typescript-eslint/types";
 import { getRefInitNode } from "./lib";
 
@@ -28,7 +28,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   function visitorFunction(node: TSESTree.Identifier | TSESTree.JSXIdentifier) {
     const initialScope = context.sourceCode.getScope(node);
     const refInit = getRefInitNode(context, node, initialScope);

--- a/plugins/eslint-plugin-react-debug/src/rules/jsx/jsx.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/jsx/jsx.ts
@@ -2,7 +2,7 @@ import { createRule } from "@/utils/create-rule";
 import { stringify } from "@/utils/stringify";
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getElementFullType, isFragmentElement } from "@eslint-react/jsx";
 import { flow } from "@local/eff";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
@@ -34,7 +34,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const jsxConfig = core.getJsxConfig(context);
 
   function getReportDescriptor(_: RuleContext) {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children/no-dangerously-set-innerhtml-with-children.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml-with-children/no-dangerously-set-innerhtml-with-children.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute, hasAttribute, isWhitespace } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-dangerously-set-innerhtml-with-children";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
 
 const DSIH = "dangerouslySetInnerHTML";
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: if the file doesn't contain `dangerouslySetInnerHTML`, we don't need to do anything
   if (!context.sourceCode.text.includes(DSIH)) {
     return {};

--- a/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml/no-dangerously-set-innerhtml.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-dangerously-set-innerhtml/no-dangerously-set-innerhtml.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-dangerously-set-innerhtml";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `dangerouslySetInnerHTML` is not present in the file
   if (!context.sourceCode.text.includes(DSIH)) return {};
   return {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-find-dom-node";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
 
 const findDOMNode = "findDOMNode";
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `findDOMNode` is not present in the file
   if (!context.sourceCode.text.includes(findDOMNode)) return {};
   return {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-flush-sync";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
 
 const flushSync = "flushSync";
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `flushSync` is not present in the file
   if (!context.sourceCode.text.includes(flushSync)) return {};
   return {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleFixer, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -32,7 +32,7 @@ export default createRule<[], MessageID>({
 
 const hydrate = "hydrate";
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `hydrate` is not present in the file
   if (!context.sourceCode.text.includes(hydrate)) return {};
   const settings = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-button-type/no-missing-button-type.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { hasAttribute } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-missing-button-type";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const resolver = createJsxElementResolver(context);
 
   return {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-missing-iframe-sandbox/no-missing-iframe-sandbox.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute, resolveAttributeValue } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-missing-iframe-sandbox";
@@ -32,7 +32,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const resolver = createJsxElementResolver(context);
 
   return {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-render-return-value";
@@ -40,7 +40,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Sets to track imported names for 'ReactDOM' and 'render'
   const reactDomNames = new Set<string>(["ReactDOM", "ReactDOM"]);
   const renderNames = new Set<string>();

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleFixer, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -30,7 +30,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `render` is not present in the file
   if (!context.sourceCode.text.includes("render")) return {};
   const settings = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-script-url/no-script-url.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { resolveAttributeValue } from "@eslint-react/jsx";
 import { RE_JAVASCRIPT_PROTOCOL } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXAttribute(node) {
       if (node.name.type !== AST.JSXIdentifier || node.value == null) return;

--- a/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-string-style-prop/no-string-style-prop.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute, isHostElement, resolveAttributeValue } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-string-style-prop";
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXElement(node) {
       // This rule only applies to host elements (ex: <div />, <span />), not custom components

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unknown-property/no-unknown-property.ts
@@ -1,6 +1,6 @@
 // Ported from https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unknown-property.js
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import {
   getAttributeTagsMap,
   getStandardName,
@@ -101,7 +101,7 @@ export default createRule({
  * @param context ESLint rule context
  * @returns Rule listener
  */
-export function create(context: RuleContext<MessageID, Options[]>) {
+export function create(context: RuleContext<MessageID, Options[]>): RuleListener {
   /**
    * Gets the ignore configuration from rule options
    * @returns Array of attribute names to ignore

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-iframe-sandbox/no-unsafe-iframe-sandbox.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute, resolveAttributeValue } from "@eslint-react/jsx";
 import { isUnsafeSandboxCombination } from "./lib";
 
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const resolver = createJsxElementResolver(context);
 
   return {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank/no-unsafe-target-blank.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-unsafe-target-blank/no-unsafe-target-blank.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute, getAttributeStaticValue } from "@eslint-react/jsx";
 import type { TSESTree } from "@typescript-eslint/types";
 import { isExternalLinkLike, isSafeRel } from "./lib";
@@ -34,7 +34,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const resolver = createJsxElementResolver(context);
 
   return {

--- a/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleFixer, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -30,7 +30,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `useFormState` is not present in the file
   if (!context.sourceCode.text.includes("useFormState")) return {};
   const settings = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children/no-void-elements-with-children.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-void-elements-with-children/no-void-elements-with-children.ts
@@ -1,6 +1,6 @@
 import { createJsxElementResolver } from "@/utils/create-jsx-element-resolver";
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { hasAnyAttribute } from "@eslint-react/jsx";
 import { VOID_ELEMENTS } from "./lib";
 
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const resolver = createJsxElementResolver(context);
 
   return {

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop-with-children/no-children-prop-with-children.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute, hasChildren } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { findChildrenProperty, getChildrenContentRange, getPropRemovalRange } from "./lib";
@@ -37,7 +37,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
       if (!core.isCreateElementCall(context, node)) return;

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-children-prop/no-children-prop.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { findAttribute } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { findChildrenProperty, getChildrenPropText, getPropRemovalRange } from "./lib";
@@ -34,7 +34,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
       if (!core.isCreateElementCall(context, node)) return;

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-comment-textnodes/no-comment-textnodes.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-comment-textnodes/no-comment-textnodes.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, isOneOf } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-comment-textnodes";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   function hasCommentLike(node: TSESTree.JSXText | TSESTree.Literal) {
     // If the node is within a JSX attribute or expression container, it's not a text node comment
     if (isOneOf([AST.JSXAttribute, AST.JSXExpressionContainer])(node.parent)) {

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-key-after-spread/no-key-after-spread.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import ts from "typescript";
 
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { jsx } = core.getJsxConfig(context);
 
   const isAutomaticRuntime = jsx === ts.JsxEmit.ReactJSX || jsx === ts.JsxEmit.ReactJSXDev;

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-dollar/no-leaked-dollar.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-dollar/no-leaked-dollar.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import type { TSESTreeJSXElementLike } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-leaked-dollar";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   /**
    * Visitor function for JSXElement and JSXFragment nodes
    * @param node The JSXElement or JSXFragment node to be checked

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-semicolon/no-leaked-semicolon.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-leaked-semicolon/no-leaked-semicolon.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-leaked-semicolon";
@@ -36,7 +36,7 @@ function hasLeakedSemicolon(text: string) {
   return text.startsWith(";\n") || text.startsWith(";\r");
 }
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const visitorFunction = (node: TSESTree.JSXText | TSESTree.Literal) => {
     if (!Check.isJSXElementOrFragment(node.parent)) {
       return;

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-namespace/no-namespace.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-namespace/no-namespace.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getElementFullType } from "@eslint-react/jsx";
 
 export const RULE_NAME = "no-namespace";
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     JSXElement(node) {
       const name = getElementFullType(node);

--- a/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.ts
+++ b/plugins/eslint-plugin-react-jsx/src/rules/no-useless-fragment/no-useless-fragment.ts
@@ -1,7 +1,13 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, type TSESTreeJSXElementLike } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, type RuleFix, type RuleFixer } from "@eslint-react/eslint";
+import {
+  type RuleContext,
+  type RuleFeature,
+  type RuleFix,
+  type RuleFixer,
+  type RuleListener,
+} from "@eslint-react/eslint";
 import {
   collapseMultilineText,
   getChildren,
@@ -67,7 +73,7 @@ export default createRule<Options, MessageID>({
   defaultOptions,
 });
 
-export function create(context: RuleContext<MessageID, Options>, [option]: Options) {
+export function create(context: RuleContext<MessageID, Options>, [option]: Options): RuleListener {
   const { allowEmptyFragment = false, allowExpressions = true } = option;
   const jsxConfig = core.getJsxConfig(context);
 

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/context-name/context-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
@@ -28,7 +28,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `createContext` is not present in the file
   if (!context.sourceCode.text.includes("createContext")) return {};
   return {

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/id-name/id-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("useId")) return {};
   return {
     CallExpression(node: TSESTree.CallExpression) {

--- a/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/rules/ref-name/ref-name.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, match } from "ts-pattern";
@@ -28,7 +28,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("useRef")) return {};
   return {
     CallExpression(node: TSESTree.CallExpression) {

--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
@@ -1,7 +1,13 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type ReportFixFunction, type RuleContext, type RuleFeature, type RuleFixer } from "@eslint-react/eslint";
+import {
+  type ReportFixFunction,
+  type RuleContext,
+  type RuleFeature,
+  type RuleFixer,
+  type RuleListener,
+} from "@eslint-react/eslint";
 import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
@@ -47,7 +53,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hasUseServer = context.sourceCode.text.includes("use server");
   const hasUseClient = context.sourceCode.text.includes("use client");
 

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
@@ -7,7 +7,7 @@ import {
 import { createRule } from "@/utils/create-rule";
 import { Check, Compare, Extract, type TSESTreeFunction } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { isValueEqual } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, isMatching, match } from "ts-pattern";
@@ -81,7 +81,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `addEventListener` is not present in the file
   if (!context.sourceCode.text.includes("addEventListener")) {
     return {};

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findProperty, resolveToObjectExpression } from "./lib";
@@ -135,7 +135,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `fetch` is not present in the file
   if (!context.sourceCode.text.includes("fetch")) return {};
   if (!/use\w*Effect/u.test(context.sourceCode.text)) return {};

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-interval/no-leaked-interval.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, type TimerEntry, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeFunction } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, isMatching } from "ts-pattern";
@@ -68,7 +68,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `setInterval` is not present in the file
   if (!context.sourceCode.text.includes("setInterval")) {
     return {};

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, type ObserverEntry, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { or } from "@local/eff";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -81,7 +81,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `ResizeObserver` is not present in the file
   if (!context.sourceCode.text.includes("ResizeObserver")) {
     return {};

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-timeout/no-leaked-timeout.ts
@@ -1,7 +1,7 @@
 import { type ComponentPhaseKind, ComponentPhaseRelevance, type TimerEntry, getPhaseKindOfFunction } from "@/types";
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeFunction } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { P, isMatching } from "ts-pattern";
@@ -66,7 +66,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `setTimeout` is not present in the file
   if (!context.sourceCode.text.includes("setTimeout")) {
     return {};

--- a/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/error-boundaries/error-boundaries.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "error-boundaries";
@@ -53,7 +53,7 @@ function getEnclosingTryBlock(node: TSESTree.Node): TSESTree.TryStatement | null
   return null;
 }
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `try` is not present in the file
   if (!context.sourceCode.text.includes("try")) return {};
 

--- a/plugins/eslint-plugin-react-x/src/rules/globals/globals.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/globals/globals.ts
@@ -2,7 +2,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { ScopeType } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
@@ -41,7 +41,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hc = core.getHookCollector(context);
   const fc = core.getFunctionComponentCollector(context);
 

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { DefinitionType } from "@typescript-eslint/scope-manager";
@@ -41,7 +41,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { additionalStateHooks } = getSettingsFromContext(context);
 
   const hc = core.getHookCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeMethodOrPropertyDefinition } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { constFalse, constTrue } from "@local/eff";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { match } from "ts-pattern";
@@ -43,7 +43,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `setState` is not present in the file
   if (!context.sourceCode.text.includes("setState")) {
     return {};

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
 import { isMatching } from "ts-pattern";
@@ -29,7 +29,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // A stack to keep track of index parameter names from nested map calls
   const indexParamNames: Array<string | null> = [];
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-count";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
       if (core.isChildrenCount(context, node)) {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-for-each";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
       if (core.isChildrenForEach(context, node)) {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-map";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
       if (core.isChildrenMap(context, node)) {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-only";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
       if (core.isChildrenOnly(context, node)) {

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-children-to-array";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     MemberExpression(node) {
       if (core.isChildrenToArray(context, node)) {

--- a/plugins/eslint-plugin-react-x/src/rules/no-class-component/no-class-component.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-class-component/no-class-component.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-class-component";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `Component` is not present in the file
   if (!context.sourceCode.text.includes("Component")) return {};
   const { api, visitor } = core.getClassComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-clone-element";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     CallExpression(node) {
       if (core.isCloneElementCall(context, node)) {

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount/no-component-will-mount.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-mount/no-component-will-mount.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-component-will-mount";
 
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `componentWillMount` is not present in the file
   if (!context.sourceCode.text.includes("componentWillMount")) return {};
   const { api, visitor } = core.getClassComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props/no-component-will-receive-props.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-receive-props/no-component-will-receive-props.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-component-will-receive-props";
 
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `componentWillReceiveProps` is not present in the file
   if (!context.sourceCode.text.includes("componentWillReceiveProps")) return {};
   const { api, visitor } = core.getClassComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-component-will-update/no-component-will-update.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-component-will-update/no-component-will-update.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-component-will-update";
 
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `componentWillUpdate` is not present in the file
   if (!context.sourceCode.text.includes("componentWillUpdate")) return {};
   const { api, visitor } = core.getClassComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-context-provider/no-context-provider.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getElementFullType } from "@eslint-react/jsx";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { compare } from "compare-versions";
@@ -32,7 +32,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `Provider` is not present in the file
   if (!context.sourceCode.text.includes("Provider")) return {};
   const { version } = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-create-ref/no-create-ref.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-create-ref/no-create-ref.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-create-ref";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("createRef")) return {};
 
   const fc = core.getFunctionComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Traverse, isOneOf } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-direct-mutation-state";
@@ -35,7 +35,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   return {
     AssignmentExpression(node: TSESTree.AssignmentExpression) {
       if (!core.isAssignmentToThisState(node)) return;

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Compare, Extract, Traverse } from "@eslint-react/ast";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-duplicate-key";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `key=` is not present in the file
   if (!context.sourceCode.text.includes("key=")) return {};
   // Map to store key attributes grouped by their parent node

--- a/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { RuleFix, RuleFixer } from "@typescript-eslint/utils/ts-eslint";
@@ -35,7 +35,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `forwardRef` is not present in the file
   if (!context.sourceCode.text.includes("forwardRef")) {
     return {};

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { unionConstituents } from "ts-api-utils";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const services = ESLintUtils.getParserServices(context, false);
   const checker = services.program.getTypeChecker();
   return {

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { unionConstituents } from "ts-api-utils";
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const services = ESLintUtils.getParserServices(context, false);
   const checker = services.program.getTypeChecker();
   return {

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
 import { ESLintUtils } from "@typescript-eslint/utils";
 import { unionConstituents } from "ts-api-utils";
@@ -33,7 +33,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const services = ESLintUtils.getParserServices(context, false);
   const checker = services.program.getTypeChecker();
   return {

--- a/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-leaked-conditional-rendering/no-leaked-conditional-rendering.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, is } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { flow } from "@local/eff";
 import { getConstrainedTypeAtLocation } from "@typescript-eslint/type-utils";
@@ -39,7 +39,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: if the file does not contain '&&', there is no need to run this rule
   if (!context.sourceCode.text.includes("&&")) return {};
   const { version } = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name/no-missing-component-display-name.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-component-display-name/no-missing-component-display-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-missing-component-display-name";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `memo` or `forwardRef` is not present in the file
   if (!context.sourceCode.text.includes("memo") && !context.sourceCode.text.includes("forwardRef")) return {};
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-context-display-name/no-missing-context-display-name.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { isAssignmentTargetEqual, resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
@@ -29,7 +29,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: if 'createContext' is not in the file, this rule doesn't apply
   if (!context.sourceCode.text.includes("createContext")) return {};
   // Stores all `React.createContext` call expressions

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeJSXElementLike, is } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { hasAttribute } from "@eslint-react/jsx";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
@@ -32,7 +32,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   type Descriptor = ReportDescriptor<MessageID> & { node: TSESTreeJSXElementLike };
 
   let inChildrenToArray = false;

--- a/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { isDevelopmentOnlyCheck } from "./lib";
@@ -35,7 +35,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `captureOwnerStack` is not present in the file
   if (!context.sourceCode.text.includes("captureOwnerStack")) return {};
   const { importSource } = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/no-nested-component-definitions.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/no-nested-component-definitions.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { isInsideCreateElementProps, isInsideJSXAttributeValue, isInsideRenderMethod } from "./lib";
 
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Configuration hints to optimize component detection accuracy and performance
   const hint = core.FunctionComponentDetectionHint.DoNotIncludeJsxWithNumberValue
     | core.FunctionComponentDetectionHint.DoNotIncludeJsxWithBooleanValue

--- a/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations/no-nested-lazy-component-declarations.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-nested-lazy-component-declarations/no-nested-lazy-component-declarations.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-nested-lazy-component-declarations";
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const fc = core.getFunctionComponentCollector(context);
   const cc = core.getClassComponentCollector(context);
   const hc = core.getHookCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-mount/no-set-state-in-component-did-mount.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-set-state-in-component-did-mount";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `componentDidMount` is not present in the file
   if (!context.sourceCode.text.includes("componentDidMount")) return {};
   return {

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-did-update/no-set-state-in-component-did-update.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-set-state-in-component-did-update";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `componentDidUpdate` is not present in the file
   if (!context.sourceCode.text.includes("componentDidUpdate")) return {};
   return {

--- a/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-set-state-in-component-will-update/no-set-state-in-component-will-update.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import type { TSESTree } from "@typescript-eslint/types";
 
 export const RULE_NAME = "no-set-state-in-component-will-update";
@@ -26,7 +26,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `componentWillUpdate` is not present in the file
   if (!context.sourceCode.text.includes("componentWillUpdate")) return {};
   return {

--- a/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/no-unnecessary-use-prefix.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/no-unnecessary-use-prefix.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { WELL_KNOWN_HOOKS, containsUseComments, isTestMockCallback } from "./lib";
 
 export const RULE_NAME = "no-unnecessary-use-prefix";
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { api, visitor } = core.getHookCollector(context);
 
   return merge(visitor, {

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount/no-unsafe-component-will-mount.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-mount/no-unsafe-component-will-mount.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-unsafe-component-will-mount";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `UNSAFE_componentWillMount` is not present in the file
   if (!context.sourceCode.text.includes("UNSAFE_componentWillMount")) return {};
   const { api, visitor } = core.getClassComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props/no-unsafe-component-will-receive-props.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-receive-props/no-unsafe-component-will-receive-props.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-unsafe-component-will-receive-props";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `UNSAFE_componentWillReceiveProps` is not present in the file
   if (!context.sourceCode.text.includes("UNSAFE_componentWillReceiveProps")) return {};
   const { api, visitor } = core.getClassComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update/no-unsafe-component-will-update.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unsafe-component-will-update/no-unsafe-component-will-update.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 
 export const RULE_NAME = "no-unsafe-component-will-update";
 
@@ -24,7 +24,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `UNSAFE_componentWillUpdate` is not present in the file
   if (!context.sourceCode.text.includes("UNSAFE_componentWillUpdate")) return {};
   const { api, visitor } = core.getClassComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-context-value/no-unstable-context-value.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { getElementFullType } from "@eslint-react/jsx";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { type ObjectType, computeObjectType } from "@eslint-react/var";
@@ -34,7 +34,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { compilationMode, version } = getSettingsFromContext(context);
   if (compilationMode === "infer" || compilationMode === "all") return {};
   if (compilationMode === "annotation" && context.sourceCode.ast.body.some(Check.isDirective("use memo"))) return {};

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { getSettingsFromContext, toRegExp } from "@eslint-react/shared";
 import { computeObjectType } from "@eslint-react/var";
 import { getOrInsertComputed } from "@local/eff";
@@ -80,7 +80,7 @@ function extractIdentifier(node: TSESTree.Node): string | null {
   return null;
 }
 
-export function create(context: RuleContext<MessageID, Options>, [options]: Options) {
+export function create(context: RuleContext<MessageID, Options>, [options]: Options): RuleListener {
   const { compilationMode } = getSettingsFromContext(context);
   if (compilationMode === "infer" || compilationMode === "all") return {};
   if (compilationMode === "annotation" && context.sourceCode.ast.body.some(Check.isDirective("use memo"))) return {};

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-class-component-members/no-unused-class-component-members.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Extract, type TSESTreeClass, type TSESTreeMethodOrPropertyDefinition } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { LIFECYCLE_METHODS, type Property, isKeyLiteral } from "./lib";
 
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // A stack to keep track of class nodes, to handle nested classes
   const classStack: TSESTreeClass[] = [];
   // A stack to keep track of method/property nodes

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { ESLintUtils, type ParserServicesWithTypeInformation } from "@typescript-eslint/utils";
 import type ts from "typescript";
@@ -28,7 +28,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const services = ESLintUtils.getParserServices(context, false);
   const checker = services.program.getTypeChecker();
   const { api, visitor } = core.getFunctionComponentCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
@@ -27,7 +27,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { additionalStateHooks } = getSettingsFromContext(context);
   const stateEntries: { name: string; node: TSESTree.Identifier }[] = [];
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-use-context/no-use-context.ts
@@ -1,6 +1,6 @@
 import { createRule } from "@/utils/create-rule";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 import { compare } from "compare-versions";
@@ -32,7 +32,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   // Fast path: skip if `useContext` is not present in the file
   if (!context.sourceCode.text.includes("useContext")) return {};
   const { version } = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { DefinitionType } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
@@ -78,7 +78,7 @@ function resolveBuiltinObjectName(
   return null;
 }
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hc = core.getHookCollector(context);
   const fc = core.getFunctionComponentCollector(context);
   const cEntries: {

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { match } from "ts-pattern";
 import { isInNullCheckTest, isInitializedFromRef, isRefCurrentNullCheck } from "./lib";
@@ -46,7 +46,7 @@ function resolveAlias(name: string, aliases: Map<string, string>): string {
   return name;
 }
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hc = core.getHookCollector(context);
   const fc = core.getFunctionComponentCollector(context);
 

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { constVoid, getOrInsertComputed, not } from "@local/eff";
@@ -54,7 +54,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!/use\w*Effect/u.test(context.sourceCode.text)) return {};
 
   const { additionalEffectHooks, additionalStateHooks } = getSettingsFromContext(context);

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { not } from "@local/eff";
@@ -40,7 +40,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const { additionalStateHooks } = getSettingsFromContext(context);
   const functionEntries: { kind: FunctionKind; node: TSESTreeFunction }[] = [];
   const componentFnRef: { current: TSESTreeFunction | null } = { current: null };

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { findVariableForIdentifier, getDynamicComponentSource } from "./lib";
 
@@ -31,7 +31,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hint = core.FunctionComponentDetectionHint.DoNotIncludeJsxWithNumberValue
     | core.FunctionComponentDetectionHint.DoNotIncludeJsxWithBooleanValue
     | core.FunctionComponentDetectionHint.DoNotIncludeJsxWithNullValue

--- a/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/unsupported-syntax.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature, merge } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { type TSESTree } from "@typescript-eslint/types";
 import { isEvalCall, isIifeCall } from "./lib";
 
@@ -35,7 +35,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hc = core.getHookCollector(context);
   const fc = core.getFunctionComponentCollector(context);
   const evalCalls: {

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
@@ -1,7 +1,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Extract, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
 import { findVariable } from "@typescript-eslint/utils/ast-utils";
@@ -44,7 +44,7 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-export function create(context: RuleContext<MessageID, []>) {
+export function create(context: RuleContext<MessageID, []>): RuleListener {
   if (!context.sourceCode.text.includes("useMemo")) return {};
 
   function validateNoOuterVariableReassignment(callback: TSESTree.FunctionLike): ReportDescriptor<MessageID>[] {

--- a/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-state/use-state.ts
@@ -2,7 +2,7 @@
 import { createRule } from "@/utils/create-rule";
 import { Check, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
-import { type RuleContext, type RuleFeature } from "@eslint-react/eslint";
+import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolveEnclosingAssignmentTarget } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -81,7 +81,7 @@ export default createRule<Options, MessageID>({
   defaultOptions,
 });
 
-export function create(context: RuleContext<MessageID, Options>) {
+export function create(context: RuleContext<MessageID, Options>): RuleListener {
   const options = context.options[0] ?? defaultOptions[0];
   const {
     enforceAssignment = true,


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Adds explicit `RuleListener` return type annotations to all `export function create` functions across the plugin rules for improved type safety and consistency.