### PR TITLE
docs(react-x): expand rule docs for React introspection APIs

### DIFF
--- a/THIRD-PARTY-LICENSE
+++ b/THIRD-PARTY-LICENSE
@@ -151,3 +151,55 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+babel-plugin-react-compiler
+
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+Astryx
+
+MIT License
+
+Copyright (c) 2026 Meta Platforms, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-count/no-children-count.mdx
@@ -27,7 +27,21 @@ react-x/no-children-count
 
 ## Rule Details
 
-Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
+Using `Children.count` to inspect the children tree is a form of React child introspection. It creates fragile coupling between parent and child components:
+
+- Breaks when children are wrapped in HOCs, `forwardRef`, or `memo`.
+- Prevents React from optimizing rendering.
+- Creates implicit contracts that types can't enforce.
+- Makes composition unpredictable with fragments, portals, and other React features.
+
+Prefer these alternatives:
+
+- Compound components with context
+- Render props or slot props
+- Data-driven APIs (array of config objects)
+- CSS-based solutions (grid, flexbox, `:nth-child`, etc.)
+
+[See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
 ## Examples
 
@@ -142,3 +156,4 @@ function ItemList({ items }: ItemListProps) {
 ## Further Reading
 
 - [React Docs: `Children`](https://react.dev/reference/react/Children)
+- [Astryx `no-react-introspection` Rule](https://github.com/facebook/astryx/blob/main/internal/eslint-plugin-astryx/no-react-introspection.js)

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-for-each/no-children-for-each.mdx
@@ -27,7 +27,21 @@ react-x/no-children-for-each
 
 ## Rule Details
 
-Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
+Using `Children.forEach` to iterate over the children tree is a form of React child introspection. It creates fragile coupling between parent and child components:
+
+- Breaks when children are wrapped in HOCs, `forwardRef`, or `memo`.
+- Prevents React from optimizing rendering.
+- Creates implicit contracts that types can't enforce.
+- Makes composition unpredictable with fragments, portals, and other React features.
+
+Prefer these alternatives:
+
+- Compound components with context
+- Render props or slot props
+- Data-driven APIs (array of config objects)
+- CSS-based solutions (grid, flexbox, `:nth-child`, etc.)
+
+[See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
 ## Examples
 
@@ -128,3 +142,4 @@ function RowList({ rows }: { rows: Row[] }) {
 ## Further Reading
 
 - [React Docs: `Children`](https://react.dev/reference/react/Children)
+- [Astryx `no-react-introspection` Rule](https://github.com/facebook/astryx/blob/main/internal/eslint-plugin-astryx/no-react-introspection.js)

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-map/no-children-map.mdx
@@ -27,7 +27,21 @@ react-x/no-children-map
 
 ## Rule Details
 
-Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
+Using `Children.map` to transform children is a form of React child introspection. It creates fragile coupling between parent and child components:
+
+- Breaks when children are wrapped in HOCs, `forwardRef`, or `memo`.
+- Prevents React from optimizing rendering.
+- Creates implicit contracts that types can't enforce.
+- Makes composition unpredictable with fragments, portals, and other React features.
+
+Prefer these alternatives:
+
+- Compound components with context
+- Render props or slot props
+- Data-driven APIs (array of config objects)
+- CSS-based solutions (grid, flexbox, `:nth-child`, etc.)
+
+[See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
 ## Examples
 
@@ -122,3 +136,4 @@ function App() {
 ## Further Reading
 
 - [React Docs: `Children`](https://react.dev/reference/react/Children)
+- [Astryx `no-react-introspection` Rule](https://github.com/facebook/astryx/blob/main/internal/eslint-plugin-astryx/no-react-introspection.js)

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-only/no-children-only.mdx
@@ -27,7 +27,21 @@ react-x/no-children-only
 
 ## Rule Details
 
-Using `Children` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
+Using `Children.only` to assert the children tree shape is a form of React child introspection. It creates fragile coupling between parent and child components:
+
+- Breaks when children are wrapped in HOCs, `forwardRef`, or `memo`.
+- Prevents React from optimizing rendering.
+- Creates implicit contracts that types can't enforce.
+- Makes composition unpredictable with fragments, portals, and other React features.
+
+Prefer these alternatives:
+
+- Compound components with context
+- Render props or slot props
+- Data-driven APIs (array of config objects)
+- CSS-based solutions (grid, flexbox, `:nth-child`, etc.)
+
+[See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
 ## Examples
 
@@ -94,3 +108,4 @@ function App() {
 ## Further Reading
 
 - [React Docs: `Children`](https://react.dev/reference/react/Children)
+- [Astryx `no-react-introspection` Rule](https://github.com/facebook/astryx/blob/main/internal/eslint-plugin-astryx/no-react-introspection.js)

--- a/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-children-to-array/no-children-to-array.mdx
@@ -27,7 +27,21 @@ react-x/no-children-to-array
 
 ## Rule Details
 
-Using `Children.toArray` is uncommon and can lead to fragile code. [See common alternatives](https://react.dev/reference/react/Children#alternatives).
+Using `Children.toArray` to materialize the children tree is a form of React child introspection. It creates fragile coupling between parent and child components:
+
+- Breaks when children are wrapped in HOCs, `forwardRef`, or `memo`.
+- Prevents React from optimizing rendering.
+- Creates implicit contracts that types can't enforce.
+- Makes composition unpredictable with fragments, portals, and other React features.
+
+Prefer these alternatives:
+
+- Compound components with context
+- Render props or slot props
+- Data-driven APIs (array of config objects)
+- CSS-based solutions (grid, flexbox, `:nth-child`, etc.)
+
+[See common alternatives](https://react.dev/reference/react/Children#alternatives).
 
 ## Examples
 
@@ -119,3 +133,4 @@ function App() {
 ## Further Reading
 
 - [React Docs: `Children`](https://react.dev/reference/react/Children)
+- [Astryx `no-react-introspection` Rule](https://github.com/facebook/astryx/blob/main/internal/eslint-plugin-astryx/no-react-introspection.js)

--- a/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.mdx
+++ b/plugins/eslint-plugin-react-x/src/rules/no-clone-element/no-clone-element.mdx
@@ -27,7 +27,21 @@ react-x/no-clone-element
 
 ## Rule Details
 
-Using `cloneElement` is uncommon and can lead to fragile code. It also makes it harder to trace data flow. Try the [alternatives](https://react.dev/reference/react/cloneElement#alternatives) instead.
+Using `cloneElement` to inject props into children is a form of React child introspection. It creates fragile coupling between parent and child components:
+
+- Breaks when children are wrapped in HOCs, `forwardRef`, or `memo`.
+- Prevents React from optimizing rendering.
+- Creates implicit contracts that types can't enforce.
+- Makes composition unpredictable with fragments, portals, and other React features.
+
+Prefer these alternatives:
+
+- Compound components with context
+- Render props or slot props
+- Data-driven APIs (array of config objects)
+- CSS-based solutions (grid, flexbox, `:nth-child`, etc.)
+
+Try the [alternatives to `cloneElement`](https://react.dev/reference/react/cloneElement#alternatives) instead.
 
 ## Examples
 
@@ -149,3 +163,4 @@ function App() {
 
 - [React Docs: `cloneElement` Alternatives](https://react.dev/reference/react/cloneElement#alternatives)
 - [Legacy React APIs: `cloneElement`](https://react.dev/reference/react/cloneElement)
+- [Astryx `no-react-introspection` Rule](https://github.com/facebook/astryx/blob/main/internal/eslint-plugin-astryx/no-react-introspection.js)


### PR DESCRIPTION
Update the documentation for the rules that ban React child introspection:

- no-children-map
- no-children-count
- no-children-for-each
- no-children-only
- no-children-to-array
- no-clone-element

For each rule, the "Rule Details" section now explains that the flagged API is a form of React child introspection and creates fragile coupling between parent and child components. The problems are presented as a list:

- Breaks when children are wrapped in HOCs, forwardRef, or memo.
- Prevents React from optimizing rendering.
- Creates implicit contracts that types can't enforce.
- Makes composition unpredictable with fragments, portals, and other React features.

Recommended alternatives are also listed:

- Compound components with context
- Render props or slot props
- Data-driven APIs (array of config objects)
- CSS-based solutions (grid, flexbox, :nth-child, etc.)

The "Further Reading" section of each rule now includes a link to the Astryx no-react-introspection rule implementation for additional context.

All docs checks pass: pnpm check:docs, pnpm lint:mdx, pnpm lint:text.

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [x] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
