### PR TITLE
fix(web-api): report observer disconnect that only happens inside its…

### DIFF
--- a/plugins/eslint-plugin-react-web-api/README.md
+++ b/plugins/eslint-plugin-react-web-api/README.md
@@ -45,7 +45,6 @@ export default defineConfig(
 | `no-leaked-idle-callback`               | Prevents leaked `requestIdleCallback`         |
 | `no-leaked-animation-frame`             | Prevents leaked `requestAnimationFrame`       |
 | `no-leaked-event-source`                | Prevents leaked `EventSource`                 |
-| `no-leaked-intersection-observer`       | Prevents leaked `IntersectionObserver`        |
 | `no-leaked-mutation-observer`           | Prevents leaked `MutationObserver`            |
 | `no-leaked-performance-observer`        | Prevents leaked `PerformanceObserver`         |
 | `no-leaked-websocket`                   | Prevents leaked `WebSocket`                   |

--- a/plugins/eslint-plugin-react-web-api/src/configs/recommended.ts
+++ b/plugins/eslint-plugin-react-web-api/src/configs/recommended.ts
@@ -7,8 +7,8 @@ export const name = "react-web-api/recommended";
 export const rules = {
   "react-web-api/no-leaked-event-listener": "warn",
   "react-web-api/no-leaked-fetch": "warn",
-  "react-web-api/no-leaked-interval": "warn",
   "react-web-api/no-leaked-intersection-observer": "warn",
+  "react-web-api/no-leaked-interval": "warn",
   "react-web-api/no-leaked-resize-observer": "warn",
   "react-web-api/no-leaked-timeout": "warn",
 } as const satisfies Linter.RulesRecord;

--- a/plugins/eslint-plugin-react-web-api/src/plugin.ts
+++ b/plugins/eslint-plugin-react-web-api/src/plugin.ts
@@ -15,8 +15,8 @@ export const plugin = {
   rules: {
     "no-leaked-event-listener": noLeakedEventListener,
     "no-leaked-fetch": noLeakedFetch,
-    "no-leaked-interval": noLeakedInterval,
     "no-leaked-intersection-observer": noLeakedIntersectionObserver,
+    "no-leaked-interval": noLeakedInterval,
     "no-leaked-resize-observer": noLeakedResizeObserver,
     "no-leaked-timeout": noLeakedTimeout,
   },

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to the `react-web-api/no-leaked-intersection-observer` rule will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial release of the `no-leaked-intersection-observer` rule. (#1868)
+
+### Fixed
+
+- Report the observe-once pattern when `disconnect` is only called inside the observer's own callback, since the callback may never run if the component unmounts before the element intersects.

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/lib.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/lib.ts
@@ -4,19 +4,6 @@ import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
- * Check if a node is a loop statement
- * @param node The node to check
- * @returns True if the node is a loop
- */
-export const isLoop = isOneOf([
-  AST.DoWhileStatement,
-  AST.ForInStatement,
-  AST.ForOfStatement,
-  AST.ForStatement,
-  AST.WhileStatement,
-]);
-
-/**
  * Check if a node is a conditional expression or control flow statement
  * @param node The node to check
  * @returns True if the node is conditional

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/no-leaked-intersection-observer.spec.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/no-leaked-intersection-observer.spec.ts
@@ -173,6 +173,57 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: "expectedDisconnectOrUnobserveInCleanup" }],
     },
+    {
+      // The observe-once pattern (disconnect via the callback parameter) still needs a cleanup
+      // fallback: the callback never runs if the component unmounts before the element intersects
+      code: tsx`
+        import { useEffect, useRef, useState } from 'react';
+
+        function LazySection() {
+          const ref = useRef<HTMLDivElement>(null);
+          const [visible, setVisible] = useState(false);
+
+          useEffect(() => {
+            if (!ref.current) return;
+            const observer = new IntersectionObserver(([entry], obs) => {
+              if (entry.isIntersecting) {
+                setVisible(true);
+                obs.disconnect(); // observe-once
+              }
+            });
+            observer.observe(ref.current);
+          }, []);
+
+          return <div ref={ref}>{visible ? <p>Loaded</p> : null}</div>;
+        }
+      `,
+      errors: [{ messageId: "expectedDisconnectOrUnobserveInCleanup" }],
+    },
+    {
+      // Same observe-once pattern, but disconnecting through the outer variable instead of the callback parameter
+      code: tsx`
+        import { useEffect, useRef, useState } from 'react';
+
+        function LazySection() {
+          const ref = useRef<HTMLDivElement>(null);
+          const [visible, setVisible] = useState(false);
+
+          useEffect(() => {
+            if (!ref.current) return;
+            const observer = new IntersectionObserver(([entry]) => {
+              if (entry.isIntersecting) {
+                setVisible(true);
+                observer.disconnect(); // observe-once
+              }
+            });
+            observer.observe(ref.current);
+          }, []);
+
+          return <div ref={ref}>{visible ? <p>Loaded</p> : null}</div>;
+        }
+      `,
+      errors: [{ messageId: "expectedDisconnectOrUnobserveInCleanup" }],
+    },
   ],
   valid: [
     tsx`
@@ -354,6 +405,52 @@ ruleTester.run(RULE_NAME, rule, {
         }, []);
 
         return <div />;
+      }
+    `,
+    // The observe-once pattern with a disconnect in the cleanup function as a fallback
+    tsx`
+      import { useEffect, useRef, useState } from 'react';
+
+      function LazySection() {
+        const ref = useRef<HTMLDivElement>(null);
+        const [visible, setVisible] = useState(false);
+
+        useEffect(() => {
+          if (!ref.current) return;
+          const observer = new IntersectionObserver(([entry], obs) => {
+            if (entry.isIntersecting) {
+              setVisible(true);
+              obs.disconnect(); // observe-once
+            }
+          });
+          observer.observe(ref.current);
+          return () => observer.disconnect(); // fallback: might be unmounted before the callback runs
+        }, []);
+
+        return <div ref={ref}>{visible ? <p>Loaded</p> : null}</div>;
+      }
+    `,
+    // The observe-once pattern through the outer variable with a disconnect in the cleanup function as a fallback
+    tsx`
+      import { useEffect, useRef, useState } from 'react';
+
+      function LazySection() {
+        const ref = useRef<HTMLDivElement>(null);
+        const [visible, setVisible] = useState(false);
+
+        useEffect(() => {
+          if (!ref.current) return;
+          const observer = new IntersectionObserver(([entry]) => {
+            if (entry.isIntersecting) {
+              setVisible(true);
+              observer.disconnect(); // observe-once
+            }
+          });
+          observer.observe(ref.current);
+          return () => observer.disconnect(); // fallback: might be unmounted before the callback runs
+        }, []);
+
+        return <div ref={ref}>{visible ? <p>Loaded</p> : null}</div>;
       }
     `,
     // TODO: Add support for `IntersectionObserver` instance in `useRef`

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/no-leaked-intersection-observer.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/no-leaked-intersection-observer.ts
@@ -70,9 +70,9 @@ export default createRule<[], MessageID>({
       expectedDisconnectInControlFlow:
         "Dynamically added 'IntersectionObserver.observe' should be cleared all at once using 'IntersectionObserver.disconnect' in the cleanup function.",
       expectedDisconnectOrUnobserveInCleanup:
-        "A 'IntersectionObserver' instance created in 'useEffect' must be disconnected in the cleanup function.",
+        "An 'IntersectionObserver' instance created in 'useEffect' must be disconnected in the cleanup function.",
       unexpectedFloatingInstance:
-        "A 'IntersectionObserver' instance created in component or custom hook must be assigned to a variable for proper cleanup.",
+        "An 'IntersectionObserver' instance created in component or custom hook must be assigned to a variable for proper cleanup.",
     },
     schema: [],
   },
@@ -183,7 +183,10 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     },
     ["Program:exit"]() {
       for (const { id, node, phaseNode } of observers) {
-        if (dEntries.some((e) => isAssignmentTargetEqual(context, e.observer, id))) {
+        // A disconnect inside the observer's own callback (the observe-once pattern) is not a reliable
+        // cleanup: the callback may never run if the component unmounts before the element intersects
+        const isInsideObserverCallback = (e: DEntry) => Traverse.findParent(e.node, (n) => n === node) != null;
+        if (dEntries.some((e) => !isInsideObserverCallback(e) && isAssignmentTargetEqual(context, e.observer, id))) {
           continue;
         }
         const oentries = oEntries.filter((e) => isAssignmentTargetEqual(context, e.observer, id));

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Report when `disconnect` is only called inside the observer's own callback, since the callback may never run if the component unmounts before the element resizes.
+
 ## [5.2.3-beta.0] - 2026-04-14
 
 ### Changed

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/lib.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/lib.ts
@@ -4,19 +4,6 @@ import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
- * Check if a node is a loop statement
- * @param node The node to check
- * @returns True if the node is a loop
- */
-export const isLoop = isOneOf([
-  AST.DoWhileStatement,
-  AST.ForInStatement,
-  AST.ForOfStatement,
-  AST.ForStatement,
-  AST.WhileStatement,
-]);
-
-/**
  * Check if a node is a conditional expression or control flow statement
  * @param node The node to check
  * @returns True if the node is conditional

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.spec.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.spec.ts
@@ -173,6 +173,29 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: "expectedDisconnectOrUnobserveInCleanup" }],
     },
+    {
+      // A disconnect inside the observer's own callback is not a reliable cleanup:
+      // the callback may never run if the component unmounts before the element resizes
+      code: tsx`
+        import { useEffect, useRef } from 'react';
+
+        function Component() {
+          const ref = useRef<HTMLDivElement>(null);
+
+          useEffect(() => {
+            if (!ref.current) return;
+            const observer = new ResizeObserver(([entry]) => {
+              console.log(entry.contentRect);
+              observer.disconnect();
+            });
+            observer.observe(ref.current);
+          }, []);
+
+          return <div ref={ref} />;
+        }
+      `,
+      errors: [{ messageId: "expectedDisconnectOrUnobserveInCleanup" }],
+    },
   ],
   valid: [
     tsx`
@@ -188,6 +211,26 @@ ruleTester.run(RULE_NAME, rule, {
         }, []);
 
         return <div />;
+      }
+    `,
+    // A disconnect inside the observer's own callback with a disconnect in the cleanup function as a fallback
+    tsx`
+      import { useEffect, useRef } from 'react';
+
+      function Component() {
+        const ref = useRef<HTMLDivElement>(null);
+
+        useEffect(() => {
+          if (!ref.current) return;
+          const observer = new ResizeObserver(([entry]) => {
+            console.log(entry.contentRect);
+            observer.disconnect();
+          });
+          observer.observe(ref.current);
+          return () => observer.disconnect(); // fallback: might be unmounted before the callback runs
+        }, []);
+
+        return <div ref={ref} />;
       }
     `,
     tsx`

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
@@ -183,7 +183,10 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     },
     ["Program:exit"]() {
       for (const { id, node, phaseNode } of observers) {
-        if (dEntries.some((e) => isAssignmentTargetEqual(context, e.observer, id))) {
+        // A disconnect inside the observer's own callback is not a reliable cleanup:
+        // the callback may never run if the component unmounts before the element resizes
+        const isInsideObserverCallback = (e: DEntry) => Traverse.findParent(e.node, (n) => n === node) != null;
+        if (dEntries.some((e) => !isInsideObserverCallback(e) && isAssignmentTargetEqual(context, e.observer, id))) {
           continue;
         }
         const oentries = oEntries.filter((e) => isAssignmentTargetEqual(context, e.observer, id));

--- a/plugins/eslint-plugin/src/configs/all.ts
+++ b/plugins/eslint-plugin/src/configs/all.ts
@@ -81,9 +81,9 @@ export const rules = {
   "@eslint-react/dom-no-void-elements-with-children": "error",
   "@eslint-react/web-api-no-leaked-event-listener": "warn",
   "@eslint-react/web-api-no-leaked-fetch": "warn",
+  "@eslint-react/web-api-no-leaked-intersection-observer": "warn",
   "@eslint-react/web-api-no-leaked-interval": "warn",
   "@eslint-react/web-api-no-leaked-resize-observer": "warn",
-  "@eslint-react/web-api-no-leaked-intersection-observer": "warn",
   "@eslint-react/web-api-no-leaked-timeout": "warn",
 
   "@eslint-react/naming-convention-context-name": "warn",

--- a/plugins/eslint-plugin/src/configs/web-api.ts
+++ b/plugins/eslint-plugin/src/configs/web-api.ts
@@ -6,8 +6,8 @@ export const name = "@eslint-react/web-api";
 export const rules = {
   "@eslint-react/web-api-no-leaked-event-listener": "warn",
   "@eslint-react/web-api-no-leaked-fetch": "warn",
-  "@eslint-react/web-api-no-leaked-interval": "warn",
   "@eslint-react/web-api-no-leaked-intersection-observer": "warn",
+  "@eslint-react/web-api-no-leaked-interval": "warn",
   "@eslint-react/web-api-no-leaked-resize-observer": "warn",
   "@eslint-react/web-api-no-leaked-timeout": "warn",
 } as const satisfies Linter.RulesRecord;


### PR DESCRIPTION
… own callback

A 'disconnect' called inside the observer's own callback (the observe-once pattern) is not a reliable cleanup: the callback may never run if the component unmounts before it fires. 'no-leaked-intersection-observer' and 'no-leaked-resize-observer' now require a disconnect outside the callback, e.g. as a cleanup function fallback.

Also:
- add observe-once test cases requested in #1868 review
- add missing rule CHANGELOG.md and fix its broken docs link
- remove no-leaked-intersection-observer from the README to-be-implemented table
- fix perfectionist/sort-objects warnings in plugin and config rule maps
- fix message grammar: 'A IntersectionObserver' -> 'An IntersectionObserver'

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
