### PR TITLE
refactor: use Check.isIdentifier and Extract.unwrap consistently

### DIFF
--- a/packages/ast/src/compare.ts
+++ b/packages/ast/src/compare.ts
@@ -51,8 +51,8 @@ export const isEqual: {
       }
       return true;
     }
-    case a.type === AST.Identifier
-      && b.type === AST.Identifier:
+    case Check.isIdentifier(a)
+      && Check.isIdentifier(b):
       return a.name === b.name;
     case a.type === AST.PrivateIdentifier
       && b.type === AST.PrivateIdentifier:

--- a/packages/ast/src/extract.ts
+++ b/packages/ast/src/extract.ts
@@ -40,10 +40,10 @@ export function findProperty(properties: TSESTree.ObjectLiteralElement[], name: 
  */
 export function getCalleeName(node: TSESTree.CallExpression): string | null {
   const callee = unwrap(node.callee);
-  if (callee.type === AST.Identifier) {
+  if (Check.isIdentifier(callee)) {
     return callee.name;
   }
-  if (callee.type === AST.MemberExpression && !callee.computed && callee.property.type === AST.Identifier) {
+  if (callee.type === AST.MemberExpression && !callee.computed && Check.isIdentifier(callee.property)) {
     return callee.property.name;
   }
   return null;
@@ -73,7 +73,7 @@ export function getInnermostCall(node: TSESTree.CallExpression): TSESTree.CallEx
  */
 export function getPropertyName(property: TSESTree.Property, effort: "min" | "max" = "min"): string | null {
   const key = unwrap(property.key);
-  if (key.type === AST.Identifier && !property.computed) return key.name;
+  if (Check.isIdentifier(key) && !property.computed) return key.name;
   if (effort === "min") return null;
   if (key.type === AST.Literal && typeof key.value === "string") return key.value;
   if (key.type === AST.TemplateLiteral && key.expressions.length === 0) {
@@ -123,9 +123,9 @@ export function getIdentifierAt(node: TSESTree.Expression | TSESTree.PrivateIden
   let current: TSESTree.Node = unwrap(node);
   while (current.type === AST.MemberExpression) {
     const property = unwrap(current.property);
-    identifiers.unshift(property.type === AST.Identifier ? property : null);
+    identifiers.unshift(Check.isIdentifier(property) ? property : null);
     current = unwrap(current.object);
   }
-  identifiers.unshift(current.type === AST.Identifier ? current : null);
+  identifiers.unshift(Check.isIdentifier(current) ? current : null);
   return identifiers.at(position) ?? null;
 }

--- a/packages/core/src/class-component.test.ts
+++ b/packages/core/src/class-component.test.ts
@@ -208,6 +208,19 @@ describe("isThisSetStateCall", () => {
     }, true);
     expect(result).toBe(false);
   });
+
+  it("should return true when this is wrapped in TSAsExpression", () => {
+    const code = "(this as any).setState({})";
+    let result = false;
+    simpleTraverse(parseCode(code).ast, {
+      enter(node) {
+        if (node.type === AST.CallExpression) {
+          result = isThisSetStateCall(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
 });
 
 describe("isAssignmentToThisState", () => {
@@ -287,5 +300,44 @@ describe("isAssignmentToThisState", () => {
       },
     }, true);
     expect(result).toBe(false);
+  });
+
+  it("should return true for (this as any).state = {}", () => {
+    const code = "(this as any).state = {}";
+    let result = false;
+    simpleTraverse(parseCode(code).ast, {
+      enter(node) {
+        if (node.type === AST.AssignmentExpression) {
+          result = isAssignmentToThisState(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should return true for (this as any).state.foo = 'baz'", () => {
+    const code = "(this as any).state.foo = 'baz'";
+    let result = false;
+    simpleTraverse(parseCode(code).ast, {
+      enter(node) {
+        if (node.type === AST.AssignmentExpression) {
+          result = isAssignmentToThisState(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
+  });
+
+  it("should return true for this!.state = {}", () => {
+    const code = "this!.state = {}";
+    let result = false;
+    simpleTraverse(parseCode(code).ast, {
+      enter(node) {
+        if (node.type === AST.AssignmentExpression) {
+          result = isAssignmentToThisState(node);
+        }
+      },
+    }, true);
+    expect(result).toBe(true);
   });
 });

--- a/packages/core/src/class-component.ts
+++ b/packages/core/src/class-component.ts
@@ -37,10 +37,10 @@ export function isClassComponent(node: TSESTree.Node): node is TSESTreeClass {
   if ("superClass" in node && node.superClass != null) {
     const re = /^(?:Pure)?Component$/u;
     switch (true) {
-      case node.superClass.type === AST.Identifier:
+      case Check.isIdentifier(node.superClass):
         return re.test(node.superClass.name);
       case node.superClass.type === AST.MemberExpression
-        && node.superClass.property.type === AST.Identifier:
+        && Check.isIdentifier(node.superClass.property):
         return re.test(node.superClass.property.name);
     }
   }
@@ -57,10 +57,10 @@ export function isPureComponent(node: TSESTree.Node) {
   if ("superClass" in node && node.superClass != null) {
     const re = /^PureComponent$/u;
     switch (true) {
-      case node.superClass.type === AST.Identifier:
+      case Check.isIdentifier(node.superClass):
         return re.test(node.superClass.name);
       case node.superClass.type === AST.MemberExpression
-        && node.superClass.property.type === AST.Identifier:
+        && Check.isIdentifier(node.superClass.property):
         return re.test(node.superClass.property.name);
     }
   }
@@ -75,7 +75,7 @@ function createLifecycleChecker(methodName: string, isStatic = false) {
   return (node: TSESTree.Node): node is TSESTreeMethodOrPropertyDefinition => (
     Check.isPropertyOrMethod(node)
     && node.static === isStatic
-    && node.key.type === AST.Identifier
+    && Check.isIdentifier(node.key)
     && node.key.name === methodName
   );
 }
@@ -110,7 +110,6 @@ export const isUnsafeComponentWillMount = createLifecycleChecker("UNSAFE_compone
 export const isUnsafeComponentWillReceiveProps = createLifecycleChecker("UNSAFE_componentWillReceiveProps");
 /** @deprecated Class components are legacy. */
 export const isUnsafeComponentWillUpdate = createLifecycleChecker("UNSAFE_componentWillUpdate");
-
 /** @deprecated Class components are legacy. */
 export const isGetDefaultProps = createLifecycleChecker("getDefaultProps", true);
 /** @deprecated Class components are legacy. */
@@ -130,7 +129,7 @@ export const isGetDerivedStateFromError = createLifecycleChecker("getDerivedStat
  */
 export function isRenderMethodLike(node: TSESTree.Node): node is TSESTreeMethodOrPropertyDefinition {
   return Check.isPropertyOrMethod(node)
-    && node.key.type === AST.Identifier
+    && Check.isIdentifier(node.key)
     && node.key.name.startsWith("render")
     && Check.isOneOf([AST.ClassDeclaration, AST.ClassExpression])(node.parent.parent);
 }
@@ -144,9 +143,8 @@ export function isRenderMethodCallback(node: TSESTreeFunction) {
   const parent = node.parent;
   const grandparent = parent.parent;
   const greatGrandparent = grandparent?.parent;
-  return greatGrandparent != null
-    && isRenderMethodLike(parent)
-    && isClassComponent(greatGrandparent);
+  if (greatGrandparent == null) return false;
+  return isRenderMethodLike(parent) && isClassComponent(greatGrandparent);
 }
 
 // #endregion
@@ -163,7 +161,7 @@ export function isThisSetStateCall(node: TSESTree.CallExpression) {
   const callee = Extract.unwrap(node.callee);
   return (
     callee.type === AST.MemberExpression
-    && callee.object.type === AST.ThisExpression
+    && Extract.unwrap(callee.object).type === AST.ThisExpression
     && Extract.getCalleeName(node) === "setState"
   );
 }
@@ -178,11 +176,12 @@ export function isAssignmentToThisState(node: TSESTree.AssignmentExpression) {
   const { left } = node;
   let current: TSESTree.Node = Extract.unwrap(left);
   while (current.type === AST.MemberExpression) {
-    const { object, property } = current;
-    if (object.type === AST.ThisExpression && property.type === AST.Identifier && property.name === "state") {
+    const object = Extract.unwrap(current.object);
+    const property = current.property;
+    if (object.type === AST.ThisExpression && Check.isIdentifier(property, "state")) {
       return true;
     }
-    current = Extract.unwrap(object);
+    current = object;
   }
   return false;
 }

--- a/packages/core/src/function-component.test.ts
+++ b/packages/core/src/function-component.test.ts
@@ -24,7 +24,7 @@ function createMockContext(): RuleContext {
   return {
     sourceCode: {
       getText: (node: TSESTree.Node) => {
-        if (node.type === AST.Identifier) {
+        if (Check.isIdentifier(node)) {
           return node.name;
         }
         return "";
@@ -180,7 +180,7 @@ describe("getFunctionComponentId", () => {
         if (Check.isFunction(node) && node.type === expectedType) {
           const id = getFunctionComponentId(context, node);
           expect(id).not.toBeNull();
-          if (id?.type === AST.Identifier) {
+          if (id != null && Check.isIdentifier(id)) {
             expect(id.name).toBe(expectedName);
           }
           found = true;

--- a/packages/core/src/function-component.ts
+++ b/packages/core/src/function-component.ts
@@ -179,10 +179,10 @@ export function isFunctionComponentNameLoose(name: string) {
 export function isFunctionWithLooseComponentName(context: RuleContext, fn: TSESTreeFunction, allowNone = false) {
   const id = getFunctionComponentId(context, fn);
   if (id == null) return allowNone;
-  if (id.type === AST.Identifier) {
+  if (Check.isIdentifier(id)) {
     return isFunctionComponentNameLoose(id.name);
   }
-  if (id.type === AST.MemberExpression && id.property.type === AST.Identifier) {
+  if (id.type === AST.MemberExpression && Check.isIdentifier(id.property)) {
     return isFunctionComponentNameLoose(id.property.name);
   }
   return false;

--- a/packages/core/src/function.test.ts
+++ b/packages/core/src/function.test.ts
@@ -95,7 +95,7 @@ describe("getFunctionId", () => {
         if (Check.isFunction(node) && node.type === expectedType) {
           const id = getFunctionId(node);
           expect(id).not.toBeNull();
-          if (id?.type === AST.Identifier) {
+          if (id != null && Check.isIdentifier(id)) {
             expect(id.name).toBe(expectedName);
           }
           found = true;

--- a/packages/core/src/function.ts
+++ b/packages/core/src/function.ts
@@ -230,7 +230,7 @@ export function isFunctionHasCallInInitPath(callName: string, initPath: Function
     const callee = Extract.unwrap(node.callee);
 
     // Check direct function calls: memo(...)
-    if (callee.type === AST.Identifier) {
+    if (Check.isIdentifier(callee)) {
       return callee.name === callName;
     }
 

--- a/packages/jsx/src/attribute-find.ts
+++ b/packages/jsx/src/attribute-find.ts
@@ -1,4 +1,4 @@
-import { type TSESTreeJSXAttributeLike, Traverse } from "@eslint-react/ast";
+import { Check, type TSESTreeJSXAttributeLike, Traverse } from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/eslint";
 import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -75,11 +75,11 @@ export function findSpreadProperty(
   seen: Set<TSESTree.Node> = new Set(),
 ): TSESTree.Property | undefined {
   let objectExpression: TSESTree.ObjectExpression | undefined;
-  if (argument.type === AST.Identifier) {
+  if (Check.isIdentifier(argument)) {
     // Follow identifier aliases (`const b = a`) until a non-identifier
     // initializer is reached, mirroring `getStaticValue`'s identifier tracking.
     let initNode: TSESTree.Node | null = resolve(context, argument);
-    while (initNode != null && initNode.type === AST.Identifier && !seen.has(initNode)) {
+    while (initNode != null && Check.isIdentifier(initNode) && !seen.has(initNode)) {
       seen.add(initNode);
       initNode = resolve(context, initNode);
     }
@@ -103,7 +103,7 @@ export function findSpreadProperty(
         if (getStaticValue(key, keyScope)?.value === name) return property;
         continue;
       }
-      if (key.type === AST.Identifier && key.name === name) return property;
+      if (Check.isIdentifier(key, name)) return property;
       if (key.type === AST.Literal && key.value === name) return property;
       continue;
     }

--- a/packages/var/src/get-require-expression-arguments.ts
+++ b/packages/var/src/get-require-expression-arguments.ts
@@ -1,4 +1,4 @@
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 /**
@@ -11,7 +11,7 @@ export function getRequireExpressionArguments(node: TSESTree.Node) {
   const unwrapped = Extract.unwrap(node);
   if (unwrapped.type === AST.CallExpression) {
     const callee = Extract.unwrap(unwrapped.callee);
-    if (callee.type === AST.Identifier && callee.name === "require") {
+    if (Check.isIdentifier(callee, "require")) {
       return unwrapped.arguments;
     }
   }

--- a/packages/var/src/is-assignment-target-equal.test.ts
+++ b/packages/var/src/is-assignment-target-equal.test.ts
@@ -1,3 +1,4 @@
+import { Check } from "@eslint-react/ast";
 import { runInRule } from "@local/testkit";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
@@ -21,7 +22,7 @@ function findIdentifierRefs(root: TSESTree.Node, name: string): TSESTree.Identif
   const result: TSESTree.Identifier[] = [];
   simpleTraverse(root, {
     enter(node) {
-      if (node.type === AST.Identifier && node.name === name) {
+      if (Check.isIdentifier(node, name)) {
         const parent = node.parent;
         if (parent.type === AST.VariableDeclarator && parent.id === node) return;
         if (parent.type === AST.FunctionDeclaration && parent.id === node) return;

--- a/packages/var/src/is-value-equal.test.ts
+++ b/packages/var/src/is-value-equal.test.ts
@@ -1,3 +1,4 @@
+import { Check } from "@eslint-react/ast";
 import { runInRule } from "@local/testkit";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
@@ -22,7 +23,7 @@ function findIdentifierRefs(root: TSESTree.Node, name: string): TSESTree.Identif
   const result: TSESTree.Identifier[] = [];
   simpleTraverse(root, {
     enter(node) {
-      if (node.type === AST.Identifier && node.name === name) {
+      if (Check.isIdentifier(node, name)) {
         const parent = node.parent;
         if (parent.type === AST.VariableDeclarator && parent.id === node) return;
         if (parent.type === AST.FunctionDeclaration && parent.id === node) return;

--- a/packages/var/src/is-value-equal.ts
+++ b/packages/var/src/is-value-equal.ts
@@ -38,8 +38,8 @@ export function isValueEqual(
       && b.type === AST.TemplateElement: {
       return a.value.cooked === b.value.cooked;
     }
-    case a.type === AST.Identifier
-      && b.type === AST.Identifier: {
+    case Check.isIdentifier(a)
+      && Check.isIdentifier(b): {
       const aDefNode = resolve(context, a);
       const bDefNode = resolve(context, b);
       const aDefNodeParent = aDefNode?.parent;

--- a/packages/var/src/resolve-enclosing-assignment-target.test.ts
+++ b/packages/var/src/resolve-enclosing-assignment-target.test.ts
@@ -1,3 +1,4 @@
+import { Check } from "@eslint-react/ast";
 import { parseCode } from "@local/testkit";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
@@ -101,7 +102,7 @@ describe("resolveEnclosingAssignmentTarget", () => {
       let itemRef: TSESTree.Identifier | null = null;
       simpleTraverse(ast, {
         enter(node, parent) {
-          if (node.type === AST.Identifier && node.name === "item" && parent?.type === AST.ExpressionStatement) {
+          if (Check.isIdentifier(node, "item") && parent?.type === AST.ExpressionStatement) {
             itemRef = node;
           }
         },

--- a/packages/var/src/resolve-object-type.ts
+++ b/packages/var/src/resolve-object-type.ts
@@ -134,7 +134,7 @@ export function resolveObjectType(context: RuleContext, node: TSESTree.Node | nu
       }
 
       // Handle static factory methods (e.g. Array.from(), Object.create())
-      if (callee.type === AST.MemberExpression && callee.object.type === AST.Identifier) {
+      if (callee.type === AST.MemberExpression && Check.isIdentifier(callee.object)) {
         const objName = callee.object.name;
         const methodName = Extract.getCalleeName(node);
         switch (objName) {

--- a/packages/var/src/resolve.test.ts
+++ b/packages/var/src/resolve.test.ts
@@ -1,3 +1,4 @@
+import { Check } from "@eslint-react/ast";
 import { runInRule } from "@local/testkit";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 import { simpleTraverse } from "@typescript-eslint/typescript-estree";
@@ -15,7 +16,7 @@ function findIdentifierReferences(ast: TSESTree.Program, name: string): TSESTree
   const refs: TSESTree.Identifier[] = [];
   simpleTraverse(ast, {
     enter(node, parent) {
-      if (node.type !== AST.Identifier || node.name !== name) return;
+      if (!Check.isIdentifier(node, name)) return;
       if (parent == null) return;
       // Skip declaration sites
       if (parent.type === AST.VariableDeclarator && parent.id === node) return;
@@ -143,7 +144,7 @@ describe("resolve", () => {
       const identifiers: TSESTree.Identifier[] = [];
       simpleTraverse(ast, {
         enter(node, parent) {
-          if (node.type !== AST.Identifier || node.name !== "outer") return;
+          if (!Check.isIdentifier(node, "outer")) return;
           if (parent == null) return;
           if (parent.type === AST.VariableDeclarator && parent.id === node) return;
           identifiers.push(node);

--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-react/lib.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-react/lib.ts
@@ -1,3 +1,4 @@
+import { Check } from "@eslint-react/ast";
 import { isInitializedFromReact } from "@eslint-react/var";
 import type { Scope } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -18,7 +19,7 @@ export function isFromReact(
   switch (true) {
     case node.parent.type === AST.MemberExpression
       && node.parent.property === node
-      && node.parent.object.type === AST.Identifier:
+      && Check.isIdentifier(node.parent.object):
       return isInitializedFromReact(node.parent.object.name, initialScope, importSource);
     case node.parent.type === AST.JSXMemberExpression
       && node.parent.property === node

--- a/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/lib.ts
+++ b/plugins/eslint-plugin-react-debug/src/rules/is-from-ref/lib.ts
@@ -1,3 +1,4 @@
+import { Check } from "@eslint-react/ast";
 import { isUseRefLikeCall } from "@eslint-react/core";
 import { type RuleContext } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
@@ -14,7 +15,7 @@ export function getRefInitNode(
   switch (true) {
     case node.parent.type === AST.MemberExpression
       && node.parent.property === node
-      && node.parent.object.type === AST.Identifier:
+      && Check.isIdentifier(node.parent.object):
       return getRefInit(context, node.parent.object.name, initialScope);
     case node.parent.type === AST.JSXMemberExpression
       && node.parent.property === node
@@ -45,7 +46,7 @@ export function getRefInit(
     switch (true) {
       // const identifier = anotherRef.current;
       case init.type === AST.MemberExpression
-        && init.object.type === AST.Identifier
+        && Check.isIdentifier(init.object)
         && (init.object.name === "ref" || init.object.name.endsWith("Ref")):
         return init;
       // const identifier = useRef();

--- a/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-hydrate/no-hydrate.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleFixer, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -46,7 +46,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const callee = Extract.unwrap(node.callee);
       switch (true) {
         // Case 1: Direct call to `hydrate()`.
-        case callee.type === AST.Identifier
+        case Check.isIdentifier(callee)
           && hydrateNames.has(callee.name):
           context.report({
             fix: buildFix(context, node),
@@ -56,7 +56,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           return;
         // Case 2: Call on a `react-dom` import, like `ReactDOM.hydrate()`
         case callee.type === AST.MemberExpression
-          && callee.object.type === AST.Identifier
+          && Check.isIdentifier(callee.object)
           && Extract.getCalleeName(node) === "hydrate"
           && reactDomNames.has(callee.object.name):
           context.report({
@@ -75,7 +75,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         switch (specifier.type) {
           // `import { hydrate } from 'react-dom'`
           case AST.ImportSpecifier:
-            if (specifier.imported.type !== AST.Identifier) continue;
+            if (!Check.isIdentifier(specifier.imported)) continue;
             if (specifier.imported.name === "hydrate") {
               hydrateNames.add(specifier.local.name);
             }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render-return-value/no-render-return-value.ts
@@ -51,7 +51,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const callee = Extract.unwrap(node.callee);
       switch (true) {
         // Handles direct calls to 'render' (ex: from `import { render } from 'react-dom'`)
-        case callee.type === AST.Identifier
+        case Check.isIdentifier(callee)
           && renderNames.has(callee.name)
           // Check if the return value is being used
           && isReturnValueUsed(node):
@@ -62,7 +62,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           return;
         // Handles member expression calls like 'ReactDOM.render'
         case callee.type === AST.MemberExpression
-          && callee.object.type === AST.Identifier
+          && Check.isIdentifier(callee.object)
           && Extract.getCalleeName(node) === "render"
           && reactDomNames.has(callee.object.name)
           // Check if the return value is being used
@@ -83,7 +83,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         switch (specifier.type) {
           // Handles named imports like `import { render } from 'react-dom'`
           case AST.ImportSpecifier:
-            if (specifier.imported.type !== AST.Identifier) continue;
+            if (!Check.isIdentifier(specifier.imported)) continue;
             if (specifier.imported.name === "render") {
               renderNames.add(specifier.local.name);
             }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-render/no-render.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleFixer, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -48,7 +48,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const callee = Extract.unwrap(node.callee);
       switch (true) {
         // Case 1: Direct call to 'render', e.g., from `import { render } from 'react-dom'`
-        case callee.type === AST.Identifier
+        case Check.isIdentifier(callee)
           && renderNames.has(callee.name):
           context.report({
             fix: buildFix(context, node),
@@ -58,7 +58,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           return;
         // Case 2: Member expression call, e.g., `ReactDOM.render()`
         case callee.type === AST.MemberExpression
-          && callee.object.type === AST.Identifier
+          && Check.isIdentifier(callee.object)
           && Extract.getCalleeName(node) === "render"
           && reactDomNames.has(callee.object.name):
           context.report({
@@ -77,7 +77,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         switch (specifier.type) {
           // Handles: import { render } from 'react-dom'
           case AST.ImportSpecifier:
-            if (specifier.imported.type !== AST.Identifier) continue;
+            if (!Check.isIdentifier(specifier.imported)) continue;
             if (specifier.imported.name === "render") {
               renderNames.add(specifier.local.name);
             }

--- a/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
+++ b/plugins/eslint-plugin-react-dom/src/rules/no-use-form-state/no-use-form-state.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext, type RuleFeature, type RuleFixer, type RuleListener } from "@eslint-react/eslint";
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -48,7 +48,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const callee = Extract.unwrap(node.callee);
       switch (true) {
         // Case 1: Direct call like `useFormState(...)`
-        case callee.type === AST.Identifier
+        case Check.isIdentifier(callee)
           && useFormStateNames.has(callee.name):
           context.report({
             fix: buildFix(context, node),
@@ -58,7 +58,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           return;
         // Case 2: Member call like `ReactDOM.useFormState(...)`
         case callee.type === AST.MemberExpression
-          && callee.object.type === AST.Identifier
+          && Check.isIdentifier(callee.object)
           && Extract.getCalleeName(node) === "useFormState"
           && reactDomNames.has(callee.object.name):
           context.report({
@@ -78,7 +78,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         switch (specifier.type) {
           // Handles: import { useFormState } from 'react-dom';
           case AST.ImportSpecifier:
-            if (specifier.imported.type !== AST.Identifier) continue;
+            if (!Check.isIdentifier(specifier.imported)) continue;
             if (specifier.imported.name === "useFormState") {
               useFormStateNames.add(specifier.local.name);
             }

--- a/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
+++ b/plugins/eslint-plugin-react-rsc/src/rules/function-definition/function-definition.ts
@@ -168,7 +168,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (!hasFileLevelUseServerDirective) return;
       const decl = Extract.unwrap(node.declaration);
       // export default serverFunction;
-      if (decl.type === AST.Identifier) {
+      if (Check.isIdentifier(decl)) {
         reportNonAsyncFunction(resolve(context, decl), "file");
         return;
       }

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-event-listener/no-leaked-event-listener.ts
@@ -133,13 +133,13 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       if (!ComponentPhaseRelevance.has(fKind)) {
         return;
       }
-      const unwrappedCallee = Extract.unwrap(node.callee);
+      const callee = Extract.unwrap(node.callee);
       match(getCallKind(node))
         .with("addEventListener", (callKind) => {
           // https://github.com/Rel1cx/eslint-react/issues/1323
-          const isFromReactNative = unwrappedCallee.type === AST.MemberExpression
-            && unwrappedCallee.object.type === AST.Identifier
-            && isInitializedFromReactNative(unwrappedCallee.object.name, context.sourceCode.getScope(node));
+          const isFromReactNative = callee.type === AST.MemberExpression
+            && Check.isIdentifier(callee.object)
+            && isInitializedFromReactNative(callee.object.name, context.sourceCode.getScope(node));
           if (isFromReactNative) {
             return;
           }
@@ -150,7 +150,6 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           const opts = options == null
             ? defaultOptions
             : getOptions(context, options);
-          const { callee } = node;
           checkInlineFunction(node, callKind, opts);
           aEntries.push({
             ...opts,
@@ -170,7 +169,6 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           const opts = options == null
             ? defaultOptions
             : getOptions(context, options);
-          const { callee } = node;
           checkInlineFunction(node, callKind, opts);
           rEntries.push({
             ...opts,

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/lib.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-fetch/lib.ts
@@ -1,11 +1,11 @@
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext } from "@eslint-react/eslint";
 import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 
 export function findProperty(node: TSESTree.ObjectLiteralElement[], name: string): TSESTree.Property | null {
   for (const property of node) {
-    if (property.type === AST.Property && !property.computed && property.key.type === AST.Identifier && property.key.name === name) {
+    if (property.type === AST.Property && !property.computed && Check.isIdentifier(property.key, name)) {
       return property;
     }
     if (property.type === AST.SpreadElement && property.argument.type === AST.ObjectExpression) {

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/lib.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/lib.ts
@@ -1,4 +1,4 @@
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext } from "@eslint-react/eslint";
 import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -6,13 +6,12 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 export function isNewIntersectionObserver(node: TSESTree.Node | null) {
   if (node?.type !== AST.NewExpression) return false;
   const callee = Extract.unwrap(node.callee);
-  return callee.type === AST.Identifier
-    && callee.name === "IntersectionObserver";
+  return Check.isIdentifier(callee, "IntersectionObserver");
 }
 
 export function isFromObserver(context: RuleContext, node: TSESTree.Expression): boolean {
   switch (true) {
-    case node.type === AST.Identifier: {
+    case Check.isIdentifier(node): {
       const initNode = resolve(context, node);
       const unwrapped = initNode == null ? null : Extract.unwrap(initNode);
       return isNewIntersectionObserver(unwrapped);

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/no-leaked-intersection-observer.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-intersection-observer/no-leaked-intersection-observer.ts
@@ -97,20 +97,20 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       fEntries.pop();
     },
     ["CallExpression"](node) {
-      const unwrappedCallee = Extract.unwrap(node.callee);
-      if (unwrappedCallee.type !== AST.MemberExpression) {
+      const callee = Extract.unwrap(node.callee);
+      if (callee.type !== AST.MemberExpression) {
         return;
       }
       const fKind = fEntries.findLast((x) => x.kind !== "other")?.kind;
       if (fKind == null || !ComponentPhaseRelevance.has(fKind)) {
         return;
       }
-      const { object } = unwrappedCallee;
+      const { object } = callee;
       match(getCallKind(context, node))
         .with("disconnect", () => {
           dEntries.push({
             kind: "IntersectionObserver",
-            callee: node.callee,
+            callee,
             method: "disconnect",
             node,
             observer: object,
@@ -124,7 +124,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           }
           oEntries.push({
             kind: "IntersectionObserver",
-            callee: node.callee,
+            callee,
             element,
             method: "observe",
             node,
@@ -139,7 +139,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           }
           uEntries.push({
             kind: "IntersectionObserver",
-            callee: node.callee,
+            callee,
             element,
             method: "unobserve",
             node,

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/lib.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/lib.ts
@@ -1,4 +1,4 @@
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import { type RuleContext } from "@eslint-react/eslint";
 import { resolve } from "@eslint-react/var";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -6,13 +6,12 @@ import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
 export function isNewResizeObserver(node: TSESTree.Node | null) {
   if (node?.type !== AST.NewExpression) return false;
   const callee = Extract.unwrap(node.callee);
-  return callee.type === AST.Identifier
-    && callee.name === "ResizeObserver";
+  return Check.isIdentifier(callee, "ResizeObserver");
 }
 
 export function isFromObserver(context: RuleContext, node: TSESTree.Expression): boolean {
   switch (true) {
-    case node.type === AST.Identifier: {
+    case Check.isIdentifier(node): {
       const initNode = resolve(context, node);
       const unwrapped = initNode == null ? null : Extract.unwrap(initNode);
       return isNewResizeObserver(unwrapped);

--- a/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
+++ b/plugins/eslint-plugin-react-web-api/src/rules/no-leaked-resize-observer/no-leaked-resize-observer.ts
@@ -97,20 +97,20 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       fEntries.pop();
     },
     ["CallExpression"](node) {
-      const unwrappedCallee = Extract.unwrap(node.callee);
-      if (unwrappedCallee.type !== AST.MemberExpression) {
+      const callee = Extract.unwrap(node.callee);
+      if (callee.type !== AST.MemberExpression) {
         return;
       }
       const fKind = fEntries.findLast((x) => x.kind !== "other")?.kind;
       if (fKind == null || !ComponentPhaseRelevance.has(fKind)) {
         return;
       }
-      const { object } = unwrappedCallee;
+      const { object } = callee;
       match(getCallKind(context, node))
         .with("disconnect", () => {
           dEntries.push({
             kind: "ResizeObserver",
-            callee: node.callee,
+            callee,
             method: "disconnect",
             node,
             observer: object,
@@ -124,7 +124,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           }
           oEntries.push({
             kind: "ResizeObserver",
-            callee: node.callee,
+            callee,
             element,
             method: "observe",
             node,
@@ -139,7 +139,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           }
           uEntries.push({
             kind: "ResizeObserver",
-            callee: node.callee,
+            callee,
             element,
             method: "unobserve",
             node,

--- a/plugins/eslint-plugin-react-x/src/rules/globals/globals.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/globals/globals.ts
@@ -62,7 +62,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
   }
 
   function recordWrite(node: TSESTree.Node, target: TSESTree.Identifier | TSESTree.MemberExpression) {
-    if (target.type === AST.Identifier) {
+    if (Check.isIdentifier(target)) {
       // Reassigning a local alias changes only the local binding. Alias
       // provenance matters only when mutating a property of the aliased value.
       if (!isGlobalVariable(context, target)) return;

--- a/plugins/eslint-plugin-react-x/src/rules/globals/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/globals/lib.ts
@@ -50,13 +50,13 @@ export function resolveGlobalOrigin(
   if (expression.type === AST.MemberExpression) {
     return resolveGlobalOrigin(context, expression.object, seen);
   }
-  if (expression.type !== AST.Identifier) return null;
+  if (!Check.isIdentifier(expression)) return null;
   if (isGlobalVariable(context, expression)) return expression;
 
   const variable = findVariable(context.sourceCode.getScope(expression), expression);
   const definition = variable?.defs.length === 1 ? variable.defs[0] : null;
   if (definition?.type !== DefinitionType.Variable) return null;
-  if (definition.node.id.type !== AST.Identifier || definition.node.init == null) return null;
+  if (!Check.isIdentifier(definition.node.id) || definition.node.init == null) return null;
   const declaration = definition.node.parent;
   if (declaration.kind !== "const") return null;
 
@@ -99,7 +99,7 @@ export function resolveToFunction(
 ): TSESTreeFunction | null {
   const expression = Extract.unwrap(node);
   if (Check.isFunction(expression)) return expression;
-  if (expression.type !== AST.Identifier || seen.has(expression)) return null;
+  if (!Check.isIdentifier(expression) || seen.has(expression)) return null;
   seen.add(expression);
   const resolved = resolve(context, expression);
   if (resolved == null) return null;

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/effects.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/effects.ts
@@ -19,7 +19,7 @@ function isGlobalOrModuleVariable(variable: Scope.Variable) {
 }
 
 function isRefMutation(context: RuleContext, mutation: MutationFact) {
-  if (mutation.target.type === AST.Identifier) return isRefLikeName(mutation.target.name);
+  if (Check.isIdentifier(mutation.target)) return isRefLikeName(mutation.target.name);
   return isRefLikeChain(context, mutation.target);
 }
 

--- a/plugins/eslint-plugin-react-x/src/rules/immutability/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/immutability/lib.ts
@@ -43,7 +43,7 @@ export const NAVIGATION_HOOKS = new Set([
 export function resolveToFunctionNode(context: RuleContext, node: TSESTree.Node, seen: Set<TSESTree.Node> = new Set()): TSESTreeFunction | null {
   const expr = Extract.unwrap(node);
   if (Check.isFunction(expr)) return expr;
-  if (expr.type !== AST.Identifier || seen.has(expr)) return null;
+  if (!Check.isIdentifier(expr) || seen.has(expr)) return null;
   seen.add(expr);
   const resolved = resolve(context, expr);
   return resolved == null ? null : resolveToFunctionNode(context, resolved, seen);
@@ -55,7 +55,7 @@ export function resolveVariableOrigin(context: RuleContext, variable: Scope.Vari
   const def = variable.defs.length === 1 ? variable.defs[0] : null;
   if (def?.type !== DefinitionType.Variable || def.node.init == null) return variable;
   const init = Extract.unwrap(def.node.init);
-  if (init.type !== AST.Identifier) return variable;
+  if (!Check.isIdentifier(init)) return variable;
   const source = findVariable(context.sourceCode.getScope(init), init);
   return source == null ? variable : resolveVariableOrigin(context, source, seen);
 }
@@ -65,15 +65,15 @@ export function isRefLikeName(name: string) {
 }
 
 export function hasRefLikeNameInChain(node: TSESTree.Node): boolean {
-  if (node.type === AST.Identifier) return isRefLikeName(node.name);
+  if (Check.isIdentifier(node)) return isRefLikeName(node.name);
   if (node.type !== AST.MemberExpression) return false;
-  return node.property.type === AST.Identifier
+  return Check.isIdentifier(node.property)
     ? isRefLikeName(node.property.name) || hasRefLikeNameInChain(node.object)
     : hasRefLikeNameInChain(node.object);
 }
 
 function isInitializedFromCall(context: RuleContext, node: TSESTree.Expression, isCall: (node: TSESTree.CallExpression) => boolean) {
-  const root = node.type === AST.Identifier ? node : Extract.getIdentifierAt(node, 0);
+  const root = Check.isIdentifier(node) ? node : Extract.getIdentifierAt(node, 0);
   if (root == null) return false;
   const variable = findVariable(context.sourceCode.getScope(root), root);
   if (variable == null) return false;

--- a/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-access-state-in-setstate/no-access-state-in-setstate.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { type TSESTreeMethodOrPropertyDefinition } from "@eslint-react/ast";
+import { Check, type TSESTreeMethodOrPropertyDefinition } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -91,7 +91,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         return;
       }
       // Check if the property being accessed is `state`
-      if (node.property.type !== AST.Identifier || node.property.name !== "state") {
+      if (!Check.isIdentifier(node.property, "state")) {
         return;
       }
       // Report an issue if `this.state` is accessed
@@ -140,8 +140,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         .some((prop) =>
           prop.type === AST.Property
           && !prop.computed
-          && prop.key.type === AST.Identifier
-          && prop.key.name === "state"
+          && Check.isIdentifier(prop.key, "state")
         );
       if (!hasState) {
         return;

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/lib.ts
@@ -48,7 +48,7 @@ export function isArrayIndexReference(context: RuleContext, node: TSESTree.Ident
   if (call.type !== AST.CallExpression) return false;
   const callee = Extract.unwrap(call.callee);
   if (callee.type !== AST.MemberExpression) return false;
-  if (callee.property.type !== AST.Identifier) return false;
+  if (!Check.isIdentifier(callee.property)) return false;
   const indexPosition = INDEX_PARAM_POSITIONS.get(callee.property.name);
   if (indexPosition == null) return false;
   // The callback is the first argument, or the second for `Children.map`/`Children.forEach`
@@ -73,7 +73,7 @@ export function isArrayIndexReference(context: RuleContext, node: TSESTree.Ident
 export function getIdentifiersFromBinaryExpression(
   side: TSESTree.BinaryExpression["left"],
 ): readonly TSESTree.Identifier[] {
-  if (side.type === AST.Identifier) {
+  if (Check.isIdentifier(side)) {
     return [side];
   }
   if (side.type === AST.BinaryExpression) {

--- a/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-array-index-key/no-array-index-key.ts
@@ -1,5 +1,5 @@
 import { createRule } from "@/utils/create-rule";
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import * as core from "@eslint-react/core";
 import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-react/eslint";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -31,24 +31,12 @@ export default createRule<[], MessageID>({
   defaultOptions: [],
 });
 
-/**
- * Gets the value of an object property named 'key' (e.g. in `createElement('div', { key: ... })`).
- * @param property The object literal member to inspect.
- * @returns The value of the 'key' property, or `null` if the member is not one.
- */
-function getKeyPropValue(property: TSESTree.ObjectLiteralElement): TSESTree.Node | null {
-  if (property.type !== AST.Property || property.computed) return null;
-  const isKeyName = (property.key.type === AST.Identifier && property.key.name === "key")
-    || (property.key.type === AST.Literal && property.key.value === "key");
-  return isKeyName ? property.value : null;
-}
-
 export function create(context: RuleContext<MessageID, []>): RuleListener {
   type Descriptor = ReportDescriptor<MessageID> & { node: TSESTree.Node };
 
   // Checks if a given node is an identifier that resolves to an array index parameter
   function isArrayIndex(node: TSESTree.Node): node is TSESTree.Identifier {
-    return node.type === AST.Identifier && isArrayIndexReference(context, node);
+    return Check.isIdentifier(node) && isArrayIndexReference(context, node);
   }
 
   // Gets the props object of a `createElement` or `cloneElement` call
@@ -123,8 +111,10 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       const propsObject = getPropsObject(node);
       if (propsObject == null) return;
       for (const property of propsObject.properties) {
-        const value = getKeyPropValue(property);
-        if (value == null) continue;
+        if (property.type !== AST.Property) continue;
+        if (property.computed) continue;
+        if (Extract.getPropertyName(property, "max") !== "key") continue;
+        const value = property.value;
         for (const desc of visitKeyExpression(value)) {
           context.report(desc);
         }

--- a/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-direct-mutation-state/no-direct-mutation-state.ts
@@ -15,7 +15,7 @@ function isConstructorFunction(
 ): node is TSESTree.FunctionDeclaration | TSESTree.FunctionExpression {
   return Check.isOneOf([AST.FunctionDeclaration, AST.FunctionExpression])(node)
     && Check.isPropertyOrMethod(node.parent)
-    && node.parent.key.type === AST.Identifier
+    && Check.isIdentifier(node.parent.key)
     && node.parent.key.name === "constructor";
 }
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-duplicate-key/no-duplicate-key.ts
@@ -80,7 +80,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
               if (n.type !== AST.CallExpression) return false;
               const callee = Extract.unwrap(n.callee);
               return callee.type === AST.MemberExpression
-                && callee.property.type === AST.Identifier
+                && Check.isIdentifier(callee.property)
                 && callee.property.name === "map";
             },
           );

--- a/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-forward-ref/no-forward-ref.ts
@@ -89,7 +89,7 @@ function couldFix(context: RuleContext, node: TSESTree.CallExpression) {
     case AST.Identifier:
       return isInitializedFromReact(callee.name, initialScope, importSource);
     case AST.MemberExpression:
-      return callee.object.type === AST.Identifier
+      return Check.isIdentifier(callee.object)
         && isInitializedFromReact(callee.object.name, initialScope, importSource);
     default:
       return false;

--- a/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-missing-key/no-missing-key.ts
@@ -40,7 +40,7 @@ export default createRule<[], MessageID>({
 function getIteratorCallback(node: TSESTree.CallExpression): TSESTreeFunction | null {
   const callee = Extract.unwrap(node.callee);
   if (callee.type !== AST.MemberExpression) return null;
-  if (callee.property.type !== AST.Identifier) return null;
+  if (!Check.isIdentifier(callee.property)) return null;
   const position = INDEX_PARAM_POSITIONS.get(callee.property.name);
   if (position == null) return null;
   const callback = node.arguments[position];

--- a/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-nested-component-definitions/lib.ts
@@ -89,7 +89,7 @@ export function getWrapperCallBoundName(context: RuleContext, node: TSESTreeFunc
       parent = parent.parent;
     }
   }
-  if (parent.type !== AST.VariableDeclarator || parent.id.type !== AST.Identifier) {
+  if (parent.type !== AST.VariableDeclarator || !Check.isIdentifier(parent.id)) {
     return null;
   }
   return parent.id.name;

--- a/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unnecessary-use-prefix/lib.ts
@@ -14,8 +14,8 @@ export function containsUseComments(context: RuleContext, node: TSESTree.Node) {
 export function isTestMock(node: TSESTree.Node | null): node is TSESTree.MemberExpression {
   return node != null
     && node.type === AST.MemberExpression
-    && node.object.type === AST.Identifier
-    && node.property.type === AST.Identifier
+    && Check.isIdentifier(node.object)
+    && Check.isIdentifier(node.property)
     && node.property.name === "mock";
 }
 

--- a/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/no-unstable-default-props/no-unstable-default-props.ts
@@ -60,18 +60,18 @@ export default createRule<Options, MessageID>({
 function extractIdentifier(node: TSESTree.Node): string | null {
   if (node.type === AST.NewExpression) {
     const callee = Extract.unwrap(node.callee);
-    if (callee.type === AST.Identifier) {
+    if (Check.isIdentifier(callee)) {
       return callee.name;
     }
   }
   if (node.type === AST.CallExpression) {
     const callee = Extract.unwrap(node.callee);
-    if (callee.type === AST.Identifier) {
+    if (Check.isIdentifier(callee)) {
       return callee.name;
     }
     if (callee.type === AST.MemberExpression) {
       const { object } = callee;
-      if (object.type === AST.Identifier) {
+      if (Check.isIdentifier(object)) {
         return object.name;
       }
     }

--- a/plugins/eslint-plugin-react-x/src/rules/purity/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/lib.ts
@@ -1,4 +1,4 @@
-import { Extract } from "@eslint-react/ast";
+import { Check, Extract } from "@eslint-react/ast";
 import type { RuleContext } from "@eslint-react/eslint";
 import { DefinitionType } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
@@ -585,7 +585,7 @@ export function resolveBuiltinObjectName(context: RuleContext, node: TSESTree.Id
 
   if (def.type === DefinitionType.Variable && def.node.init != null) {
     const init = Extract.unwrap(def.node.init);
-    if (init.type === AST.Identifier) {
+    if (Check.isIdentifier(init)) {
       return resolveBuiltinObjectName(context, init, seen);
     }
     if (init.type === AST.MemberExpression) {

--- a/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/purity/purity.ts
@@ -45,7 +45,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       CallExpression(node: TSESTree.CallExpression) {
         const expr = Extract.unwrap(node.callee);
         switch (true) {
-          case expr.type === AST.Identifier: {
+          case Check.isIdentifier(expr): {
             const builtinName = resolveBuiltinObjectName(context, expr);
             if (builtinName == null) return;
             const globalThisImpure = IMPURE_FUNCS.get("globalThis");
@@ -56,7 +56,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
             break;
           }
           case expr.type === AST.MemberExpression
-            && expr.property.type === AST.Identifier: {
+            && Check.isIdentifier(expr.property): {
             const rootId = Extract.getIdentifierAt(expr.object, 0);
             if (rootId == null) return;
             const objectName = resolveBuiltinObjectName(context, rootId);
@@ -73,7 +73,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       },
       NewExpression(node: TSESTree.NewExpression) {
         const expr = Extract.unwrap(node.callee);
-        if (expr.type !== AST.Identifier) return;
+        if (!Check.isIdentifier(expr)) return;
         const builtinName = resolveBuiltinObjectName(context, expr);
         if (builtinName == null) return;
         if (!IMPURE_CTORS.has(builtinName)) return;

--- a/plugins/eslint-plugin-react-x/src/rules/refs/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/lib.ts
@@ -60,7 +60,7 @@ export function createBindingResolver(context: RuleContext) {
 
   function getBindingValue(node: TSESTree.Node): BindingValue {
     const value = Extract.unwrap(node);
-    if (value.type === AST.Identifier) {
+    if (Check.isIdentifier(value)) {
       const variable = getVariable(value);
       return variable == null ? { kind: "unknown" } : { kind: "variable", variable };
     }
@@ -68,7 +68,7 @@ export function createBindingResolver(context: RuleContext) {
     if (value.type === AST.CallExpression && (core.isUseRefLikeCall(value, additionalRefHooks) || core.isCreateRefCall(context, value))) {
       return { kind: "ref" };
     }
-    if (value.type === AST.MemberExpression && value.property.type === AST.Identifier) {
+    if (value.type === AST.MemberExpression && Check.isIdentifier(value.property)) {
       if (isRefLikeName(value.property.name)) return { kind: "ref" };
     }
     return { kind: "unknown" };
@@ -143,14 +143,14 @@ export function createBindingResolver(context: RuleContext) {
   function resolveCallable(node: TSESTree.Node, position: number): TSESTreeFunction | null {
     const callee = Extract.unwrap(node);
     if (isFunctionExpressionLike(callee)) return callee;
-    if (callee.type === AST.Identifier) {
+    if (Check.isIdentifier(callee)) {
       const variable = getVariable(callee);
       return variable == null ? null : resolveFunction(variable, position);
     }
-    if (callee.type !== AST.MemberExpression || callee.property.type !== AST.Identifier) return null;
+    if (callee.type !== AST.MemberExpression || !Check.isIdentifier(callee.property)) return null;
     const object = Extract.unwrap(callee.object);
     const property = callee.property.name;
-    if (object.type !== AST.Identifier) return null;
+    if (!Check.isIdentifier(object)) return null;
     const variable = getVariable(object);
     if (variable == null) return null;
     const event = getLatestValue(memberBindings.get(variable)?.get(property), position);
@@ -162,13 +162,13 @@ export function createBindingResolver(context: RuleContext) {
 
   function getRefTarget(node: TSESTree.MemberExpression): { identity: Variable | null } | null {
     const object = Extract.unwrap(node.object);
-    if (object.type === AST.Identifier) {
+    if (Check.isIdentifier(object)) {
       const variable = getVariable(object);
       if (variable == null) return null;
       const identity = resolveRef(variable, node.range[0]);
       return identity == null ? null : { identity };
     }
-    if (object.type === AST.MemberExpression && object.property.type === AST.Identifier) {
+    if (object.type === AST.MemberExpression && Check.isIdentifier(object.property)) {
       if (isRefLikeName(object.property.name)) return { identity: null };
     }
     return null;
@@ -179,13 +179,13 @@ export function createBindingResolver(context: RuleContext) {
       test,
       (candidate) => {
         if (candidate.type !== AST.MemberExpression) return false;
-        if (candidate.property.type !== AST.Identifier || candidate.property.name !== "current") return false;
+        if (!Check.isIdentifier(candidate.property, "current")) return false;
         return getRefTarget(candidate)?.identity === identity;
       },
       (candidate) => {
         if (candidate.type === AST.Literal) return candidate.value == null;
         if (candidate.type === AST.UnaryExpression && candidate.operator === "void") return true;
-        if (candidate.type !== AST.Identifier || candidate.name !== "undefined") return false;
+        if (!Check.isIdentifier(candidate, "undefined")) return false;
         const variable = getVariable(candidate);
         return variable == null || variable.defs.length === 0;
       },

--- a/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/refs/refs.ts
@@ -74,13 +74,13 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       AssignmentExpression(node: TSESTree.AssignmentExpression) {
         if (node.operator !== "=") return;
         const left = Extract.unwrap(node.left);
-        if (left.type === AST.Identifier) {
+        if (Check.isIdentifier(left)) {
           addIdentifierBinding(left, node.right, node.range[0]);
           return;
         }
-        if (left.type !== AST.MemberExpression || left.property.type !== AST.Identifier) return;
+        if (left.type !== AST.MemberExpression || !Check.isIdentifier(left.property)) return;
         const object = Extract.unwrap(left.object);
-        if (object.type === AST.Identifier) {
+        if (Check.isIdentifier(object)) {
           addMemberBinding(object, left.property.name, node.right, node.range[0]);
         }
       },
@@ -93,11 +93,11 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       JSXAttribute(node: TSESTree.JSXAttribute) {
         if (node.name.type !== AST.JSXIdentifier || node.name.name !== "ref" || node.value?.type !== AST.JSXExpressionContainer) return;
         const expression = Extract.unwrap(node.value.expression);
-        if (expression.type !== AST.Identifier) return;
+        if (!Check.isIdentifier(expression)) return;
         addJsxRef(expression);
       },
       MemberExpression(node: TSESTree.MemberExpression) {
-        if (node.property.type !== AST.Identifier || node.property.name !== "current") return;
+        if (!Check.isIdentifier(node.property, "current")) return;
         refAccesses.push(getRefAccess(node));
       },
       "Program:exit"(program) {
@@ -197,7 +197,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
           for (const argument of callArguments) {
             if (argument.type === AST.SpreadElement) continue;
             const value = Extract.unwrap(argument);
-            if (value.type !== AST.Identifier) continue;
+            if (!Check.isIdentifier(value)) continue;
             const variable = getVariable(value);
             if (variable == null || resolveRef(variable, value.range[0]) == null) continue;
             context.report({ messageId: "refPassedToFunction", node: value });
@@ -205,7 +205,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         }
       },
       VariableDeclarator(node: TSESTree.VariableDeclarator) {
-        if (node.id.type !== AST.Identifier || node.init == null) return;
+        if (!Check.isIdentifier(node.id) || node.init == null) return;
         addIdentifierBinding(node.id, node.init, node.range[0]);
       },
     },

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/lib.ts
@@ -14,7 +14,7 @@ import { findVariable } from "@typescript-eslint/utils/ast-utils";
 export function getNestedIdentifiers(node: TSESTree.Node): readonly TSESTree.Identifier[] {
   const identifiers: TSESTree.Identifier[] = [];
   // Base case: the node itself is an Identifier
-  if (node.type === AST.Identifier) {
+  if (Check.isIdentifier(node)) {
     identifiers.push(node);
   }
   // CallExpression / NewExpression arguments: foo(a, b)
@@ -138,7 +138,7 @@ export function isHookDecl(node: TSESTree.Node): node is
   & { init: TSESTree.CallExpression }
 {
   if (node.type !== AST.VariableDeclarator) return false;
-  if (node.id.type !== AST.Identifier) return false;
+  if (!Check.isIdentifier(node.id)) return false;
   const init = node.init;
   if (init == null || init.type !== AST.CallExpression) return false;
   const name = Extract.getCalleeName(init);
@@ -161,7 +161,7 @@ export function isInitializedFromRef(
     switch (true) {
       // const identifier = anotherRef.current;
       case init.type === AST.MemberExpression
-        && init.object.type === AST.Identifier
+        && Check.isIdentifier(init.object)
         && (init.object.name === "ref" || init.object.name.endsWith("Ref")):
         return true;
       // const identifier = useRef();
@@ -215,7 +215,7 @@ function isRefInExpression(context: RuleContext, node: TSESTree.Node): boolean {
 export function getSetStateCallExpression(
   node: TSESTree.CallExpression | TSESTree.Identifier,
 ): TSESTree.CallExpression | TSESTree.Identifier {
-  return node.type === AST.Identifier && node.parent.type === AST.CallExpression
+  return Check.isIdentifier(node) && node.parent.type === AST.CallExpression
     ? node.parent
     : node;
 }

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -139,7 +139,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     return variableNodeParent
       .id
       .elements
-      .findIndex((e) => e?.type === AST.Identifier && e.name === id.name) === at;
+      .findIndex((e) => e != null && Check.isIdentifier(e, id.name)) === at;
   }
 
   function isSetStateCall(node: TSESTree.CallExpression) {
@@ -360,7 +360,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
       }
       for (const { callee } of trackedFnCalls) {
         const unwrappedCallee = Extract.unwrap(callee);
-        if (unwrappedCallee.type !== AST.Identifier) {
+        if (!Check.isIdentifier(unwrappedCallee)) {
           continue;
         }
         const setStateCalls = getSetStateCalls(context, unwrappedCallee);

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/lib.ts
@@ -34,10 +34,10 @@ export function isInsideEventHandler(node: TSESTree.Node, stopAt: TSESTreeFuncti
 export function isComponentOrHookLikeFunction(node: TSESTreeFunction) {
   const id = core.getFunctionId(node);
   if (id == null) return false;
-  if (id.type === AST.Identifier) {
+  if (Check.isIdentifier(id)) {
     return core.isFunctionComponentName(id.name) || core.isHookName(id.name);
   }
-  if (id.type === AST.MemberExpression && id.property.type === AST.Identifier) {
+  if (id.type === AST.MemberExpression && Check.isIdentifier(id.property)) {
     return core.isFunctionComponentName(id.property.name) || core.isHookName(id.property.name);
   }
   return false;

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-render/set-state-in-render.ts
@@ -60,7 +60,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
     return initNodeParent
       .id
       .elements
-      .findIndex((e) => e?.type === AST.Identifier && e.name === topLevelId.name) === at;
+      .findIndex((e) => e != null && Check.isIdentifier(e, topLevelId.name)) === at;
   }
 
   function isSetStateCall(node: TSESTree.CallExpression) {

--- a/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/lib.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/unsupported-syntax/lib.ts
@@ -9,7 +9,7 @@ export function isEvalCall(node: TSESTree.CallExpression) {
     case AST.MemberExpression: {
       if (!Check.isIdentifier(Extract.unwrap(callee.object), "globalThis")) return false;
       // In `globalThis[eval]` the property is the runtime value of `eval`, not the static name "eval"
-      return !callee.computed && callee.property.type === AST.Identifier && callee.property.name === "eval";
+      return !callee.computed && Check.isIdentifier(callee.property, "eval");
     }
     default:
       return false;

--- a/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/use-memo/use-memo.ts
@@ -56,7 +56,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         const left = Extract.unwrap(node.left);
         // Only flag direct variable reassignment (x = …), not property mutations (ref.current = …)
         // to match React Compiler's StoreContext semantics.
-        if (left.type !== AST.Identifier) return;
+        if (!Check.isIdentifier(left)) return;
         if (Traverse.findParent(node, Check.isFunction, (n) => n === callback) != null) return;
 
         const scope = context.sourceCode.getScope(left);
@@ -122,7 +122,7 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         if (firstParam == null) return;
         context.report({
           messageId: "noParameters",
-          node: firstParam.type === AST.Identifier ? firstParam : callback,
+          node: Check.isIdentifier(firstParam) ? firstParam : callback,
         });
       }
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] I have added a convincing reason for adding this feature, if necessary

### Other information

Replaces direct `node.type === AST.Identifier` checks with the existing `Check.isIdentifier` helper and uses `Extract.unwrap` where appropriate for consistency across packages and rule implementations.