### PR TITLE
refactor: unify member expression property name checks with Extract.getPropertyName

### DIFF
--- a/packages/core/src/class-component.ts
+++ b/packages/core/src/class-component.ts
@@ -141,8 +141,7 @@ export function isThisSetStateCall(node: TSESTree.CallExpression) {
   return (
     callee.type === AST.MemberExpression
     && callee.object.type === AST.ThisExpression
-    && callee.property.type === AST.Identifier
-    && callee.property.name === "setState"
+    && Extract.getPropertyName(callee.property) === "setState"
   );
 }
 

--- a/packages/core/src/function-component.ts
+++ b/packages/core/src/function-component.ts
@@ -321,14 +321,12 @@ export function isFunctionComponentDefinition(context: RuleContext, node: TSESTr
       break;
     case parentCallee != null
       && parentCallee.type === AST.MemberExpression
-      && parentCallee.property.type === AST.Identifier
-      && parentCallee.property.name === "map":
+      && Extract.getPropertyName(parentCallee.property) === "map":
       if (hint & FunctionComponentDetectionHint.DoNotIncludeFunctionDefinedAsArrayMapCallback) return false;
       break;
     case parentCallee != null
       && parentCallee.type === AST.MemberExpression
-      && parentCallee.property.type === AST.Identifier
-      && parentCallee.property.name === "flatMap":
+      && Extract.getPropertyName(parentCallee.property) === "flatMap":
       if (hint & FunctionComponentDetectionHint.DoNotIncludeFunctionDefinedAsArrayFlatMapCallback) return false;
       break;
     case parent.type === AST.CallExpression

--- a/packages/core/src/jsx.test.ts
+++ b/packages/core/src/jsx.test.ts
@@ -214,9 +214,9 @@ describe("isJsxLike", () => {
       expect(run("React.createElement('div');", hint)).toBe(false);
     });
 
-    it("should not match computed member access", () => {
-      // `React['createElement']` has a Literal property, not an Identifier.
-      expect(run("React['createElement']('div');")).toBe(false);
+    it("should match computed member access", () => {
+      // `React['createElement']` has a Literal property.
+      expect(run("React['createElement']('div');")).toBe(true);
     });
 
     it("should detect createElement when callee is wrapped in TSAsExpression", () => {

--- a/packages/core/src/jsx.ts
+++ b/packages/core/src/jsx.ts
@@ -101,8 +101,7 @@ export function isJsxLike(
           case AST.Identifier:
             return callee.name === "createElement";
           case AST.MemberExpression:
-            return callee.property.type === AST.Identifier
-              && callee.property.name === "createElement";
+            return Extract.getPropertyName(callee.property) === "createElement";
           default:
             return false;
         }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.spec.ts
@@ -112,6 +112,14 @@ ruleTester.run(RULE_NAME, rule, {
       `,
       errors: [{ messageId: "default" }],
     },
+    // Computed property access named findDOMNode
+    {
+      code: tsx`
+        const obj = { findDOMNode: () => {} };
+        obj["findDOMNode"]();
+      `,
+      errors: [{ messageId: "default" }],
+    },
   ],
   valid: [
     // Variable named findDOMNode but not called
@@ -125,13 +133,6 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: tsx`
         myFindDOMNode(this);
-      `,
-    },
-    // String property access (not detected)
-    {
-      code: tsx`
-        const obj = { findDOMNode: () => {} };
-        obj["findDOMNode"]();
       `,
     },
   ],

--- a/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-find-dom-node/no-find-dom-node.ts
@@ -1,4 +1,5 @@
 import { createRule } from "@/utils/create-rule";
+import { Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
@@ -41,7 +42,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           return;
         // Handles cases like `ReactDOM.findDOMNode()`.
         case AST.MemberExpression:
-          if (callee.property.type === AST.Identifier && callee.property.name === findDOMNode) {
+          if (Extract.getPropertyName(callee.property) === findDOMNode) {
             context.report({ messageId: "default", node });
           }
           return;

--- a/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.spec.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.spec.ts
@@ -214,6 +214,16 @@ ruleTester.run(RULE_NAME, rule, {
         { messageId: "default" },
       ],
     },
+    // Computed property access named flushSync
+    {
+      code: tsx`
+        const obj = { flushSync: () => {} };
+        obj["flushSync"]();
+      `,
+      errors: [
+        { messageId: "default" },
+      ],
+    },
     // In conditional expression
     {
       code: tsx`
@@ -263,13 +273,6 @@ ruleTester.run(RULE_NAME, rule, {
     {
       code: tsx`
         myFlushSync(() => {});
-      `,
-    },
-    // String property access (not detected)
-    {
-      code: tsx`
-        const obj = { flushSync: () => {} };
-        obj["flushSync"]();
       `,
     },
   ],

--- a/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-flush-sync/no-flush-sync.ts
@@ -1,4 +1,5 @@
 import { createRule } from "@/utils/create-rule";
+import { Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST } from "@typescript-eslint/types";
 
@@ -41,7 +42,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           return;
         // Handle member access calls like `ReactDOM.flushSync()`
         case AST.MemberExpression:
-          if (callee.property.type === AST.Identifier && callee.property.name === flushSync) {
+          if (Extract.getPropertyName(callee.property) === flushSync) {
             context.report({ messageId: "default", node });
           }
           return;

--- a/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
@@ -59,8 +59,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         // Case 2: Call on a `react-dom` import, like `ReactDOM.hydrate()`
         case callee.type === AST.MemberExpression
           && callee.object.type === AST.Identifier
-          && callee.property.type === AST.Identifier
-          && callee.property.name === hydrate
+          && Extract.getPropertyName(callee.property) === hydrate
           && reactDomNames.has(callee.object.name):
           context.report({
             fix: getFix(context, node),

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
@@ -63,8 +63,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         // Handles member expression calls like 'ReactDOM.render'
         case callee.type === AST.MemberExpression
           && callee.object.type === AST.Identifier
-          && callee.property.type === AST.Identifier
-          && callee.property.name === "render"
+          && Extract.getPropertyName(callee.property) === "render"
           && reactDomNames.has(callee.object.name)
           // Check if the return value is being used
           && isReturnValueUsed(node):

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
@@ -59,8 +59,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         // Case 2: Member expression call, e.g., `ReactDOM.render()`
         case callee.type === AST.MemberExpression
           && callee.object.type === AST.Identifier
-          && callee.property.type === AST.Identifier
-          && callee.property.name === "render"
+          && Extract.getPropertyName(callee.property) === "render"
           && reactDomNames.has(callee.object.name):
           context.report({
             fix: getFix(context, node),

--- a/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
@@ -59,8 +59,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         // Case 2: Member call like `ReactDOM.useFormState(...)`
         case callee.type === AST.MemberExpression
           && callee.object.type === AST.Identifier
-          && callee.property.type === AST.Identifier
-          && callee.property.name === "useFormState"
+          && Extract.getPropertyName(callee.property) === "useFormState"
           && reactDomNames.has(callee.object.name):
           context.report({
             fix: getFix(context, node),

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/no-leaked-fetch.ts
@@ -47,15 +47,13 @@ function getCallKind(node: TSESTree.CallExpression): CallKind {
       && callee.name === "fetch":
       return "fetch";
     case callee.type === AST.MemberExpression
-      && callee.property.type === AST.Identifier
-      && callee.property.name === "fetch":
+      && Extract.getPropertyName(callee.property) === "fetch":
       return "fetch";
     case callee.type === AST.Identifier
       && callee.name === "abort":
       return "abort";
     case callee.type === AST.MemberExpression
-      && callee.property.type === AST.Identifier
-      && callee.property.name === "abort":
+      && Extract.getPropertyName(callee.property) === "abort":
       return "abort";
     default:
       return "other";

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
@@ -97,22 +97,12 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       case AST.CallExpression: {
         const callee = Extract.unwrap(node.callee);
         // Case: key={index.toString()}
-        if (
-          callee.type === AST.MemberExpression
-          && callee.property.type === AST.Identifier
-          && callee.property.name === "toString"
-          && isArrayIndex(callee.object)
-        ) {
+        if (callee.type === AST.MemberExpression && Extract.getPropertyName(callee.property) === "toString" && isArrayIndex(callee.object)) {
           return [{ messageId: "default", node: callee.object }];
         }
         // Case: key={String(index)} or key={Number(index)}
         const argument = node.arguments.at(0);
-        if (
-          callee.type === AST.Identifier
-          && COERCION_FUNCTIONS.has(callee.name)
-          && argument != null
-          && isArrayIndex(argument)
-        ) {
+        if (callee.type === AST.Identifier && COERCION_FUNCTIONS.has(callee.name) && argument != null && isArrayIndex(argument)) {
           return [{ messageId: "default", node: argument }];
         }
         return [];

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
@@ -80,8 +80,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
               if (n.type !== AST.CallExpression) return false;
               const callee = Extract.unwrap(n.callee);
               return callee.type === AST.MemberExpression
-                && callee.property.type === AST.Identifier
-                && callee.property.name === "map";
+                && Extract.getPropertyName(callee.property) === "map";
             },
           );
           const iter = Traverse.findParent(jsxElement, Check.isFunction, (n) => n === call);

--- a/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/lib.ts
@@ -1,4 +1,4 @@
-import { Check } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
@@ -15,8 +15,7 @@ export function isTestMock(node: TSESTree.Node | null): node is TSESTree.MemberE
   return node != null
     && node.type === AST.MemberExpression
     && node.object.type === AST.Identifier
-    && node.property.type === AST.Identifier
-    && node.property.name === "mock";
+    && Extract.getPropertyName(node.property) === "mock";
 }
 
 export function isTestMockCallback(node: TSESTree.Node | null) {

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -76,8 +76,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   function isThenCall(node: TSESTree.CallExpression) {
     const callee = Extract.unwrap(node.callee);
     return callee.type === AST.MemberExpression
-      && callee.property.type === AST.Identifier
-      && callee.property.name === "then";
+      && Extract.getPropertyName(callee.property) === "then";
   }
 
   function isUseStateCall(node: TSESTree.Node) {
@@ -156,7 +155,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         if (!("name" in innerCallee.object)) {
           return false;
         }
-        const isAt = innerCallee.property.type === AST.Identifier && innerCallee.property.name === "at";
+        const isAt = Extract.getPropertyName(innerCallee.property) === "at";
         const [index] = callee.arguments;
         if (!isAt || index == null) {
           return false;

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
@@ -76,7 +76,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         if (!("name" in innerCallee.object)) {
           return false;
         }
-        const isAt = innerCallee.property.type === AST.Identifier && innerCallee.property.name === "at";
+        const isAt = Extract.getPropertyName(innerCallee.property) === "at";
         const [index] = callee.arguments;
         if (!isAt || index == null) {
           return false;


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Unifies `MemberExpression` property name checks across rules and core utilities by replacing `property.type === AST.Identifier && property.name === ...` with `Extract.getPropertyName(...) === ...`.

This makes the detection consistent and also handles computed string property access (e.g. `obj["foo"]()`). The affected test cases were updated to expect this broader detection.
