### PR TITLE
docs: reorder ast section in kit package docs

### DIFF
--- a/apps/website/content/docs/packages/kit.mdx
+++ b/apps/website/content/docs/packages/kit.mdx
@@ -338,6 +338,42 @@ isCreateRefCall(node);
 
 ---
 
+### `ast`
+
+Low-level AST utilities for handling TypeScript-specific syntax.
+
+| Method       | Signature                      | Description                                                                                                                                                                                                                                  |
+| ------------ | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `findParent` | `(node, test) -> Node \| null` | Walks up the AST from the given node and returns the first ancestor that satisfies the predicate, stopping at `Program`. Returns `null` if no match is found.                                                                                |
+| `unwrap`     | `(node) -> Node`               | Recursively strips TypeScript type-expression wrappers (`TSAsExpression`, `TSSatisfiesExpression`, `TSNonNullExpression`, `TSTypeAssertion`, `TSInstantiationExpression`) and `ChainExpression` from a node, returning the underlying value. |
+
+`ast.unwrap` is useful when you need to inspect a callee, argument, or initializer that may be wrapped in a TypeScript type assertion:
+
+```ts twoslash
+import type { RuleFunction } from "@eslint-react/kit";
+
+function noLeakedEventListener(): RuleFunction {
+  return (context, { ast }) => ({
+    CallExpression(node) {
+      const callee = ast.unwrap(node.callee);
+      if (
+        callee.type === "MemberExpression"
+        && callee.object.type === "Identifier"
+        && callee.object.name === "window"
+        && callee.property.type === "Identifier"
+        && callee.property.name === "addEventListener"
+      ) {
+        // Report leaked event listener…
+      }
+    },
+  });
+}
+```
+
+Without `unwrap`, the code above would miss calls like `(window.addEventListener as any)("click", handler)` because `node.callee.type` would be `TSAsExpression` instead of `MemberExpression`.
+
+---
+
 ### `hint`
 
 Bit-flags that control what the component collector considers a "component". Combine with bitwise OR (`|`) and remove with bitwise AND-NOT (`& ~`).
@@ -384,40 +420,6 @@ for (const component of query.all(program)) {
   }
 }
 ```
-
-### `ast`
-
-Low-level AST utilities for handling TypeScript-specific syntax.
-
-| Method       | Signature                      | Description                                                                                                                                                                                                                                  |
-| ------------ | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `findParent` | `(node, test) -> Node \| null` | Walks up the AST from the given node and returns the first ancestor that satisfies the predicate, stopping at `Program`. Returns `null` if no match is found.                                                                                |
-| `unwrap`     | `(node) -> Node`               | Recursively strips TypeScript type-expression wrappers (`TSAsExpression`, `TSSatisfiesExpression`, `TSNonNullExpression`, `TSTypeAssertion`, `TSInstantiationExpression`) and `ChainExpression` from a node, returning the underlying value. |
-
-`ast.unwrap` is useful when you need to inspect a callee, argument, or initializer that may be wrapped in a TypeScript type assertion:
-
-```ts twoslash
-import type { RuleFunction } from "@eslint-react/kit";
-
-function noLeakedEventListener(): RuleFunction {
-  return (context, { ast }) => ({
-    CallExpression(node) {
-      const callee = ast.unwrap(node.callee);
-      if (
-        callee.type === "MemberExpression"
-        && callee.object.type === "Identifier"
-        && callee.object.name === "window"
-        && callee.property.type === "Identifier"
-        && callee.property.name === "addEventListener"
-      ) {
-        // Report leaked event listener…
-      }
-    },
-  });
-}
-```
-
-Without `unwrap`, the code above would miss calls like `(window.addEventListener as any)("click", handler)` because `node.callee.type` would be `TSAsExpression` instead of `MemberExpression`.
 
 ---
 


### PR DESCRIPTION
Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information
Reordered the `ast` section in the `@eslint-react/kit` documentation to a more appropriate position.
