### PR TITLE
fix: register the same plugin object in preset configs as the default…

### DIFF
--- a/plugins/eslint-plugin-react-debug/src/index.ts
+++ b/plugins/eslint-plugin-react-debug/src/index.ts
@@ -4,10 +4,26 @@ import { plugin } from "./plugin";
 
 type ConfigName = "all";
 
+function createConfig(base: { plugins?: Record<string, unknown> } & Record<string, unknown>): Linter.Config {
+  return {
+    ...base,
+    plugins: {
+      ...base.plugins,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["react-debug"]() {
+        return finalPlugin;
+      },
+    },
+  };
+}
+
 const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> } = {
   ...plugin,
   configs: {
-    ["all"]: allConfig,
+    ["all"]: createConfig(allConfig),
   },
 };
 

--- a/plugins/eslint-plugin-react-dom/src/index.ts
+++ b/plugins/eslint-plugin-react-dom/src/index.ts
@@ -5,11 +5,27 @@ import { plugin } from "./plugin";
 
 type ConfigName = "recommended" | "strict";
 
+function createConfig(base: { plugins?: Record<string, unknown> } & Record<string, unknown>): Linter.Config {
+  return {
+    ...base,
+    plugins: {
+      ...base.plugins,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["react-dom"]() {
+        return finalPlugin;
+      },
+    },
+  };
+}
+
 const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> } = {
   ...plugin,
   configs: {
-    ["recommended"]: recommendedConfig,
-    ["strict"]: strictConfig,
+    ["recommended"]: createConfig(recommendedConfig),
+    ["strict"]: createConfig(strictConfig),
   },
 };
 

--- a/plugins/eslint-plugin-react-jsx/src/index.ts
+++ b/plugins/eslint-plugin-react-jsx/src/index.ts
@@ -5,11 +5,27 @@ import { plugin } from "./plugin";
 
 type ConfigName = "recommended" | "strict";
 
+function createConfig(base: { plugins?: Record<string, unknown> } & Record<string, unknown>): Linter.Config {
+  return {
+    ...base,
+    plugins: {
+      ...base.plugins,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["react-jsx"]() {
+        return finalPlugin;
+      },
+    },
+  };
+}
+
 const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> } = {
   ...plugin,
   configs: {
-    ["recommended"]: recommendedConfig,
-    ["strict"]: strictConfig,
+    ["recommended"]: createConfig(recommendedConfig),
+    ["strict"]: createConfig(strictConfig),
   },
 };
 

--- a/plugins/eslint-plugin-react-naming-convention/src/index.ts
+++ b/plugins/eslint-plugin-react-naming-convention/src/index.ts
@@ -4,10 +4,26 @@ import { plugin } from "./plugin";
 
 type ConfigName = "recommended";
 
+function createConfig(base: { plugins?: Record<string, unknown> } & Record<string, unknown>): Linter.Config {
+  return {
+    ...base,
+    plugins: {
+      ...base.plugins,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["react-naming-convention"]() {
+        return finalPlugin;
+      },
+    },
+  };
+}
+
 const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> } = {
   ...plugin,
   configs: {
-    ["recommended"]: recommendedConfig,
+    ["recommended"]: createConfig(recommendedConfig),
   },
 };
 

--- a/plugins/eslint-plugin-react-rsc/src/index.ts
+++ b/plugins/eslint-plugin-react-rsc/src/index.ts
@@ -13,6 +13,22 @@ type ConfigName =
   | "strict"
   | "strict-typescript";
 
+function createConfig(base: { plugins?: Record<string, unknown> } & Record<string, unknown>): Linter.Config {
+  return {
+    ...base,
+    plugins: {
+      ...base.plugins,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["react-rsc"]() {
+        return finalPlugin;
+      },
+    },
+  };
+}
+
 const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> } = {
   ...plugin,
   configs: {
@@ -23,19 +39,19 @@ const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> 
     /**
      * Enforce rules that are recommended by ESLint React for general purpose React + React DOM projects
      */
-    ["recommended"]: recommendedConfig,
+    ["recommended"]: createConfig(recommendedConfig),
     /**
      * Same as the `recommended` preset but disables rules that can be enforced by TypeScript
      */
-    ["recommended-typescript"]: recommendedTypeScriptConfig,
+    ["recommended-typescript"]: createConfig(recommendedTypeScriptConfig),
     /**
      * More strict version of the `recommended` preset
      */
-    ["strict"]: strictConfig,
+    ["strict"]: createConfig(strictConfig),
     /**
      * Same as the `strict` preset but disables rules that can be enforced by TypeScript
      */
-    ["strict-typescript"]: strictTypeScriptConfig,
+    ["strict-typescript"]: createConfig(strictTypeScriptConfig),
   },
 };
 

