### PR TITLE
refactor(react-x): move purity and refs resolvers to lib.ts

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/purity/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/lib.ts
@@ -1,4 +1,8 @@
-// #region Impurity Detection
+import { Extract } from "@eslint-react/ast";
+import type { RuleContext } from "@eslint-react/eslint";
+import { DefinitionType } from "@typescript-eslint/scope-manager";
+import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
+import { findVariable } from "@typescript-eslint/utils/ast-utils";
 
 /**
  * Known impure functions
@@ -553,4 +557,45 @@ export const PURE_CTORS: ReadonlySet<string> = new Set([
   "WeakSet",
 ]);
 
-// #endregion
+/**
+ * Recursively resolve an identifier to the root builtin global object name.
+ * Follows simple assignment chains like `const M = Math` or `const w = window`.
+ * Returns `null` if the identifier is locally defined (parameter, import, function declaration, etc.)
+ * or resolves to a non-builtin source.
+ * @param context - The rule context.
+ * @param node - The identifier node to resolve.
+ * @param seen - A set of already visited identifier names to prevent infinite loops.
+ */
+export function resolveBuiltinObjectName(context: RuleContext, node: TSESTree.Identifier, seen = new Set<string>()): string | null {
+  if (seen.has(node.name)) return null;
+  seen.add(node.name);
+
+  const scope = context.sourceCode.getScope(node);
+  const variable = findVariable(scope, node);
+
+  // No variable found -> treat as global
+  if (variable == null) return node.name;
+
+  const def = variable.defs[0];
+  if (def == null) return node.name; // implicit global
+
+  if (def.type === DefinitionType.ImplicitGlobalVariable) {
+    return node.name;
+  }
+
+  if (def.type === DefinitionType.Variable && def.node.init != null) {
+    const init = Extract.unwrap(def.node.init);
+    if (init.type === AST.Identifier) {
+      return resolveBuiltinObjectName(context, init, seen);
+    }
+    if (init.type === AST.MemberExpression) {
+      const rootId = Extract.getRootIdentifier(init);
+      if (rootId != null) {
+        return resolveBuiltinObjectName(context, rootId, seen);
+      }
+    }
+  }
+
+  // Other definitions (Parameter, FunctionName, ImportBinding, etc.) are not builtins
+  return null;
+}

--- a/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
@@ -2,10 +2,8 @@ import { createRule } from "@/utils/create-rule";
 import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
-import { DefinitionType } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
-import { findVariable } from "@typescript-eslint/utils/ast-utils";
-import { IMPURE_CTORS, IMPURE_FUNCS } from "./lib";
+import { IMPURE_CTORS, IMPURE_FUNCS, resolveBuiltinObjectName } from "./lib";
 
 export const RULE_NAME = "purity";
 
@@ -28,53 +26,6 @@ export default createRule<[], MessageID>({
   create,
   defaultOptions: [],
 });
-
-/**
- * Recursively resolve an identifier to the root builtin global object name.
- * Follows simple assignment chains like `const M = Math` or `const w = window`.
- * Returns `null` if the identifier is locally defined (parameter, import, function declaration, etc.)
- * or resolves to a non-builtin source.
- * @param context - The rule context.
- * @param node - The identifier node to resolve.
- * @param seen - A set of already visited identifier names to prevent infinite loops.
- */
-function resolveBuiltinObjectName(
-  context: RuleContext,
-  node: TSESTree.Identifier,
-  seen = new Set<string>(),
-): string | null {
-  if (seen.has(node.name)) return null;
-  seen.add(node.name);
-
-  const scope = context.sourceCode.getScope(node);
-  const variable = findVariable(scope, node);
-
-  // No variable found -> treat as global
-  if (variable == null) return node.name;
-
-  const def = variable.defs[0];
-  if (def == null) return node.name; // implicit global
-
-  if (def.type === DefinitionType.ImplicitGlobalVariable) {
-    return node.name;
-  }
-
-  if (def.type === DefinitionType.Variable && def.node.init != null) {
-    const init = Extract.unwrap(def.node.init);
-    if (init.type === AST.Identifier) {
-      return resolveBuiltinObjectName(context, init, seen);
-    }
-    if (init.type === AST.MemberExpression) {
-      const rootId = Extract.getRootIdentifier(init);
-      if (rootId != null) {
-        return resolveBuiltinObjectName(context, rootId, seen);
-      }
-    }
-  }
-
-  // Other definitions (Parameter, FunctionName, ImportBinding, etc.) are not builtins
-  return null;
-}
 
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hc = core.getHookCollector(context);

