### PR TITLE
fix(react-x): don't attribute render-phase setState to effects calling prop functions

### DIFF
--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.spec.ts
@@ -1829,5 +1829,54 @@ ruleTester.run(RULE_NAME, rule, {
         }
       `,
     },
+    // https://github.com/Rel1cx/eslint-react/issues/1944
+    {
+      name: "render-phase setState with an effect calling a prop function",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        export function One({ target, onDone }: { target: number; onDone: () => void }) {
+          const [page, setPage] = useState(1);
+          if (page !== target) setPage(target);
+          useEffect(() => {
+            onDone();
+          }, [onDone, target]);
+          return <div>{page}</div>;
+        }
+      `,
+    },
+    // https://github.com/Rel1cx/eslint-react/issues/1944
+    {
+      name: "render-phase setState with multiple effects calling a prop function",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        export function Two({ target, onDone }: { target: number; onDone: () => void }) {
+          const [page, setPage] = useState(1);
+          if (page !== target) setPage(target);
+          useEffect(() => {
+            onDone();
+          }, [onDone, target]);
+          useEffect(() => {
+            onDone();
+          }, [onDone]);
+          return <div>{page}</div>;
+        }
+      `,
+    },
+    // https://github.com/Rel1cx/eslint-react/issues/1944
+    {
+      name: "render-phase setState with a prop function passed to useEffect as setup",
+      code: tsx`
+        import { useEffect, useState } from "react";
+
+        export function Component({ target, onDone }: { target: number; onDone: () => void }) {
+          const [page, setPage] = useState(1);
+          if (page !== target) setPage(target);
+          useEffect(onDone, [onDone, target]);
+          return <div>{page}</div>;
+        }
+      `,
+    },
   ],
 });

--- a/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
+++ b/plugins/eslint-plugin-react-x/src/rules/set-state-in-effect/set-state-in-effect.ts
@@ -5,8 +5,9 @@ import { type RuleContext, type RuleFeature, type RuleListener } from "@eslint-r
 import { getSettingsFromContext } from "@eslint-react/shared";
 import { resolve } from "@eslint-react/var";
 import { constVoid, getOrInsertComputed, not } from "@local/eff";
+import { DefinitionType } from "@typescript-eslint/scope-manager";
 import { AST_NODE_TYPES as AST, type TSESTree } from "@typescript-eslint/types";
-import { getStaticValue } from "@typescript-eslint/utils/ast-utils";
+import { findVariable, getStaticValue } from "@typescript-eslint/utils/ast-utils";
 import { match } from "ts-pattern";
 import { getNestedIdentifiers, getSetStateCallExpression, isHookDecl, isInitializedFromRef, isRefGatedContext } from "./lib";
 
@@ -335,6 +336,14 @@ export function create(context: RuleContext<MessageID, []>): RuleListener {
         context: RuleContext,
         id: TSESTree.Identifier,
       ): TSESTree.CallExpression[] | TSESTree.Identifier[] => {
+        // The value of a function parameter (e.g. a function received via props) is provided
+        // by the caller and cannot be resolved to a function defined in this component.
+        // `resolve` maps a parameter to its containing function, which would wrongly attribute
+        // the component's own render-phase setState calls to the effect (https://github.com/Rel1cx/eslint-react/issues/1944).
+        const variable = findVariable(context.sourceCode.getScope(id), id);
+        if (variable != null && variable.defs.some((def) => def.type === DefinitionType.Parameter)) {
+          return [];
+        }
         const node = resolve(context, id);
         switch (node?.type) {
           case AST.ArrowFunctionExpression:


### PR DESCRIPTION
Fixes #1944

`set-state-in-effect` falsely reported a render-phase `setState` (the docs-sanctioned "adjust state while rendering" pattern) as "called synchronously in an effect" whenever any `useEffect` body called a function received via props — duplicated once per such effect.

Root cause: `getSetStateCalls` resolves the callee of every call made inside an effect setup; for a prop function, `resolve()` maps the parameter to its containing function (documented behavior), i.e. the component itself — so the lookup handed back the component's own render-phase `setState` calls and attributed them to the effect.

Fix: in `getSetStateCalls`, bail out (return no calls) when the callee's binding is a function parameter — a caller-supplied value whose body is unknowable, matching how `console.log` / module-scope callees already behave. The shared `@eslint-react/var` `resolve()` is left unchanged; this rule was its only consumer with this pattern.

Tests: 3 regression cases from the issue (the exact `One`/`Two` repros plus a prop passed directly as the `useEffect` setup argument), verified failing-first with the reported 1/2/3 duplicate counts, then green. Full monorepo suite passes (117 files, 4426 tests); no invalid-case expectations changed. `tsdown` build, `tsl` typecheck, eslint, and `dprint` all clean.