--- a/plugins/eslint-plugin-react-web-api/src/index.ts
+++ b/plugins/eslint-plugin-react-web-api/src/index.ts
@@ -4,10 +4,26 @@ import { plugin } from "./plugin";
 
 type ConfigName = "recommended";
 
+function createConfig(base: { plugins?: Record<string, unknown> } & Record<string, unknown>): Linter.Config {
+  return {
+    ...base,
+    plugins: {
+      ...base.plugins,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["react-web-api"]() {
+        return finalPlugin;
+      },
+    },
+  };
+}
+
 const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> } = {
   ...plugin,
   configs: {
-    ["recommended"]: recommendedConfig,
+    ["recommended"]: createConfig(recommendedConfig),
   },
 };
 

--- a/plugins/eslint-plugin-react-x/src/index.ts
+++ b/plugins/eslint-plugin-react-x/src/index.ts
@@ -23,6 +23,22 @@ type ConfigName =
   | "strict-type-checked"
   | "strict-typescript";
 
+function createConfig(base: { plugins?: Record<string, unknown> } & Record<string, unknown>): Linter.Config {
+  return {
+    ...base,
+    plugins: {
+      ...base.plugins,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["react-x"]() {
+        return finalPlugin;
+      },
+    },
+  };
+}
+
 const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> } = {
   ...plugin,
   configs: {
@@ -45,27 +61,27 @@ const finalPlugin: ESLint.Plugin & { configs: Record<ConfigName, Linter.Config> 
     /**
      * Enforce rules that are recommended by ESLint React for general purpose React + React DOM projects
      */
-    ["recommended"]: recommendedConfig,
+    ["recommended"]: createConfig(recommendedConfig),
     /**
      * Same as the `recommended-typescript` preset but enables additional rules that require type information
      */
-    ["recommended-type-checked"]: recommendedTypeCheckedConfig,
+    ["recommended-type-checked"]: createConfig(recommendedTypeCheckedConfig),
     /**
      * Same as the `recommended` preset but disables rules that can be enforced by TypeScript
      */
-    ["recommended-typescript"]: recommendedTypeScriptConfig,
+    ["recommended-typescript"]: createConfig(recommendedTypeScriptConfig),
     /**
      * More strict version of the `recommended` preset
      */
-    ["strict"]: strictConfig,
+    ["strict"]: createConfig(strictConfig),
     /**
      * Same as the `strict-typescript` preset but enables additional rules that require type information
      */
-    ["strict-type-checked"]: strictTypeCheckedConfig,
+    ["strict-type-checked"]: createConfig(strictTypeCheckedConfig),
     /**
      * Same as the `strict` preset but disables rules that can be enforced by TypeScript
      */
-    ["strict-typescript"]: strictTypeScriptConfig,
+    ["strict-typescript"]: createConfig(strictTypeScriptConfig),
   },
 };
 

--- a/plugins/eslint-plugin/src/index.ts
+++ b/plugins/eslint-plugin/src/index.ts
@@ -54,7 +54,13 @@ function createConfig(base: { plugins?: Record<string, unknown> } & Record<strin
     ...base,
     plugins: {
       ...base.plugins,
-      "@eslint-react": plugin,
+      // Use a getter to resolve the plugin reference lazily so every config registers the same
+      // object as the default export below. Otherwise ESLint reports a "Cannot redefine plugin"
+      // error when users register the plugin manually and also extend one of the presets.
+      // See https://github.com/Rel1cx/eslint-react/issues/1946
+      get ["@eslint-react"]() {
+        return finalPlugin;
+      },
     },
   };
 }


### PR DESCRIPTION
… export

Previously every preset registered the internal plugin object while the default export was a new object created via object spread, so registering the plugin manually and extending any preset resulted in ESLint reporting "Cannot redefine plugin". Resolve the plugin reference in each config lazily via a getter so it is the same object as the default export, closes #1946.

Update "[ ]" to "[x]" to check a box

### What kind of change does this PR introduce?

Check at least one. If you are introducing a new binding, you must reference an issue where this binding has been proposed, discussed and approved by the maintainers.

- [x] Bugfix
- [ ] Feature
- [ ] Perf
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Enhancement
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

If yes, please describe the impact and migration path for existing applications in an attached issue.

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist

- [x] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information