--- a/plugins/eslint-plugin-react-x/src/rules/refs/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/lib.ts
@@ -1,20 +1,8 @@
 import { Check, Extract, type TSESTreeFunction } from "@eslint-react/ast";
+import * as core from "@eslint-react/core";
+import type { RuleContext } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
-
-export type NullCheckBranch = "alternate" | "consequent";
-
-export type PositionedValue<T> = {
-  position: number;
-  value: T;
-};
-
-export type RefAccess = {
-  isInitializationWrite: boolean;
-  isWrite: boolean;
-  node: TSESTree.MemberExpression;
-};
-
-type GetNullBranch = (test: TSESTree.Expression) => NullCheckBranch | null;
+import { findVariable } from "@typescript-eslint/utils/ast-utils";
 
 const SYNC_ARRAY_CALLBACKS = new Set([
   "every",
@@ -32,9 +20,191 @@ const SYNC_ARRAY_CALLBACKS = new Set([
   "sort",
 ]);
 
-// Binding and call helpers
+export type RefAccess = {
+  isInitializationWrite: boolean;
+  isWrite: boolean;
+  node: TSESTree.MemberExpression;
+};
 
-export function getLatestValue<T>(events: PositionedValue<T>[] | undefined, position: number): PositionedValue<T> | null {
+export type Variable = NonNullable<ReturnType<typeof findVariable>>;
+
+type PositionedValue<T> = {
+  position: number;
+  value: T;
+};
+
+type BindingValue =
+  | { kind: "function"; node: TSESTreeFunction }
+  | { kind: "ref" }
+  | { kind: "unknown" }
+  | { kind: "variable"; variable: Variable };
+
+type BindingEvent = PositionedValue<BindingValue>;
+
+type NullCheckBranch = "alternate" | "consequent";
+
+type GetNullBranch = (test: TSESTree.Expression) => NullCheckBranch | null;
+
+// Binding resolution
+
+export function createBindingResolver(context: RuleContext) {
+  const bindings = new Map<Variable, BindingEvent[]>();
+  const memberBindings = new Map<Variable, Map<string, BindingEvent[]>>();
+  const jsxRefs = new Set<Variable>();
+
+  function getVariable(node: TSESTree.Identifier): Variable | null {
+    return findVariable(context.sourceCode.getScope(node), node) ?? null;
+  }
+
+  function getBindingValue(node: TSESTree.Node): BindingValue {
+    const value = Extract.unwrap(node);
+    if (value.type === AST.Identifier) {
+      const variable = getVariable(value);
+      return variable == null ? { kind: "unknown" } : { kind: "variable", variable };
+    }
+    if (isFunctionExpressionLike(value)) return { kind: "function", node: value };
+    if (value.type === AST.CallExpression && (core.isUseRefCall(context, value) || core.isCreateRefCall(context, value))) {
+      return { kind: "ref" };
+    }
+    if (value.type === AST.MemberExpression) {
+      const property = Extract.getPropertyName(value.property);
+      if (property != null && isRefLikeName(property)) return { kind: "ref" };
+    }
+    return { kind: "unknown" };
+  }
+
+  function addBinding(variable: Variable, value: BindingValue, position: number) {
+    const events = bindings.get(variable) ?? [];
+    bindings.set(variable, events);
+    events.push({ position, value });
+  }
+
+  function addIdentifierBinding(node: TSESTree.Identifier, value: TSESTree.Node, position = node.range[0]) {
+    const variable = getVariable(node);
+    if (variable != null) addBinding(variable, getBindingValue(value), position);
+  }
+
+  function addFunctionBinding(node: TSESTree.Identifier, value: TSESTreeFunction, position: number) {
+    const variable = getVariable(node);
+    if (variable != null) addBinding(variable, { kind: "function", node: value }, position);
+  }
+
+  function addMemberBinding(object: TSESTree.Identifier, property: string, value: TSESTree.Node, position: number) {
+    const variable = getVariable(object);
+    if (variable == null) return;
+    const properties = memberBindings.get(variable) ?? new Map<string, BindingEvent[]>();
+    memberBindings.set(variable, properties);
+    const events = properties.get(property) ?? [];
+    properties.set(property, events);
+    events.push({ position, value: getBindingValue(value) });
+  }
+
+  function addJsxRef(node: TSESTree.Identifier) {
+    const variable = getVariable(node);
+    if (variable != null) jsxRefs.add(variable);
+  }
+
+  function resolveRef(variable: Variable, position: number, seen = new Set<Variable>()): Variable | null {
+    if (seen.has(variable)) return null;
+    seen.add(variable);
+    if (jsxRefs.has(variable) || isRefLikeName(variable.name)) return variable;
+    const event = getLatestValue(bindings.get(variable), position);
+    if (event != null) {
+      switch (event.value.kind) {
+        case "ref":
+          return variable;
+        case "variable":
+          return resolveRef(event.value.variable, event.position, seen);
+        case "function":
+        case "unknown":
+          return null;
+      }
+    }
+    return null;
+  }
+
+  function resolveFunction(variable: Variable, position: number, seen = new Set<Variable>()): TSESTreeFunction | null {
+    if (seen.has(variable)) return null;
+    seen.add(variable);
+    const event = getLatestValue(bindings.get(variable), position);
+    if (event == null) return null;
+    switch (event.value.kind) {
+      case "function":
+        return event.value.node;
+      case "variable":
+        return resolveFunction(event.value.variable, event.position, seen);
+      case "ref":
+      case "unknown":
+        return null;
+    }
+  }
+
+  function resolveCallable(node: TSESTree.Node, position: number): TSESTreeFunction | null {
+    const callee = Extract.unwrap(node);
+    if (isFunctionExpressionLike(callee)) return callee;
+    if (callee.type === AST.Identifier) {
+      const variable = getVariable(callee);
+      return variable == null ? null : resolveFunction(variable, position);
+    }
+    if (callee.type !== AST.MemberExpression) return null;
+    const object = Extract.unwrap(callee.object);
+    const property = Extract.getPropertyName(callee.property);
+    if (object.type !== AST.Identifier || property == null) return null;
+    const variable = getVariable(object);
+    if (variable == null) return null;
+    const event = getLatestValue(memberBindings.get(variable)?.get(property), position);
+    if (event == null) return null;
+    if (event.value.kind === "function") return event.value.node;
+    if (event.value.kind === "variable") return resolveFunction(event.value.variable, event.position);
+    return null;
+  }
+
+  function getRefTarget(node: TSESTree.MemberExpression): { identity: Variable | null } | null {
+    const object = Extract.unwrap(node.object);
+    if (object.type === AST.Identifier) {
+      const variable = getVariable(object);
+      if (variable == null) return null;
+      const identity = resolveRef(variable, node.range[0]);
+      return identity == null ? null : { identity };
+    }
+    if (object.type === AST.MemberExpression) {
+      const property = Extract.getPropertyName(object.property);
+      if (property != null && isRefLikeName(property)) return { identity: null };
+    }
+    return null;
+  }
+
+  function getNullBranch(test: TSESTree.Expression, identity: Variable): NullCheckBranch | null {
+    return getNullCheckBranch(
+      test,
+      (candidate) => {
+        if (candidate.type !== AST.MemberExpression || Extract.getPropertyName(candidate.property) !== "current") return false;
+        return getRefTarget(candidate)?.identity === identity;
+      },
+      (candidate) => {
+        if (candidate.type === AST.Literal) return candidate.value == null;
+        if (candidate.type === AST.UnaryExpression && candidate.operator === "void") return true;
+        if (candidate.type !== AST.Identifier || candidate.name !== "undefined") return false;
+        const variable = getVariable(candidate);
+        return variable == null || variable.defs.length === 0;
+      },
+    );
+  }
+
+  return {
+    addFunctionBinding,
+    addIdentifierBinding,
+    addJsxRef,
+    addMemberBinding,
+    getNullBranch,
+    getRefTarget,
+    getVariable,
+    resolveCallable,
+    resolveRef,
+  };
+}
+
+function getLatestValue<T>(events: PositionedValue<T>[] | undefined, position: number): PositionedValue<T> | null {
   let latest: PositionedValue<T> | null = null;
   for (const event of events ?? []) {
     if (event.position > position) continue;
@@ -43,13 +213,15 @@ export function getLatestValue<T>(events: PositionedValue<T>[] | undefined, posi
   return latest;
 }
 
-export function isFunctionExpressionLike(node: TSESTree.Node): node is TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression {
+function isFunctionExpressionLike(node: TSESTree.Node): node is TSESTree.FunctionExpression | TSESTree.ArrowFunctionExpression {
   return node.type === AST.FunctionExpression || node.type === AST.ArrowFunctionExpression;
 }
 
-export function isRefLikeName(name: string): boolean {
+function isRefLikeName(name: string): boolean {
   return name === "ref" || name.endsWith("Ref");
 }
+
+// Call reachability
 
 export function getCalleeName(node: TSESTree.CallExpression): string | null {
   const callee = Extract.unwrap(node.callee);
@@ -85,11 +257,28 @@ export function isReachedThroughFunctions(node: TSESTree.Node, boundary: TSESTre
 
 // Ref access classification
 
+export function getRefAccess(node: TSESTree.MemberExpression): RefAccess {
+  let parent: TSESTree.Node = node.parent;
+  while (Check.isTypeExpression(parent)) parent = parent.parent;
+  const isDirectWrite = parent.type === AST.AssignmentExpression
+    ? parent.left === node || Extract.unwrap(parent.left) === node
+    : parent.type === AST.UpdateExpression
+    ? parent.argument === node || Extract.unwrap(parent.argument) === node
+    : false;
+  return {
+    isInitializationWrite: parent.type === AST.AssignmentExpression
+      && parent.operator === "="
+      && (parent.left === node || Extract.unwrap(parent.left) === node),
+    isWrite: isDirectWrite || isNestedRefCurrentWrite(node),
+    node,
+  };
+}
+
 /**
  * Check whether `node` (a `ref.current` MemberExpression) is being written to indirectly through
  * a nested property write, e.g. `ref.current.inner = value` or `ref.current.inner++`.
  */
-export function isNestedRefCurrentWrite(node: TSESTree.MemberExpression): boolean {
+function isNestedRefCurrentWrite(node: TSESTree.MemberExpression): boolean {
   let outer: TSESTree.Node = node;
   let sawNesting = false;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -112,23 +301,6 @@ export function isNestedRefCurrentWrite(node: TSESTree.MemberExpression): boolea
   }
 }
 
-export function getRefAccess(node: TSESTree.MemberExpression): RefAccess {
-  let parent: TSESTree.Node = node.parent;
-  while (Check.isTypeExpression(parent)) parent = parent.parent;
-  const isDirectWrite = parent.type === AST.AssignmentExpression
-    ? parent.left === node || Extract.unwrap(parent.left) === node
-    : parent.type === AST.UpdateExpression
-    ? parent.argument === node || Extract.unwrap(parent.argument) === node
-    : false;
-  return {
-    isInitializationWrite: parent.type === AST.AssignmentExpression
-      && parent.operator === "="
-      && (parent.left === node || Extract.unwrap(parent.left) === node),
-    isWrite: isDirectWrite || isNestedRefCurrentWrite(node),
-    node,
-  };
-}
-
 // Null-guard analysis
 
 /**
@@ -136,7 +308,7 @@ export function getRefAccess(node: TSESTree.MemberExpression): RefAccess {
  * Truthiness checks such as `!ref.current` are deliberately excluded: falsy ref values are not
  * necessarily uninitialized.
  */
-export function getNullCheckBranch(
+function getNullCheckBranch(
   test: TSESTree.Expression,
   isCheckedValue: (node: TSESTree.Node) => boolean,
   isNullishValue: (node: TSESTree.Node) => boolean,
@@ -188,7 +360,7 @@ export function getGuardDisposition(node: TSESTree.MemberExpression, getNullBran
 }
 
 /** Return whether every path through a statement exits the current function. */
-export function isUnconditionallyTerminating(statement: TSESTree.Statement): boolean {
+function isUnconditionallyTerminating(statement: TSESTree.Statement): boolean {
   switch (statement.type) {
     case AST.ReturnStatement:
     case AST.ThrowStatement:

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
@@ -3,22 +3,17 @@ import { Check, Extract, type TSESTreeFunction, Traverse } from "@eslint-react/a
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, type RuleListener, merge } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
-import { findVariable } from "@typescript-eslint/utils/ast-utils";
 import {
-  type NullCheckBranch,
-  type PositionedValue,
   type RefAccess,
+  type Variable,
+  createBindingResolver,
   getCalleeName,
   getGuardDisposition,
-  getLatestValue,
-  getNullCheckBranch,
   getRefAccess,
   getSynchronousCallbackIndexes,
   isAfterTerminatingNonNullGuard,
-  isFunctionExpressionLike,
   isGuardTestAccess,
   isReachedThroughFunctions,
-  isRefLikeName,
 } from "./lib";
 
 export const RULE_NAME = "refs";
@@ -53,156 +48,25 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-type Variable = NonNullable<ReturnType<typeof findVariable>>;
-
-type BindingValue =
-  | { kind: "function"; node: TSESTreeFunction }
-  | { kind: "ref" }
-  | { kind: "unknown" }
-  | { kind: "variable"; variable: Variable };
-
-type BindingEvent = PositionedValue<BindingValue>;
-
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   const hc = core.getHookCollector(context);
   const fc = core.getFunctionComponentCollector(context);
+  const {
+    addFunctionBinding,
+    addIdentifierBinding,
+    addJsxRef,
+    addMemberBinding,
+    getNullBranch,
+    getRefTarget,
+    getVariable,
+    resolveCallable,
+    resolveRef,
+  } = createBindingResolver(context);
 
   // Phase 1: collect binding identities and ref operations. Maps are keyed by ESLint variables,
   // not source names, so shadowed identifiers and separate components cannot contaminate each other.
-  const bindings = new Map<Variable, BindingEvent[]>();
-  const memberBindings = new Map<Variable, Map<string, BindingEvent[]>>();
-  const jsxRefs = new Set<Variable>();
   const calls: TSESTree.CallExpression[] = [];
   const refAccesses: RefAccess[] = [];
-
-  function getVariable(node: TSESTree.Identifier): Variable | null {
-    return findVariable(context.sourceCode.getScope(node), node) ?? null;
-  }
-
-  function addBinding(variable: Variable, value: BindingValue, position: number) {
-    const events = bindings.get(variable) ?? [];
-    bindings.set(variable, events);
-    events.push({ position, value });
-  }
-
-  function addIdentifierBinding(node: TSESTree.Identifier, value: BindingValue, position = node.range[0]) {
-    const variable = getVariable(node);
-    if (variable != null) addBinding(variable, value, position);
-  }
-
-  function addMemberBinding(object: TSESTree.Identifier, property: string, value: BindingValue, position: number) {
-    const variable = getVariable(object);
-    if (variable == null) return;
-    const properties = memberBindings.get(variable) ?? new Map<string, BindingEvent[]>();
-    memberBindings.set(variable, properties);
-    const events = properties.get(property) ?? [];
-    properties.set(property, events);
-    events.push({ position, value });
-  }
-
-  function bindingValueFrom(node: TSESTree.Node): BindingValue {
-    const value = Extract.unwrap(node);
-    if (value.type === AST.Identifier) {
-      const variable = getVariable(value);
-      return variable == null ? { kind: "unknown" } : { kind: "variable", variable };
-    }
-    if (isFunctionExpressionLike(value)) return { kind: "function", node: value };
-    if (value.type === AST.CallExpression && (core.isUseRefCall(context, value) || core.isCreateRefCall(context, value))) {
-      return { kind: "ref" };
-    }
-    if (value.type === AST.MemberExpression) {
-      const property = Extract.getPropertyName(value.property);
-      if (property != null && isRefLikeName(property)) return { kind: "ref" };
-    }
-    return { kind: "unknown" };
-  }
-
-  function resolveRef(variable: Variable, position: number, seen = new Set<Variable>()): Variable | null {
-    if (seen.has(variable)) return null;
-    seen.add(variable);
-    if (jsxRefs.has(variable) || isRefLikeName(variable.name)) return variable;
-    const event = getLatestValue(bindings.get(variable), position);
-    if (event != null) {
-      switch (event.value.kind) {
-        case "ref":
-          return variable;
-        case "variable":
-          return resolveRef(event.value.variable, event.position, seen);
-        case "function":
-        case "unknown":
-          return null;
-      }
-    }
-    return null;
-  }
-
-  function resolveFunction(variable: Variable, position: number, seen = new Set<Variable>()): TSESTreeFunction | null {
-    if (seen.has(variable)) return null;
-    seen.add(variable);
-    const event = getLatestValue(bindings.get(variable), position);
-    if (event == null) return null;
-    switch (event.value.kind) {
-      case "function":
-        return event.value.node;
-      case "variable":
-        return resolveFunction(event.value.variable, event.position, seen);
-      case "ref":
-      case "unknown":
-        return null;
-    }
-  }
-
-  function resolveCallable(node: TSESTree.Node, position: number): TSESTreeFunction | null {
-    const callee = Extract.unwrap(node);
-    if (isFunctionExpressionLike(callee)) return callee;
-    if (callee.type === AST.Identifier) {
-      const variable = getVariable(callee);
-      return variable == null ? null : resolveFunction(variable, position);
-    }
-    if (callee.type !== AST.MemberExpression) return null;
-    const object = Extract.unwrap(callee.object);
-    const property = Extract.getPropertyName(callee.property);
-    if (object.type !== AST.Identifier || property == null) return null;
-    const variable = getVariable(object);
-    if (variable == null) return null;
-    const event = getLatestValue(memberBindings.get(variable)?.get(property), position);
-    if (event == null) return null;
-    if (event.value.kind === "function") return event.value.node;
-    if (event.value.kind === "variable") return resolveFunction(event.value.variable, event.position);
-    return null;
-  }
-
-  function getRefTarget(node: TSESTree.MemberExpression): { identity: Variable | null } | null {
-    const object = Extract.unwrap(node.object);
-    if (object.type === AST.Identifier) {
-      const variable = getVariable(object);
-      if (variable == null) return null;
-      const identity = resolveRef(variable, node.range[0]);
-      return identity == null ? null : { identity };
-    }
-    if (object.type === AST.MemberExpression) {
-      const property = Extract.getPropertyName(object.property);
-      if (property != null && isRefLikeName(property)) return { identity: null };
-    }
-    return null;
-  }
-
-  function getNullBranch(test: TSESTree.Expression, identity: Variable): NullCheckBranch | null {
-    return getNullCheckBranch(
-      test,
-      (candidate) => {
-        if (candidate.type !== AST.MemberExpression || Extract.getPropertyName(candidate.property) !== "current") return false;
-        return getRefTarget(candidate)?.identity === identity;
-      },
-      (candidate) => {
-        if (candidate.type === AST.Literal) return candidate.value == null;
-        if (candidate.type === AST.UnaryExpression && candidate.operator === "void") return true;
-        if (candidate.type !== AST.Identifier || candidate.name !== "undefined") return false;
-        const variable = getVariable(candidate);
-        return variable == null || variable.defs.length === 0;
-      },
-    );
-  }
 
   return merge(
     hc.visitor,
@@ -212,32 +76,27 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         if (node.operator !== "=") return;
         const left = Extract.unwrap(node.left);
         if (left.type === AST.Identifier) {
-          addIdentifierBinding(left, bindingValueFrom(node.right), node.range[0]);
+          addIdentifierBinding(left, node.right, node.range[0]);
           return;
         }
         if (left.type !== AST.MemberExpression) return;
         const object = Extract.unwrap(left.object);
         const property = Extract.getPropertyName(left.property);
         if (object.type === AST.Identifier && property != null) {
-          addMemberBinding(object, property, bindingValueFrom(node.right), node.range[0]);
+          addMemberBinding(object, property, node.right, node.range[0]);
         }
       },
       CallExpression(node: TSESTree.CallExpression) {
         calls.push(node);
       },
       FunctionDeclaration(node: TSESTree.FunctionDeclaration) {
-        if (node.id != null) addIdentifierBinding(node.id, { kind: "function", node }, -1);
+        if (node.id != null) addFunctionBinding(node.id, node, -1);
       },
       JSXAttribute(node: TSESTree.JSXAttribute) {
-        if (
-          node.name.type !== AST.JSXIdentifier
-          || node.name.name !== "ref"
-          || node.value?.type !== AST.JSXExpressionContainer
-        ) return;
+        if (node.name.type !== AST.JSXIdentifier || node.name.name !== "ref" || node.value?.type !== AST.JSXExpressionContainer) return;
         const expression = Extract.unwrap(node.value.expression);
         if (expression.type !== AST.Identifier) return;
-        const variable = getVariable(expression);
-        if (variable != null) jsxRefs.add(variable);
+        addJsxRef(expression);
       },
       MemberExpression(node: TSESTree.MemberExpression) {
         if (Extract.getPropertyName(node.property) !== "current") return;
@@ -349,7 +208,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       },
       VariableDeclarator(node: TSESTree.VariableDeclarator) {
         if (node.id.type !== AST.Identifier || node.init == null) return;
-        addIdentifierBinding(node.id, bindingValueFrom(node.init), node.range[0]);
+        addIdentifierBinding(node.id, node.init, node.range[0]);
       },
     },
   );


### PR DESCRIPTION
Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
