### PR TITLE
refactor(static-components): extract helpers and reuse @typescript-es…

### DIFF
--- a/packages/ast/src/extract.ts
+++ b/packages/ast/src/extract.ts
@@ -33,25 +33,25 @@ export function getPropertyName(node: TSESTree.Node, resolve = (n: TSESTree.Iden
 }
 
 export function getFullyQualifiedName(node: TSESTree.Node, getText: (node: TSESTree.Node) => string): string {
-  node = unwrap(node);
-  switch (node.type) {
+  const expr = unwrap(node);
+  switch (expr.type) {
     case AST.Identifier:
     case AST.JSXIdentifier:
     case AST.PrivateIdentifier:
-      return node.name;
+      return expr.name;
     case AST.MemberExpression: {
-      if (node.computed) return getText(node);
-      return `${getFullyQualifiedName(node.object, getText)}.${getFullyQualifiedName(node.property, getText)}`;
+      if (expr.computed) return getText(expr);
+      return `${getFullyQualifiedName(expr.object, getText)}.${getFullyQualifiedName(expr.property, getText)}`;
     }
     case AST.JSXMemberExpression:
-      return `${getFullyQualifiedName(node.object, getText)}.${getFullyQualifiedName(node.property, getText)}`;
+      return `${getFullyQualifiedName(expr.object, getText)}.${getFullyQualifiedName(expr.property, getText)}`;
     case AST.JSXNamespacedName:
-      return `${node.namespace.name}:${node.name.name}`;
+      return `${expr.namespace.name}:${expr.name.name}`;
     case AST.JSXText:
-      return node.value;
+      return expr.value;
     case AST.Literal:
-      return node.raw;
+      return expr.raw;
     default:
-      return getText(node);
+      return getText(expr);
   }
 }

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/CHANGELOG.md
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored the rule's internals without changing behavior:
+  - `lib.ts`: `findVariableForIdentifier` now delegates to `@typescript-eslint/utils/ast-utils`'s `findVariable` instead of a hand-rolled scope-chain walk; split `resolveDynamicValue` into `findDynamicCreationSite` (expression resolution) and `findReassignmentCreationSite` (reassignment tracking); removed the unused `isDynamicComponent` export.
+  - `static-components.ts`: extracted `createRenderBoundaryChecker` (merges function/class component nodes into a single `Set` for the render-boundary check) and `reportIfCreatedDuringRender` (per-candidate reporting) out of the `Program:exit` handler; JSX candidates are now collected as a typed `JsxComponentCandidate` list holding the `JSXIdentifier` directly.
+
 ## [5.6.0-beta.1] - 2026-04-28
 
 ### Added

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/lib.ts
@@ -2,53 +2,82 @@ import { Extract } from "@eslint-react/ast";
 import { type RuleContext } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import type { TSESLint } from "@typescript-eslint/utils";
+import { findVariable } from "@typescript-eslint/utils/ast-utils";
 
 export interface DynamicComponentResult {
   creationNode: TSESTree.Node | null;
   isDynamic: boolean;
 }
 
-function resolveDynamicValue(
+type IsInsideRender = (node: TSESTree.Node) => boolean;
+
+/**
+ * Expression kinds that always produce a brand-new value on every evaluation, and are
+ * therefore considered "dynamically created" when used as a component's value.
+ */
+const DYNAMIC_EXPRESSION_TYPES: ReadonlySet<TSESTree.Node["type"]> = new Set([
+  AST.ArrowFunctionExpression,
+  AST.CallExpression,
+  AST.ClassExpression,
+  AST.FunctionExpression,
+  AST.NewExpression,
+]);
+
+export function findVariableForIdentifier(
+  context: RuleContext,
+  identifier: TSESTree.Identifier | TSESTree.JSXIdentifier,
+): TSESLint.Scope.Variable | null {
+  const scope = context.sourceCode.getScope(identifier);
+  return findVariable(scope, identifier.name);
+}
+
+/**
+ * Resolves an expression down to the node that dynamically created its value, if any.
+ * Recurses through identifier references and both branches of ternaries.
+ */
+function findDynamicCreationSite(
   context: RuleContext,
   node: TSESTree.Node,
-  isInsideRender: (node: TSESTree.Node) => boolean,
+  isInsideRender: IsInsideRender,
   seen: Set<TSESLint.Scope.Variable>,
 ): TSESTree.Node | null {
   const expr = Extract.unwrap(node);
 
+  if (DYNAMIC_EXPRESSION_TYPES.has(expr.type)) {
+    return expr;
+  }
+
   switch (expr.type) {
-    case AST.FunctionExpression:
-    case AST.ArrowFunctionExpression:
-    case AST.NewExpression:
-    case AST.CallExpression:
-    case AST.ClassExpression:
-      return expr;
-    case AST.ConditionalExpression: {
-      const consequent = resolveDynamicValue(context, expr.consequent, isInsideRender, seen);
-      if (consequent != null) return consequent;
-      return resolveDynamicValue(context, expr.alternate, isInsideRender, seen);
-    }
+    case AST.ConditionalExpression:
+      return findDynamicCreationSite(context, expr.consequent, isInsideRender, seen)
+        ?? findDynamicCreationSite(context, expr.alternate, isInsideRender, seen);
     case AST.Identifier:
     case AST.JSXIdentifier: {
-      const resolved = findVariableForIdentifier(context, expr);
-      if (resolved == null) return null;
-      const result = getDynamicComponentSource(context, resolved, isInsideRender, seen);
-      return result.creationNode;
+      const variable = findVariableForIdentifier(context, expr);
+      if (variable == null) return null;
+      return getDynamicComponentSource(context, variable, isInsideRender, seen).creationNode;
     }
     default:
       return null;
   }
 }
 
-export function findVariableForIdentifier(
+/**
+ * Looks for a reassignment of `variable` (e.g. `Component = createComponent();`) whose
+ * right-hand side is dynamically created.
+ */
+function findReassignmentCreationSite(
   context: RuleContext,
-  identifier: TSESTree.Identifier | TSESTree.JSXIdentifier,
-): TSESLint.Scope.Variable | null {
-  let scope: ReturnType<typeof context.sourceCode.getScope> | null = context.sourceCode.getScope(identifier);
-  while (scope != null) {
-    const variable = scope.variables.find((v) => v.name === identifier.name);
-    if (variable != null) return variable;
-    scope = scope.upper;
+  variable: TSESLint.Scope.Variable,
+  isInsideRender: IsInsideRender,
+  seen: Set<TSESLint.Scope.Variable>,
+): TSESTree.Node | null {
+  for (const ref of variable.references) {
+    if (!ref.isWrite()) continue;
+    const { identifier } = ref;
+    if (identifier.parent.type !== AST.AssignmentExpression || identifier.parent.left !== identifier) continue;
+    const source = findDynamicCreationSite(context, identifier.parent.right, isInsideRender, seen);
+    if (source != null) return source;
   }
   return null;
 }
@@ -56,7 +85,7 @@ export function findVariableForIdentifier(
 export function getDynamicComponentSource(
   context: RuleContext,
   variable: TSESLint.Scope.Variable,
-  isInsideRender: (node: TSESTree.Node) => boolean,
+  isInsideRender: IsInsideRender,
   seen = new Set<TSESLint.Scope.Variable>(),
 ): DynamicComponentResult {
   if (seen.has(variable)) return { creationNode: null, isDynamic: false };
@@ -66,45 +95,24 @@ export function getDynamicComponentSource(
     const defNode = def.node;
     if (!isInsideRender(defNode)) continue;
 
-    if (defNode.type === AST.FunctionDeclaration) {
-      return { creationNode: defNode, isDynamic: true };
-    }
-    if (defNode.type === AST.ClassDeclaration) {
+    if (defNode.type === AST.FunctionDeclaration || defNode.type === AST.ClassDeclaration) {
       return { creationNode: defNode, isDynamic: true };
     }
 
-    if (defNode.type === AST.VariableDeclarator) {
-      if (defNode.init != null) {
-        const source = resolveDynamicValue(context, defNode.init, isInsideRender, seen);
-        if (source != null) {
-          return { creationNode: source, isDynamic: true };
-        }
-      }
+    if (defNode.type !== AST.VariableDeclarator) continue;
 
-      for (const ref of variable.references) {
-        if (!ref.isWrite()) continue;
-        const id = ref.identifier;
-        if (
-          id.parent.type === AST.AssignmentExpression
-          && id.parent.left === id
-        ) {
-          const source = resolveDynamicValue(context, id.parent.right, isInsideRender, seen);
-          if (source != null) {
-            return { creationNode: source, isDynamic: true };
-          }
-        }
-      }
+    const initSource = defNode.init == null
+      ? null
+      : findDynamicCreationSite(context, defNode.init, isInsideRender, seen);
+    if (initSource != null) {
+      return { creationNode: initSource, isDynamic: true };
+    }
+
+    const reassignmentSource = findReassignmentCreationSite(context, variable, isInsideRender, seen);
+    if (reassignmentSource != null) {
+      return { creationNode: reassignmentSource, isDynamic: true };
     }
   }
 
   return { creationNode: null, isDynamic: false };
-}
-
-export function isDynamicComponent(
-  context: RuleContext,
-  variable: TSESLint.Scope.Variable,
-  isInsideRender: (node: TSESTree.Node) => boolean,
-  seen = new Set<TSESLint.Scope.Variable>(),
-): boolean {
-  return getDynamicComponentSource(context, variable, isInsideRender, seen).isDynamic;
 }

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.diff.md
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.diff.md
@@ -9,7 +9,7 @@
 
 The SPEC operates on the React Compiler's HIR, iterating over blocks, phi nodes, and instructions. It uses a `knownDynamicComponents` map with phi-node propagation across control-flow joins. Component detection is via `JsxExpression` instructions on already-lowered HIR. Render boundaries are `HIRFunction` boundaries.
 
-The IMPL operates on the ESLint AST with scope analysis (`findVariableForIdentifier`, `resolveDynamicValue`). It uses recursive variable-definition tracing through `getDynamicComponentSource`. Component detection uses `core.getFunctionComponentCollector` and `core.getClassComponentCollector` with extensive hints. Enclosing components are computed via `Traverse.findParent` against collected function/class components.
+The IMPL operates on the ESLint AST with scope analysis (`findVariableForIdentifier`, built on `@typescript-eslint/utils/ast-utils`'s `findVariable`). It uses recursive variable-definition tracing through `getDynamicComponentSource`, which delegates expression resolution to `findDynamicCreationSite` and reassignment tracking to `findReassignmentCreationSite`. Component detection uses `core.getFunctionComponentCollector` and `core.getClassComponentCollector` with extensive hints. Enclosing components (the render boundary check) are computed by `createRenderBoundaryChecker`, which merges collected function/class component nodes into a single `Set` and walks up via `Traverse.findParent`; per-candidate reporting is handled by `reportIfCreatedDuringRender`.
 
 ---
 
@@ -43,7 +43,7 @@ The IMPL handles `ConditionalExpression` by recursively resolving `consequent` f
 
 The SPEC propagates assignments through `StoreLocal` and `LoadLocal` instructions in HIR. Scope resolution uses HIR identifier IDs and local stores.
 
-The IMPL traces `VariableDeclarator.init` via `resolveDynamicValue`. Re-assignments are explicitly tracked via `variable.references` with `AssignmentExpression` write detection. Scope resolution uses ESLint `Scope.Variable` and `Scope.Definition` traversal.
+The IMPL traces `VariableDeclarator.init` via `findDynamicCreationSite`. Re-assignments are explicitly tracked in `findReassignmentCreationSite` via `variable.references` with `AssignmentExpression` write detection. Scope resolution uses ESLint `Scope.Variable` and `Scope.Definition` traversal, with identifier-to-variable lookup delegated to the standard `findVariable` scope-chain walk instead of a hand-rolled one.
 
 **Verdict**: The SPEC's propagation is unified through HIR instructions. The IMPL manually traces assignments and re-assignments through ESLint scope/reference APIs.
 
@@ -53,7 +53,7 @@ The IMPL traces `VariableDeclarator.init` via `resolveDynamicValue`. Re-assignme
 
 The SPEC triggers when it encounters a `JsxExpression` instruction where the tag identifier is in `knownDynamicComponents`. It checks any identifier in JSX component position that is tracked as dynamic.
 
-The IMPL collects `JSXOpeningElement` candidates with component-like names (`core.isFunctionComponentName`), then validates at `Program:exit`. It only checks JSX elements with `JSXIdentifier` names; namespace/components (`<Foo.Bar />`) are ignored due to the `node.name.type !== AST.JSXIdentifier` check.
+The IMPL collects `JSXOpeningElement` candidates with component-like names (`core.isFunctionComponentName`) into a typed `JsxComponentCandidate` list (storing the `JSXIdentifier` directly), then validates at `Program:exit`. It only checks JSX elements with `JSXIdentifier` names; namespace/components (`<Foo.Bar />`) are ignored due to the `node.name.type !== AST.JSXIdentifier` check performed during collection.
 
 **Verdict**: The IMPL has an additional filtering layer (function-component name heuristic) before performing expensive variable tracing, whereas the SPEC checks any dynamic identifier used in JSX.
 
@@ -79,4 +79,4 @@ Both sides report dual locations:
 4. **Component Detection Overhead**: The IMPL performs full function-component detection with hints (`FunctionComponentDetectionHint`) to establish render boundaries, whereas the SPEC operates directly on `HIRFunction` boundaries.
 5. **JSX Namespace Filtering**: The IMPL ignores JSX member expressions (`<Foo.Bar />`) due to the `node.name.type !== AST.JSXIdentifier` check. The SPEC does not explicitly mention such filtering.
 6. **Class-Field Arrow Render Helpers**: When a nested component is defined inside a class-field arrow function acting as a render helper (e.g., `_renderMessage = () => { const Message = () => ...; return <Message />; }`), the IMPL does **not** flag `Message` as dynamic. The class-field arrow is not recognized as a function-component boundary by `core.getFunctionComponentCollector`, so `getEnclosingComponent` either misses the boundary or resolves to the outer class component in a way that does not surface the violation. The SPEC's HIR-block analysis tracks dynamic components across all blocks uniformly and would flag this.
-7. **CallExpression Reassignment of External Components**: If an external (non-dynamic) component is reassigned via a `CallExpression` such as `useMemo(() => Component, [Component])`, the IMPL flags the reassigned variable as dynamic because `resolveDynamicValue` returns the `CallExpression` node without inspecting the call's return value. The SPEC's HIR analysis would see through the `useMemo` to the underlying external component and not flag it.
+7. **CallExpression Reassignment of External Components**: If an external (non-dynamic) component is reassigned via a `CallExpression` such as `useMemo(() => Component, [Component])`, the IMPL flags the reassigned variable as dynamic because `findDynamicCreationSite` returns the `CallExpression` node without inspecting the call's return value. The SPEC's HIR analysis would see through the `useMemo` to the underlying external component and not flag it.

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.spec.ts
@@ -394,6 +394,77 @@ ruleTester.run(RULE_NAME, rule, {
         },
       ],
     },
+    // Boundary: a `ClassDeclaration` nested directly inside render is dynamic,
+    // mirroring the `FunctionDeclaration` case above.
+    {
+      code: tsx`
+        function Parent() {
+          class ChildComponent extends React.Component {
+            render() {
+              return <div />;
+            }
+          }
+
+          return <ChildComponent />;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "ChildComponent" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "ChildComponent" },
+          messageId: "default",
+        },
+      ],
+    },
+    // Boundary: only the alternate branch of a ternary is dynamic; the consequent is a
+    // static external reference. The IMPL still flags the whole expression as dynamic.
+    {
+      code: tsx`
+        function Parent({ type }) {
+          const Component = type === "button"
+            ? StaticButton
+            : () => <div>Text</div>;
+
+          return <Component />;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "Component" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "Component" },
+          messageId: "default",
+        },
+      ],
+    },
+    // Boundary: only the consequent branch of a ternary is dynamic; the alternate is a
+    // static external reference. The IMPL still flags the whole expression as dynamic.
+    {
+      code: tsx`
+        function Parent({ type }) {
+          const Component = type === "button"
+            ? () => <button>Click</button>
+            : StaticText;
+
+          return <Component />;
+        }
+      `,
+      errors: [
+        {
+          data: { name: "Component" },
+          messageId: "createdHere",
+        },
+        {
+          data: { name: "Component" },
+          messageId: "default",
+        },
+      ],
+    },
   ],
   valid: [
     {
@@ -534,6 +605,63 @@ ruleTester.run(RULE_NAME, rule, {
           let Component = DefaultComponent;
           fn(Component);
           return <Component />;
+        }
+      `,
+    },
+    // Boundary: JSX member expression tags (e.g. `<Namespace.Bar />`) are ignored entirely,
+    // even when the referenced property is dynamically created.
+    {
+      code: tsx`
+        function Parent() {
+          const Namespace = { Bar: () => <div /> };
+          return <Namespace.Bar />;
+        }
+      `,
+    },
+    // Boundary: a lowercase-named binding is never treated as a component reference,
+    // regardless of how its value was created, because JSX treats lowercase tags as
+    // host elements rather than component references.
+    {
+      code: tsx`
+        function Parent() {
+          const childComponent = () => <div />;
+          return <childComponent />;
+        }
+      `,
+    },
+    // Boundary: hooks (names starting with lowercase "use") are not recognized as
+    // function-component render boundaries, so components nested directly inside a
+    // top-level hook (not itself nested inside a component) are not flagged.
+    {
+      code: tsx`
+        function useFoo() {
+          function Component() {
+            return <div />;
+          }
+          return <Component />;
+        }
+      `,
+    },
+    // Boundary: both branches of the ternary resolve to static/external references,
+    // so the assembled component is not considered dynamic.
+    {
+      code: tsx`
+        function Parent({ type }) {
+          const Component = type === "button" ? StaticButton : StaticText;
+          return <Component />;
+        }
+      `,
+    },
+    // Boundary: mutual reassignment between two variables must not cause infinite
+    // recursion; the cycle-detection guard should terminate and treat it as static.
+    {
+      code: tsx`
+        function Parent() {
+          let A = DefaultComponent;
+          let B = DefaultComponent;
+          A = B;
+          B = A;
+          return <A />;
         }
       `,
     },

--- a/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/static-components/static-components.ts
@@ -46,7 +46,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   const fc = core.getFunctionComponentCollector(context, { hint });
   const cc = core.getClassComponentCollector(context);
 
-  const jsxCandidates: Array<{ name: string; node: TSESTree.JSXOpeningElement }> = [];
+  const candidates: JsxComponentCandidate[] = [];
 
   return merge(
     fc.visitor,
@@ -56,53 +56,73 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         if (node.name.type !== AST.JSXIdentifier) return;
         const name = node.name.name;
         if (!core.isFunctionComponentName(name)) return;
-        jsxCandidates.push({ name, node });
+        candidates.push({ name, identifier: node.name });
       },
       "Program:exit"(program) {
-        const fComponents = [...fc.api.getAllComponents(program)];
-        const cComponents = [...cc.api.getAllComponents(program)];
-
-        function getEnclosingComponent(node: TSESTree.Node) {
-          return Traverse.findParent(node, (n) => {
-            if (Check.isFunction(n)) return fComponents.some((c) => c.node === n);
-            if (Check.isClass(n)) return cComponents.some((c) => c.node === n);
-            return false;
-          });
-        }
-
-        const isInsideRender = (node: TSESTree.Node) => getEnclosingComponent(node) != null;
-
-        for (const { name, node: jsxNode } of jsxCandidates) {
-          // tsl-ignore dx/no-unsafe-as
-          const jsxName = jsxNode.name as TSESTree.JSXIdentifier;
-          const variable = findVariableForIdentifier(context, jsxName);
-          if (variable == null || variable.defs.length === 0) continue;
-
-          const def = variable.defs.at(0);
-          if (def == null) continue;
-          const defNode = def.node;
-
-          const enclosing = getEnclosingComponent(defNode);
-          if (enclosing == null) continue;
-
-          const result = getDynamicComponentSource(context, variable, isInsideRender);
-          if (!result.isDynamic) continue;
-
-          context.report({
-            data: { name },
-            messageId: "default",
-            node: jsxNode.name,
-          });
-
-          if (result.creationNode != null) {
-            context.report({
-              data: { name },
-              messageId: "createdHere",
-              node: result.creationNode,
-            });
-          }
+        const isInsideRender = createRenderBoundaryChecker(fc, cc, program);
+        for (const candidate of candidates) {
+          reportIfCreatedDuringRender(context, candidate, isInsideRender);
         }
       },
     },
   );
+}
+
+interface JsxComponentCandidate {
+  name: string;
+  identifier: TSESTree.JSXIdentifier;
+}
+
+/**
+ * Builds a predicate that tells whether a given node lies within the body of a
+ * previously-collected function or class component, i.e. whether it is "created during render".
+ */
+function createRenderBoundaryChecker(
+  fc: ReturnType<typeof core.getFunctionComponentCollector>,
+  cc: ReturnType<typeof core.getClassComponentCollector>,
+  program: TSESTree.Program,
+) {
+  const componentNodes = new Set([
+    ...fc.api.getAllComponents(program),
+    ...cc.api.getAllComponents(program),
+  ].map((component) => component.node));
+
+  const getEnclosingComponent = (node: TSESTree.Node) => Traverse.findParent(node, (n) => (Check.isFunction(n) || Check.isClass(n)) && componentNodes.has(n));
+
+  return (node: TSESTree.Node) => getEnclosingComponent(node) != null;
+}
+
+function reportIfCreatedDuringRender(
+  context: RuleContext<MessageID, []>,
+  candidate: JsxComponentCandidate,
+  isInsideRender: (node: TSESTree.Node) => boolean,
+) {
+  const { name, identifier } = candidate;
+
+  const variable = findVariableForIdentifier(context, identifier);
+  if (variable == null) return;
+
+  const def = variable.defs.at(0);
+  if (def == null) return;
+
+  // The declaration of the component's value must itself live inside a component's render body
+  // for it to be a candidate for "created during render".
+  if (!isInsideRender(def.node)) return;
+
+  const { creationNode, isDynamic } = getDynamicComponentSource(context, variable, isInsideRender);
+  if (!isDynamic) return;
+
+  context.report({
+    data: { name },
+    messageId: "default",
+    node: identifier,
+  });
+
+  if (creationNode != null) {
+    context.report({
+      data: { name },
+      messageId: "createdHere",
+      node: creationNode,
+    });
+  }
 }


### PR DESCRIPTION
…lint findVariable

Refactor the `static-components` rule internals without changing behavior:

- `packages/ast/src/extract.ts`
  - Stop reassigning the `node` parameter in `getFullyQualifiedName`; introduce an `expr` const via `Extract.unwrap` and operate on that.

- `plugins/eslint-plugin-react-x/src/rules/static-components/lib.ts`
  - Replace the hand-rolled scope-chain walk in `findVariableForIdentifier` with `@typescript-eslint/utils/ast-utils`'s `findVariable`.
  - Split `resolveDynamicValue` into `findDynamicCreationSite` (expression resolution) and `findReassignmentCreationSite` (reassignment tracking).
  - Introduce a `DYNAMIC_EXPRESSION_TYPES` set for the node kinds that always produce a fresh value.
  - Remove the unused `isDynamicComponent` export.

- `plugins/eslint-plugin-react-x/src/rules/static-components/static-components.ts`
  - Collect JSX candidates as a typed `JsxComponentCandidate[]` storing the `JSXIdentifier` directly.
  - Extract `createRenderBoundaryChecker` to merge function/class component nodes into a single `Set` for the render-boundary check.
  - Extract `reportIfCreatedDuringRender` for per-candidate reporting.

- Tests and docs
  - Add test coverage in `static-components.spec.ts`.
  - Update the rule's `CHANGELOG.md` and `static-components.spec.diff.md` to reflect the new helper names and structure.

All existing checks pass: `dprint check`, `eslint`, `lint:ts`, `vitest run static-components.spec.ts`, and `textlint`.

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
