### PR TITLE
docs(website): add under construction callouts and refine pages

### DIFF
--- a/apps/website/CHANGELOG.md
+++ b/apps/website/CHANGELOG.md
@@ -6,8 +6,12 @@ All notable changes to the `apps/website` documentation and its content.
 
 ### 📝 Documentation
 
+- Added "Under Construction" callouts to documentation pages still in development (`community.mdx`, `contributing.mdx`, `diagrams.mdx`, `examples.mdx`, `packages/index.mdx`, `recipes/index.mdx`, `removed.md`, `roadmap.md`).
 - Added missing inline table of contents to `contributing.mdx`.
+- Refactored `packages/index.mdx` to focus on utility packages for building custom rules, replacing the full monorepo package listing with a card-based layout highlighting `@eslint-react/kit` and adding external resources.
+- Refactored `recipes/index.mdx` to use card-based layouts instead of tables for recipe listings.
 - Removed `no-multiple-children-in-title` recipe; the same check can be enforced by leveraging type system to restrict the `children` type accepted by `<title>` components. (Consider suggesting an update to the `<title>` children type definition in `@types/react` or `@types/react-dom`.)
+- Removed the `℞` prefix from recipe titles across the recipes section for cleaner headings.
 - Reworked the **Brand Assets** documentation page: removed the **Icons** section, added an under-construction callout, and migrated the page from `.md` back to `.mdx`; hidden from navigation (`!brand-assets`) pending completion.
 - Updated `kit.mdx` callout example and AST explanation.
 - Updated default React fallback version references to `19.2.7` across analyzer and kit docs (#1827).

--- a/apps/website/content/docs/community.mdx
+++ b/apps/website/content/docs/community.mdx
@@ -7,6 +7,10 @@ import { BskyPost } from "@/components/BskyPost";
 import { GitHubRepoGrid } from "@/components/GitHubRepoGrid";
 import { projects, presets } from "./community.tsx";
 
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
+
 ## OSS Projects Using ESLint React
 
 <GitHubRepoGrid repos={projects} />

--- a/apps/website/content/docs/configuration/configure-analyzer.mdx
+++ b/apps/website/content/docs/configuration/configure-analyzer.mdx
@@ -54,7 +54,7 @@ This allows rules to align their behavior with the React Compiler's optimization
 
 ## Advanced Configuration
 
-<Callout type="warning">
+<Callout type="warn">
   The basic configuration is sufficient for most projects. Over-reliance on advanced configuration options will reduce the portability of your code across different tooling ecosystems.
 </Callout>
 

--- a/apps/website/content/docs/configuration/configure-project-config.mdx
+++ b/apps/website/content/docs/configuration/configure-project-config.mdx
@@ -30,7 +30,7 @@ The following rules require type information:
 - [`react-x/no-leaked-conditional-rendering`](/docs/rules/no-leaked-conditional-rendering)
 - [`react-x/no-unused-props`](/docs/rules/no-unused-props)
 
-<Callout type="warning">
+<Callout type="warn">
   Some rules, such as `react-x/no-leaked-conditional-rendering`, work better when certain TypeScript compiler options are enabled. We recommend enabling `strictNullChecks` in your `tsconfig.json` or `jsconfig.json`:
 
   ```json

--- a/apps/website/content/docs/configuration/configure-project-rules.mdx
+++ b/apps/website/content/docs/configuration/configure-project-rules.mdx
@@ -4,7 +4,7 @@ title: "Configure Project Rules"
 
 Configure [Project Rules](/docs/glossary#project-rules) using `@eslint-react/kit`.
 
-<Callout type="warning">
+<Callout type="warn">
   This module is currently in **beta**. APIs may change in future releases.
 </Callout>
 

--- a/apps/website/content/docs/contributing.mdx
+++ b/apps/website/content/docs/contributing.mdx
@@ -6,6 +6,10 @@ full: true
 
 import { InlineTOC } from "fumadocs-ui/components/inline-toc";
 
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
+
 Contributions are welcome!
 
 This project does not have contributing guidelines. Explore the repository to learn how to contribute.

--- a/apps/website/content/docs/diagrams.mdx
+++ b/apps/website/content/docs/diagrams.mdx
@@ -10,6 +10,10 @@ import {
 } from "./diagrams.tsx";
 import { InlineTOC } from "fumadocs-ui/components/inline-toc";
 
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
+
 <InlineTOC items={toc}>Table of Contents</InlineTOC>
 
 ## Function Component Collector Sequence

--- a/apps/website/content/docs/examples.mdx
+++ b/apps/website/content/docs/examples.mdx
@@ -3,6 +3,10 @@ title: Examples
 description: Start quickly from ready-to-use ESLint React example projects
 ---
 
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
+
 ## Example Projects
 
 If you prefer to start from a working setup, you can use one of the official example projects:

--- a/apps/website/content/docs/faq.mdx
+++ b/apps/website/content/docs/faq.mdx
@@ -65,7 +65,7 @@ For users who use the presets we provide (such as `recommended` or `strict`), it
 
 For users who need more fine-grained control or build and maintain an ESLint configuration for themselves or their organization, it is recommended to use individual plugins. This allows you to freely select plugins and compose rules as needed, without being limited by presets.
 
-<Callout type="warning">
+<Callout type="warn">
   The unified plugin (`@eslint-react/eslint-plugin`) contains some historical decisions and internal behaviors that were originally made to be compatible with both [Legacy Config](https://eslint.org/docs/v8.x/use/configure/configuration-files) and [Flat Config](https://eslint.org/docs/v8.x/use/configure/configuration-files-new). Reducing external package dependencies on it is better in the long run.
 </Callout>
 

--- a/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
+++ b/apps/website/content/docs/migrating-from-eslint-plugin-react.mdx
@@ -18,7 +18,7 @@ ESLint React is a collection of ESLint plugins and utilities for React, with a f
 
 ## Rule Comparison Table
 
-<Callout type="warning">
+<Callout type="warn">
   Not all rules have direct equivalents, and some behave differently.
 </Callout>
 

--- a/apps/website/content/docs/packages/index.mdx
+++ b/apps/website/content/docs/packages/index.mdx
@@ -1,47 +1,24 @@
 ---
 title: Packages
-description: All packages in the ESLint React monorepo
+description: Utility modules for building custom React rules
 ---
 
-## Packages Summary
+import { Card, Cards } from "fumadocs-ui/components/card";
 
-This section provides a summary of the packages in the monorepo.
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
 
-### Local Packages
+ESLint React provides a set of utility packages designed to help you build custom React rules and analyze React code.
 
-- `.pkgs/configs`: Workspace config bases
-- `.pkgs/eff`: JavaScript and TypeScript utilities
+Explore the available packages below:
 
-### Internal Packages
+<Cards>
+  <Card title="@eslint-react/kit" description="ESLint React's toolkit for building custom React rules with JavaScript functions." href="/docs/packages/kit" />
+</Cards>
 
-- **Utilities**
-  - `packages/ast`: TSESTree AST utility module for static analysis
-  - `packages/var`: TSESTree AST utility module for static analysis of variables
-  - `packages/jsx`: TSESTree JSX utility module for static analysis of JSX patterns
-- **Core & Shared**
-  - `packages/core`: Utility module for static analysis of React core APIs and patterns
-  - `packages/shared`: Shared constants, types and functions
+## Resources
 
-### Public Packages
-
-- **Utilities**
-  - [`@eslint-react/kit`](https://npmx.dev/package/@eslint-react/kit): Utility module for building custom React rules with JavaScript functions
-- **ESLint Plugins**
-  - [`eslint-plugin-react-x`](https://npmx.dev/package/eslint-plugin-react-x): Core React rules
-  - [`eslint-plugin-react-jsx`](https://npmx.dev/package/eslint-plugin-react-jsx): React Flavored JSX rules
-  - [`eslint-plugin-react-rsc`](https://npmx.dev/package/eslint-plugin-react-rsc): React Server Components rules
-  - [`eslint-plugin-react-dom`](https://npmx.dev/package/eslint-plugin-react-dom): React DOM rules
-  - [`eslint-plugin-react-web-api`](https://npmx.dev/package/eslint-plugin-react-web-api): Web API interaction rules
-  - [`eslint-plugin-react-naming-convention`](https://npmx.dev/package/eslint-plugin-react-naming-convention): Naming convention rules
-  - [`eslint-plugin-react-debug`](https://npmx.dev/package/eslint-plugin-react-debug): Debugging rules for inspecting React patterns in code
-  - [`@eslint-react/eslint-plugin`](https://npmx.dev/package/@eslint-react/eslint-plugin): A unified plugin that combines all individual plugins into one
-
-### Documentation
-
-- `apps/website`: Documentation website
-- `apps/playground`: Interactive playground (placeholder)
-
-## Learn More
-
-- See the [Rules](/docs/rules) page for a full list of available lint rules.
-- See the [`@eslint-react/kit`](/docs/packages/kit) page for building your own custom React rules.
+- [AST Explorer](https://ast-explorer.dev/#eNpNkE9PwzAMxb+K5dMmDbiXrQeQOCIEEqdcQuqJjDSpEncCVf3u2Al/donk3/Pzi71gwA5P9myLy35i3OEkgL8mauCKSvBRuRPuxyllhmeyjuGY0wgGsxYGb000UX1wNzOn+JTTVOAAi4kA7t2HIVPsmvW6vo9pIHEBpHgfvPvoYLOFQw/n5Afha514nKNjn+LP1M3yNwvW7jJq25Iy8Zwj7N+qAvqhg8FWGeyXX/e6v2mw1ygTZcEkC9YZBsmN9pVykWCDnYBgmYpsufvXH8hKFBVtqDYVTuVTa84z1VZlcrTgaXjh7PVQTVVRYldcvwGs9YT5) - A tool for exploring the abstract syntax tree (AST) of JavaScript code, which is essential for writing custom rules.
+- [ESLint Developer Guide](https://eslint.org/docs/latest/extend/custom-rules) - Official ESLint documentation for creating custom rules.
+- [Using the TypeScript Compiler API](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API#type-checker-apis) - TypeScript compiler API documentation for working with type information in custom rules.

--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -5,7 +5,7 @@ description: ESLint React's toolkit for building custom React rules with JavaScr
 
 import { BskyPost } from "@/components/BskyPost";
 
-<Callout type="warning">
+<Callout type="warn">
   This module is currently in **beta**. APIs may change in future releases.
 </Callout>
 

--- a/apps/website/content/docs/recipes/custom-rules-of-context.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-context.mdx
@@ -1,5 +1,5 @@
 ---
-title: ℞ Custom Rules Of Context
+title: Custom Rules Of Context
 description: Validates React Context API usage. Includes checks for 'useContext' and other context-related patterns
 ---
 
@@ -115,7 +115,7 @@ export default [
 
 ## See Also
 
-- [℞ Custom Rules Of Props](./custom-rules-of-props)\
+- [Custom Rules Of Props](./custom-rules-of-props)\
   Custom rules for validating JSX props. Includes checks for duplicate props and mixing controlled and uncontrolled props.
-- [℞ Custom Rules Of State](./custom-rules-of-state)\
+- [Custom Rules Of State](./custom-rules-of-state)\
   Custom rules for validating state usage. Prefer the updater function form in useState setters.

--- a/apps/website/content/docs/recipes/custom-rules-of-props.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-props.mdx
@@ -1,5 +1,5 @@
 ---
-title: ℞ Custom Rules Of Props
+title: Custom Rules Of Props
 description: Validates JSX props. Includes checks for duplicate props, mixing controlled and uncontrolled props, explicit spread props, and direct props access
 ---
 
@@ -441,7 +441,7 @@ export default [
 
 ## See Also
 
-- [℞ Custom Rules Of State](./custom-rules-of-state)\
+- [Custom Rules Of State](./custom-rules-of-state)\
   Custom rules for validating state usage. Prefer the updater function form in useState setters.
-- [℞ Custom Rules Of Context](./custom-rules-of-context)\
+- [Custom Rules Of Context](./custom-rules-of-context)\
   Validates React Context API usage. Includes checks for `useContext` and other context-related patterns.

--- a/apps/website/content/docs/recipes/custom-rules-of-state.mdx
+++ b/apps/website/content/docs/recipes/custom-rules-of-state.mdx
@@ -1,5 +1,5 @@
 ---
-title: ℞ Custom Rules Of State
+title: Custom Rules Of State
 description: Validates state usage. Prefer the updater function form in useState setters
 ---
 
@@ -263,7 +263,7 @@ export default [
 
 ## See Also
 
-- [℞ Custom Rules Of Props](./custom-rules-of-props)\
+- [Custom Rules Of Props](./custom-rules-of-props)\
   Custom rules for validating JSX props. Includes checks for duplicate props and mixing controlled and uncontrolled props.
-- [℞ Custom Rules Of Context](./custom-rules-of-context)\
+- [Custom Rules Of Context](./custom-rules-of-context)\
   Validates React Context API usage. Includes checks for `useContext` and other context-related patterns.

--- a/apps/website/content/docs/recipes/function-component-definition.mdx
+++ b/apps/website/content/docs/recipes/function-component-definition.mdx
@@ -1,5 +1,5 @@
 ---
-title: ℞ Function Component Definition
+title: Function Component Definition
 description: Enforces arrow function style for function component definitions
 ---
 

--- a/apps/website/content/docs/recipes/index.mdx
+++ b/apps/website/content/docs/recipes/index.mdx
@@ -3,6 +3,12 @@ title: Recipes
 description: Ready-to-use custom ESLint rule definitions built with @eslint-react/kit
 ---
 
+import { Card, Cards } from "fumadocs-ui/components/card";
+
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
+
 Recipes are ready-to-use custom ESLint rule definitions built with [`@eslint-react/kit`](/docs/packages/kit). They are **not** part of the core plugin. Instead, they are designed to be **copied and pasted** directly into your project. Each recipe contains one or more custom rules.
 
 ## Why Recipes?
@@ -78,21 +84,25 @@ export default defineConfig(
 
 Single-purpose recipes containing one custom rule for a specific linting need.
 
-| Recipe                                                                           | Description                                                                                                                                 |
-| :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`℞ Function Component Definition`](/docs/recipes/function-component-definition) | Enforces arrow function style for function component definitions.                                                                           |
-| [`℞ No Circular Effect`](/docs/recipes/no-circular-effect)                       | Detects circular dependencies between useEffect hooks. Prevents infinite update loops caused by effects that set state they also depend on. |
-| [`℞ Prefer Namespace Import`](/docs/recipes/prefer-namespace-import)             | Enforces importing React via a namespace import instead of default import.                                                                  |
+<Cards>
+  <Card title="Function Component Definition" description="Enforces arrow function style for function component definitions." href="/docs/recipes/function-component-definition" />
+
+  <Card title="No Circular Effect" description="Detects circular dependencies between useEffect hooks. Prevents infinite update loops caused by effects that set state they also depend on." href="/docs/recipes/no-circular-effect" />
+
+  <Card title="Prefer Namespace Import" description="Enforces importing React via a namespace import instead of default import." href="/docs/recipes/prefer-namespace-import" />
+</Cards>
 
 ### Compound
 
 Multi-rule recipes that bundle related rules around a specific domain (props, state, children, context).
 
-| Recipe                                                               | Rules | Description                                                                                                                                         |
-| :------------------------------------------------------------------- | :---: | :-------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`℞ Custom Rules Of Props`](/docs/recipes/custom-rules-of-props)     |   4   | Validates JSX props. Includes checks for duplicate props, mixing controlled and uncontrolled props, explicit spread props, and direct props access. |
-| [`℞ Custom Rules Of State`](/docs/recipes/custom-rules-of-state)     |   1   | Validates state usage. Prefer the updater function form in useState setters.                                                                        |
-| [`℞ Custom Rules Of Context`](/docs/recipes/custom-rules-of-context) |   1   | Validates React Context API usage. Includes checks for `useContext` and other context-related patterns.                                             |
+<Cards>
+  <Card title="Custom Rules Of Props" description="Validates JSX props. Includes checks for duplicate props, mixing controlled and uncontrolled props, explicit spread props, and direct props access." href="/docs/recipes/custom-rules-of-props" />
+
+  <Card title="Custom Rules Of State" description="Validates state usage. Prefer the updater function form in useState setters." href="/docs/recipes/custom-rules-of-state" />
+
+  <Card title="Custom Rules Of Context" description="Validates React Context API usage. Includes checks for `useContext` and other context-related patterns." href="/docs/recipes/custom-rules-of-context" />
+</Cards>
 
 ## Resources
 

--- a/apps/website/content/docs/recipes/no-circular-effect.mdx
+++ b/apps/website/content/docs/recipes/no-circular-effect.mdx
@@ -1,9 +1,9 @@
 ---
-title: ℞ No Circular Effect
+title: No Circular Effect
 description: Detects circular dependencies between useEffect hooks. Prevents infinite update loops caused by effects that set state they also depend on
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   In most cases, use the built-in [`set-state-in-effect`](/docs/rules/set-state-in-effect) rule instead. It's also part of [React's official lints](https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect). Use this custom recipe only when you need to detect circular dependencies across multiple effects.
 </Callout>
 

--- a/apps/website/content/docs/recipes/prefer-namespace-import.mdx
+++ b/apps/website/content/docs/recipes/prefer-namespace-import.mdx
@@ -1,5 +1,5 @@
 ---
-title: ℞ Prefer Namespace Import
+title: Prefer Namespace Import
 description: Enforces importing React via a namespace import
 ---
 

--- a/apps/website/content/docs/removed.md
+++ b/apps/website/content/docs/removed.md
@@ -3,6 +3,10 @@ title: Removed
 description: Reference for removed rules, presets, and settings
 ---
 
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
+
 ## Rules
 
 | Rule                                                         | Replaced by                                                                                           | Removed in | Reason           |

--- a/apps/website/content/docs/roadmap.md
+++ b/apps/website/content/docs/roadmap.md
@@ -2,6 +2,10 @@
 title: Roadmap
 ---
 
+<Callout type="warn" title="Under Construction">
+  This page is under construction.
+</Callout>
+
 ## Milestone 5.0
 
 ### System Requirements

--- a/apps/website/content/docs/rules/index.mdx
+++ b/apps/website/content/docs/rules/index.mdx
@@ -161,7 +161,7 @@ import { InlineTOC } from "fumadocs-ui/components/inline-toc";
 
 ## Debug Rules
 
-<Callout type="warning">
+<Callout type="warn">
   The `eslint-plugin-react-debug` package is not included in the unified plugin. You need to install and configure it separately.
 
   These rules are useful for code metrics, code transformation, issue reporting, or when building custom tooling that needs to identify specific patterns. They can also serve as an rule-based alternative to [react-docgen](https://react-docgen.dev/).

--- a/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.mdx
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.mdx
@@ -95,7 +95,7 @@ export default function PrintApp() {
 
 Similarly, `flushSync` can be appropriate when used inside `startViewTransition` (or a helper wrapping it) to ensure the DOM is updated synchronously before the browser captures the transition state.
 
-<Callout type="warning">
+<Callout type="warn">
   The View Transitions API is still experimental and not fully supported in all browsers.
 </Callout>
 

--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.mdx
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.mdx
@@ -3,7 +3,7 @@ title: function-definition
 description: Validates and transforms React Client/Server Function definitions.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.mdx
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.mdx
@@ -3,7 +3,7 @@ title: no-leaked-fetch
 description: Enforces that every 'fetch' in a component or custom hook has a corresponding 'AbortController' abort in the cleanup function.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/globals/globals.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/globals/globals.mdx
@@ -3,7 +3,7 @@ title: globals
 description: Validates against assignment/mutation of globals during render, part of ensuring that side effects must run outside of render.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/immutability.mdx
@@ -3,7 +3,7 @@ title: immutability
 description: Validates against mutating props, state, and other values that are immutable.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.mdx
@@ -3,7 +3,7 @@ title: no-duplicate-key
 description: Prevents duplicate 'key' props on sibling elements when rendering lists.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-children/no-implicit-children.mdx
@@ -3,7 +3,7 @@ title: no-implicit-children
 description: Prevents implicitly passing the 'children' prop to components.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-key/no-implicit-key.mdx
@@ -3,7 +3,7 @@ title: no-implicit-key
 description: Prevents implicitly passing the 'key' prop to components.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-implicit-ref/no-implicit-ref.mdx
@@ -3,7 +3,7 @@ title: no-implicit-ref
 description: Prevents implicitly passing the 'ref' prop to components.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-misused-capture-owner-stack/no-misused-capture-owner-stack.mdx
@@ -3,7 +3,7 @@ title: no-misused-capture-owner-stack
 description: Prevents incorrect usage of 'captureOwnerStack'.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-props/no-unused-props.mdx
@@ -3,7 +3,7 @@ title: no-unused-props
 description: Warns about component props that are defined but never used.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unused-state/no-unused-state.mdx
@@ -3,7 +3,7 @@ title: no-unused-state
 description: Warns about state variables that are defined but never used.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/purity/purity.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/purity.mdx
@@ -3,7 +3,7 @@ title: purity
 description: Validates that components and hooks are pure by checking that they do not call known-impure functions during render.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.mdx
@@ -3,7 +3,7 @@ title: refs
 description: Validates correct usage of refs by checking that 'ref.current' is not read or written during render.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This is an evaluation implementation and may contain false positives or negatives that have not yet been fully audited. Review each report carefully before applying fixes.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.mdx
@@ -3,7 +3,7 @@ title: set-state-in-render
 description: Validates against unconditionally setting state during render, which can trigger additional renders and potential infinite render loops.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.mdx
@@ -3,7 +3,7 @@ title: static-components
 description: Validates that components are static, not recreated every render.
 ---
 
-<Callout type="warning">
+<Callout type="warn">
   This rule is experimental and may change in the future or be removed. It is not recommended for use in production code at this time.
 </Callout>
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [x] Docs

### Does this PR introduce a breaking change?

- [x] No

### Checklist

- [x] I have reviewed the changes and they are ready for submission.

### Other information

This PR polishes several documentation pages:
- Adds "Under Construction" callouts to unfinished pages (`community`, `contributing`, `diagrams`, `examples`, `packages/index`, `recipes/index`, `removed`, `roadmap`).
- Refactors `packages/index.mdx` to focus on utility packages with a card-based layout for `@eslint-react/kit` and adds external resources.
- Refactors `recipes/index.mdx` to use card-based layouts instead of tables.
- Removes the `℞` prefix from recipe titles for cleaner headings.
- Unifies `Callout` type from `warning` to `warn` across rule documentation files.
- Updates `apps/website/CHANGELOG.md` accordingly.