### PR TITLE
fix(jsx): handle namespaced host elements and clean spread child API

### DIFF
--- a/packages/jsx/src/get-attribute-static-value.ts
+++ b/packages/jsx/src/get-attribute-static-value.ts
@@ -11,19 +11,23 @@ import { resolveAttributeValue } from "./resolve-attribute-value";
  * {@link resolveAttributeValue} -> `toStatic()`, with automatic handling of the
  * `spreadProps` case (extracts the named property from the spread object).
  *
- * Returns `undefined` when the attribute is absent or when its value cannot be
- * statically determined.
+ * Returns `null` when the attribute is absent, `undefined` when the value cannot
+ * be statically determined (including empty expression containers), and the
+ * resolved static value otherwise.
  * @param context The ESLint rule context
  * @param element The `JSXElement` node to inspect
  * @param name The attribute name to look up (ex: "className")
- * @returns The static value of the attribute, or `undefined`
+ * @returns The static value of the attribute, `null` when absent, or `undefined` when indeterminate
  */
 export function getAttributeStaticValue(context: RuleContext, element: TSESTree.JSXElement, name: string): unknown {
   const attr = findAttribute(context, element, name);
-  if (attr == null) return undefined;
+  if (attr == null) return null;
   const resolved = resolveAttributeValue(context, attr);
   if (resolved.kind === "spreadProps") {
     return resolved.getProperty(name);
+  }
+  if (resolved.kind === "missing") {
+    return undefined;
   }
   return resolved.toStatic();
 }

--- a/packages/jsx/src/is-host-element.ts
+++ b/packages/jsx/src/is-host-element.ts
@@ -10,7 +10,13 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
  * @returns `true` when the node is a `JSXElement` with a lowercase tag name
  */
 export function isHostElement(node: TSESTree.Node): node is TSESTree.JSXElement {
-  return node.type === AST.JSXElement
-    && node.openingElement.name.type === AST.JSXIdentifier
-    && /^[a-z]/u.test(node.openingElement.name.name);
+  if (node.type !== AST.JSXElement) return false;
+  const name = node.openingElement.name;
+  if (name.type === AST.JSXIdentifier) {
+    return /^[a-z]/u.test(name.name);
+  }
+  if (name.type === AST.JSXNamespacedName) {
+    return /^[a-z]/u.test(name.name.name);
+  }
+  return false;
 }

--- a/packages/jsx/src/jsx-attribute-value.ts
+++ b/packages/jsx/src/jsx-attribute-value.ts
@@ -54,7 +54,7 @@ interface JsxAttributeValueMissing {
 /** Spread child expression (ex: `{...items}` as children) */
 interface JsxAttributeValueSpreadChild {
   readonly kind: "spreadChild";
-  getChildren(at: number): unknown;
+  getChildren(): unknown;
   readonly node: TSESTree.JSXSpreadChild["expression"];
   toStatic(): null;
 }

--- a/packages/jsx/src/resolve-attribute-value.ts
+++ b/packages/jsx/src/resolve-attribute-value.ts
@@ -86,7 +86,7 @@ function resolveJsxAttribute(context: RuleContext, node: TSESTree.JSXAttribute):
     case AST.JSXSpreadChild: {
       return {
         kind: "spreadChild",
-        getChildren(_at: number) {
+        getChildren() {
           return null;
         },
         node: node.value.expression,


### PR DESCRIPTION
- isHostElement now recognizes JSXNamespacedName host tags like <svg:circle>

- remove unused at parameter from JsxAttributeValueSpreadChild.getChildren

- getAttributeStaticValue returns null for missing attributes and undefined for indeterminate values

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
